### PR TITLE
Improve POSIX (unix, mac/bsd) compatibility

### DIFF
--- a/src/Main/Application.cs
+++ b/src/Main/Application.cs
@@ -91,17 +91,17 @@ namespace WheelMUD.Main
             {
                 // If the database file doesn't exist, try to copy the original source.
                 string sourcePath = null;
-                int i = appDir.IndexOf("\\systemdata\\", System.StringComparison.Ordinal);
+                int i = appDir.IndexOf(Path.DirectorySeparatorChar + "systemdata" + Path.DirectorySeparatorChar, System.StringComparison.Ordinal);
                 if (i > 0)
                 {
-                    sourcePath = appDir.Substring(0, i) + "\\systemdata\\Files\\";
+                    sourcePath = appDir.Substring(0, i) + Path.DirectorySeparatorChar + "systemdata" + Path.DirectorySeparatorChar + "Files" + Path.DirectorySeparatorChar;
                 }
                 else
                 {
                     // The binDebug folder now houses a sub-folder like "netcoreapp3.1" so we need to go up
                     // two levels to search for the starting system data.
                     sourcePath = Path.GetDirectoryName(Path.GetDirectoryName(appDir));
-                    sourcePath = Path.Combine(sourcePath + "\\systemdata\\Files\\");
+                    sourcePath = Path.Combine(sourcePath + Path.DirectorySeparatorChar + "systemdata" + Path.DirectorySeparatorChar + "Files" + Path.DirectorySeparatorChar);
                 }
 
                 DirectoryCopy(sourcePath, GameConfiguration.DataStoragePath, true);
@@ -239,18 +239,18 @@ namespace WheelMUD.Main
                 {
                     // If the database file doesn't exist, try to copy the original source.
                     string sourcePath = null;
-                    int i = appDir.IndexOf("\\systemdata\\", System.StringComparison.Ordinal);
+                    int i = appDir.IndexOf(Path.DirectorySeparatorChar + "systemdata" + Path.DirectorySeparatorChar, System.StringComparison.Ordinal);
                     if (i > 0)
                     {
-                        sourcePath = appDir.Substring(0, i) + "\\systemdata\\SQL\\SQLite";
+                        sourcePath = appDir.Substring(0, i) + Path.DirectorySeparatorChar + "systemdata" + Path.DirectorySeparatorChar + "SQL" + Path.DirectorySeparatorChar + "SQLite";
                         sourcePath = Path.Combine(sourcePath, DatabaseName);
                     }
                     else
                     {
                         // The binDebug folder now houses a sub-folder like "netcoreapp3.1" so we need to go up two
-                        // levels to search for the starting system data.
+                        // levels to search for the starting system data.+
                         sourcePath = Path.GetDirectoryName(Path.GetDirectoryName(appDir));
-                        sourcePath = Path.Combine(sourcePath + "\\systemdata\\SQL\\SQLite", DatabaseName);
+                        sourcePath = Path.Combine(sourcePath + Path.DirectorySeparatorChar + "systemdata" + Path.DirectorySeparatorChar + "SQL" + Path.DirectorySeparatorChar + "SQLite", DatabaseName);
                     }
 
                     if (File.Exists(sourcePath))

--- a/src/Main/Application.cs
+++ b/src/Main/Application.cs
@@ -248,7 +248,7 @@ namespace WheelMUD.Main
                     else
                     {
                         // The binDebug folder now houses a sub-folder like "netcoreapp3.1" so we need to go up two
-                        // levels to search for the starting system data.+
+                        // levels to search for the starting system data.
                         sourcePath = Path.GetDirectoryName(Path.GetDirectoryName(appDir));
                         sourcePath = Path.Combine(sourcePath + Path.DirectorySeparatorChar + "systemdata" + Path.DirectorySeparatorChar + "SQL" + Path.DirectorySeparatorChar + "SQLite", DatabaseName);
                     }

--- a/src/Utilities/GameConfiguration.cs
+++ b/src/Utilities/GameConfiguration.cs
@@ -46,7 +46,7 @@ namespace WheelMUD.Utilities
             Copyright = assembly.GetCustomAttribute<AssemblyCopyrightAttribute>().Copyright.Replace("©", "(c)");
 
             // Additional work to modify raw settings should generally be done once and cached, as follows.
-            string root = System.Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string root = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             string rootPath = Path.Combine(root, "WheelMUD");
             string gamePath = Path.Combine(rootPath, GameConfiguration.Name);
             string fullPath = Path.Combine(gamePath, "Files");

--- a/src/Utilities/GameConfiguration.cs
+++ b/src/Utilities/GameConfiguration.cs
@@ -46,7 +46,7 @@ namespace WheelMUD.Utilities
             Copyright = assembly.GetCustomAttribute<AssemblyCopyrightAttribute>().Copyright.Replace("©", "(c)");
 
             // Additional work to modify raw settings should generally be done once and cached, as follows.
-            string root = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            string root = System.Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             string rootPath = Path.Combine(root, "WheelMUD");
             string gamePath = Path.Combine(rootPath, GameConfiguration.Name);
             string fullPath = Path.Combine(gamePath, "Files");


### PR DESCRIPTION
- Changed configuration root to use `Environment.SpecialFolder.ApplicationData` rather than `Environment.SpecialFolder.CommonApplicationData`. The former points to per-user, non-temporary application-specific data which on *nix systems is the `.config` folder in the user's home directory. The latter attempts to use the system-wide `/usr` which requires root permissions to access by default.
- Replaced several instances of the "\\" escape sequence with the environment agnostic `Path.DirectorySeparatorChar` constant. 
