### PR TITLE
Fixed view talent command to accept multi word names

### DIFF
--- a/src/WarriorRogueMage/CharacterCreation/PickTalentsState.cs
+++ b/src/WarriorRogueMage/CharacterCreation/PickTalentsState.cs
@@ -43,7 +43,8 @@ namespace WarriorRogueMage.CharacterCreation
                 case "view":
                     if (commandParts.Length > 1)
                     {
-                        this.ViewTalentDescription(commandParts[1]);
+                        string talentName = string.Join(" ", commandParts, 1, commandParts.Length - 1);
+                        this.ViewTalentDescription(talentName);
                     }
                     else
                     {
@@ -84,7 +85,7 @@ namespace WarriorRogueMage.CharacterCreation
         {
             string talentToView = talent.Replace("view ", string.Empty);
 
-            Talent foundTalent = this.talents.Find(s => s.Name.Equals(talentToView, StringComparison.CurrentCultureIgnoreCase));
+            Talent foundTalent = this.talents.Find(s => s.Name.Contains(talentToView, StringComparison.CurrentCultureIgnoreCase));
             if (foundTalent != null)
             {
                 var sb = new StringBuilder();

--- a/src/WarriorRogueMage/CharacterCreation/PickTalentsState.cs
+++ b/src/WarriorRogueMage/CharacterCreation/PickTalentsState.cs
@@ -85,7 +85,8 @@ namespace WarriorRogueMage.CharacterCreation
         {
             string talentToView = talent.Replace("view ", string.Empty);
 
-            Talent foundTalent = this.talents.Find(s => s.Name.Contains(talentToView, StringComparison.CurrentCultureIgnoreCase));
+            Talent foundTalent = this.talents.Find(s => s.Name.StartsWith(talentToView, StringComparison.CurrentCultureIgnoreCase) || 
+                                                        s.Name.Contains(talentToView, StringComparison.CurrentCultureIgnoreCase));
             if (foundTalent != null)
             {
                 var sb = new StringBuilder();


### PR DESCRIPTION
The fix is simple. Instead of only taking the second word of the input as the talent name which breaks on multi-word names, the code takes the entire string after the view command as the input to act upon.