### PR TITLE
Adding a link to GitHubDocs in ServerHarness project

### DIFF
--- a/src/ServerHarness/ServerHarness.csproj
+++ b/src/ServerHarness/ServerHarness.csproj
@@ -39,4 +39,8 @@
     <ProjectReference Include="..\Main\WheelMUD.Main.csproj" />
     <ProjectReference Include="..\Utilities\WheelMUD.Utilities.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Including links to the same documentation we render through GitHub, to encourage searchability and maintainability directly in the IDEs. -->
+    <EmbeddedResource Include="..\..\**\*.md" LinkBase="GitHubDocs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
#57 - Adding a link to GitHubDocs in ServerHarness project, for convenience and searchability.

@JeremyTHolland, does this suit your expectations for searching documentation inside the IDEs?

In VS 2019, we get this:
![image](https://user-images.githubusercontent.com/11418078/102049783-62fbf400-3d96-11eb-961e-0d17f0807928.png)
