### PR TITLE
Fixed AppVeyor Builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,4 +6,5 @@ configuration:
   - Release
 
 build:
-  project: src/WheelMUD.sln
+  project:
+    - src/WheelMUD.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,5 +5,5 @@ configuration:
   - Debug
   - Release
 
-build_script:
-  - msbuild src/WheelMUD.sln
+build:
+  project: src/WheelMUD.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
-platform:
-  - x86
-
+version: 1.0.{build}
+image: Visual Studio 2017
 configuration:
-  - Debug
-  - Release
-
+- Debug
+- Release
+platform: x86
 build:
   project: src\WheelMUD.sln
+  verbosity: normal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,5 +6,4 @@ configuration:
   - Release
 
 build:
-  project:
-    - src/WheelMUD.sln
+  project: src\WheelMUD.sln

--- a/src/Core/WheelMUD.Core.csproj
+++ b/src/Core/WheelMUD.Core.csproj
@@ -60,9 +60,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CompilerServices.AsyncTargetingPack.Net4">
-      <HintPath>..\packages\Microsoft.CompilerServices.AsyncTargetingPack.1.0.1\lib\net40\Microsoft.CompilerServices.AsyncTargetingPack.Net4.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>

--- a/src/Data.RavenDb/WheelMUD.Data.RavenDb.csproj
+++ b/src/Data.RavenDb/WheelMUD.Data.RavenDb.csproj
@@ -74,21 +74,11 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CompilerServices.AsyncTargetingPack.Net4">
-      <HintPath>..\packages\Microsoft.CompilerServices.AsyncTargetingPack.1.0.1\lib\net40\Microsoft.CompilerServices.AsyncTargetingPack.Net4.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Edm.5.2.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.OData, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.OData.5.2.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.2.0.6.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Raven.Abstractions, Version=2.5.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -106,13 +96,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\RavenDB.Database.2.5.2750\lib\net40\Raven.Database.dll</HintPath>
     </Reference>
-    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Services.Client" />
-    <Reference Include="System.Spatial, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Spatial.5.2.0\lib\net40\System.Spatial.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>

--- a/src/Rules/InvokerRegistry.cs
+++ b/src/Rules/InvokerRegistry.cs
@@ -46,14 +46,13 @@ namespace WheelMUD.Rules
 
             if (invokers.Any(ri => ri.Key == ruleInvoker.ParameterType))
             {
-                var invokers = this.invokers.First((KeyValuePair<Type, List<IRuleInvoker>> ri) => ri.Key == ruleInvoker.ParameterType).Value;
-                invokers.Add(ruleInvoker);
+                var invokersList = this.invokers.First((KeyValuePair<Type, List<IRuleInvoker>> ri) => ri.Key == ruleInvoker.ParameterType).Value;
+                invokersList.Add(ruleInvoker);
             }
             else
             {
-                var invokers = new List<IRuleInvoker>();
-                invokers.Add(ruleInvoker);
-                this.invokers.Add(new KeyValuePair<Type, List<IRuleInvoker>>(ruleInvoker.ParameterType, invokers));
+                var newInvokersList = new List<IRuleInvoker>() { ruleInvoker };
+                this.invokers.Add(new KeyValuePair<Type, List<IRuleInvoker>>(ruleInvoker.ParameterType, newInvokersList));
             }
         }
 

--- a/src/WarriorRogueMage/WarriorRogueMage.csproj
+++ b/src/WarriorRogueMage/WarriorRogueMage.csproj
@@ -55,9 +55,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CompilerServices.AsyncTargetingPack.Net4">
-      <HintPath>..\packages\Microsoft.CompilerServices.AsyncTargetingPack.1.0.1\lib\net40\Microsoft.CompilerServices.AsyncTargetingPack.Net4.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>

--- a/src/WheelMUD.sln
+++ b/src/WheelMUD.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28729.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MudFramework", "MudFramework", "{70B47C52-9264-4B57-BA38-D1A5BAECC660}"
 EndProject
@@ -72,13 +72,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Files", "Files", "{13D09790
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestHarness", "TestHarness\TestHarness.csproj", "{F6AE400B-3760-4D4E-909A-D09F3E477BB5}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{CDE99827-E16A-44A1-AE28-386B6185B97D}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.exe = .nuget\NuGet.exe
-		.nuget\NuGet.targets = .nuget\NuGet.targets
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -185,6 +178,9 @@ Global
 		{F9235B03-F19E-494D-A6BF-87750A821B1D} = {6132C745-3F4C-496A-A904-C7C7CE363085}
 		{3BFE4F46-3B33-4449-AA58-B2B2F6E0A464} = {D051C5A7-F170-427F-A8C8-DEBC246CA934}
 		{2C0AABE2-0B83-4F32-82C5-A0AF066AB34A} = {219394ED-676D-46B8-8AEE-FC6A2084F90F}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {264B2ECC-2D1D-4C6D-9CA9-82539671B3B1}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = WheelMUD.vsmdi


### PR DESCRIPTION
Fixed the AppVeyor configurations to find our main solution again.
Explicitly set the image to Visual Studio 2017, as they don't have a VS 2019 image to specify, and VS2017 is a pretty reasonable minimum bar to reinforce with the automatic builds.
Fixed Release build failures exposed, around conflicting CompilerServices references.
Fixed an issue exposed with AppVeyor's warnings-as-errors in InvokerRegistry around conflicting 'invokers' local/member names.
Also removed the .nuget folder from the solution.