### PR TITLE
Improve identification of race/skill/talent/etc.

### DIFF
--- a/src/Core/GameEngine/GameRace.cs
+++ b/src/Core/GameEngine/GameRace.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------------
-// <copyright file="RacialTemplate.cs" company="WheelMUD Development Team">
+// <copyright file="GameRace.cs" company="WheelMUD Development Team">
 //   Copyright (c) WheelMUD Development Team.  See LICENSE.txt.  This file is 
 //   subject to the Microsoft Public License.  All other rights reserved.
 // </copyright>
@@ -11,7 +11,7 @@ namespace WheelMUD.Core
     using WheelMUD.Interfaces;
 
     /// <summary>Describes the most basic characteristics for a race in the current gaming system.</summary>
-    public class GameRace : IPersistsWithPlayer
+    public class GameRace : IPersistsWithPlayer, INamed
     {
         /// <summary>Gets or sets the name of the race.</summary>
         public string Name { get; set; }

--- a/src/Core/GameEngine/GameSkill.cs
+++ b/src/Core/GameEngine/GameSkill.cs
@@ -11,7 +11,7 @@ namespace WheelMUD.Core
     using WheelMUD.Interfaces;
 
     /// <summary>Holds data for an individual rule-set skill.</summary>
-    public class GameSkill : IPersistsWithPlayer
+    public class GameSkill : IPersistsWithPlayer, INamed
     {
         /// <summary>Gets or sets the name.</summary>
         /// <value>The name of this skill.</value>

--- a/src/Interfaces/INamed.cs
+++ b/src/Interfaces/INamed.cs
@@ -1,0 +1,14 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="INamed.cs" company="WheelMUD Development Team">
+//   Copyright (c) WheelMUD Development Team.  See LICENSE.txt.  This file is 
+//   subject to the Microsoft Public License.  All other rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+namespace WheelMUD.Interfaces
+{
+    public interface INamed
+    {
+        string Name { get; }
+    }
+}

--- a/src/WarriorRogueMage/CharacterCreation/PickRaceState.cs
+++ b/src/WarriorRogueMage/CharacterCreation/PickRaceState.cs
@@ -22,7 +22,7 @@ namespace WarriorRogueMage.CharacterCreation
     {
         private int longestRaceName;
         private string formattedRaces;
-        private List<GameRace> gameRaces;
+        private readonly List<GameRace> gameRaces;
 
         /// <summary>Initializes a new instance of the <see cref="PickRaceState"/> class.</summary>
         /// <param name="session">The session.</param>
@@ -72,9 +72,7 @@ namespace WarriorRogueMage.CharacterCreation
 
         private GameRace GetRace(string raceName)
         {
-            return (from r in this.gameRaces
-                    where r.Name.Equals(raceName, StringComparison.OrdinalIgnoreCase)
-                    select r).FirstOrDefault();
+            return WrmChargenCommon.GetFirstPriorityMatch(raceName, gameRaces);
         }
 
         private void ViewRaceDescription(string race)

--- a/src/WarriorRogueMage/CharacterCreation/PickSkillsState.cs
+++ b/src/WarriorRogueMage/CharacterCreation/PickSkillsState.cs
@@ -66,6 +66,11 @@ namespace WarriorRogueMage.CharacterCreation
             }
         }
 
+        private GameSkill GetSkill(string skillName)
+        {
+            return WrmChargenCommon.GetFirstPriorityMatch(skillName, gameSkills);
+        }
+
         public override string BuildPrompt()
         {
             return "Select the character's skills\n> ";
@@ -73,19 +78,14 @@ namespace WarriorRogueMage.CharacterCreation
 
         private bool SetSkill(string skillName)
         {
-            var selectedSkill = (from s in this.gameSkills
-                                 where s.Name.Equals(skillName, StringComparison.OrdinalIgnoreCase)
-                                 select s).FirstOrDefault();
+            var selectedSkill = GetSkill(skillName);
             if (selectedSkill == null)
             {
                 WrmChargenCommon.SendErrorMessage(this.Session, "That skill does not exist.");
                 return false;
             }
 
-            var alreadySelected = (from s in this.selectedSkills
-                                   where s.Name.Equals(skillName, StringComparison.OrdinalIgnoreCase)
-                                   select s).Any();
-            if (alreadySelected)
+            if (selectedSkills.Contains(selectedSkill))
             {
                 WrmChargenCommon.SendErrorMessage(this.Session, "You have already selected that skill.");
                 return false;
@@ -112,9 +112,7 @@ namespace WarriorRogueMage.CharacterCreation
 
         private void ViewSkillDescription(string skillName)
         {
-            GameSkill foundSkill = (from s in this.gameSkills
-                                    where s.Name.Equals(skillName, StringComparison.OrdinalIgnoreCase)
-                                    select s).FirstOrDefault();
+            GameSkill foundSkill = GetSkill(skillName);
             if (foundSkill == null)
             {
                 WrmChargenCommon.SendErrorMessage(this.Session, "That skill does not exist.");

--- a/src/WarriorRogueMage/CharacterCreation/PickTalentsState.cs
+++ b/src/WarriorRogueMage/CharacterCreation/PickTalentsState.cs
@@ -5,15 +5,15 @@
 // </copyright>
 //-----------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using WheelMUD.ConnectionStates;
+using WheelMUD.Core;
+
 namespace WarriorRogueMage.CharacterCreation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using WheelMUD.ConnectionStates;
-    using WheelMUD.Core;
-
     /// <summary>The character creation step where the player will pick their talents.</summary>
     public class PickTalentsState : CharacterCreationSubState
     {
@@ -76,17 +76,12 @@ namespace WarriorRogueMage.CharacterCreation
 
         private Talent GetTalent(string talentName)
         {
-            return (from r in this.talents
-                    where r.Name.Equals(talentName, StringComparison.OrdinalIgnoreCase)
-                    select r).FirstOrDefault();
+            return WrmChargenCommon.GetFirstPriorityMatch(talentName, talents);
         }
 
         private void ViewTalentDescription(string talent)
         {
-            string talentToView = talent.Replace("view ", string.Empty);
-
-            Talent foundTalent = this.talents.Find(s => s.Name.StartsWith(talentToView, StringComparison.CurrentCultureIgnoreCase) || 
-                                                        s.Name.Contains(talentToView, StringComparison.CurrentCultureIgnoreCase));
+            Talent foundTalent = GetTalent(talent);
             if (foundTalent != null)
             {
                 var sb = new StringBuilder();

--- a/src/WarriorRogueMage/CharacterCreation/WRMChargenCommon.cs
+++ b/src/WarriorRogueMage/CharacterCreation/WRMChargenCommon.cs
@@ -5,12 +5,15 @@
 // </copyright>
 //-----------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using WheelMUD.Core;
+using WheelMUD.Interfaces;
+
 namespace WarriorRogueMage.CharacterCreation
 {
-    using System;
-    using System.Text;
-    using WheelMUD.Core;
-
     /// <summary>Common methods for Warrior, Rogue, and Mage character creation.</summary>
     public class WrmChargenCommon
     {
@@ -49,6 +52,16 @@ namespace WarriorRogueMage.CharacterCreation
             }
 
             return retval;
+        }
+
+        public static T GetFirstPriorityMatch<T>(string userQuery, IEnumerable<T> collection) where T: INamed
+        {
+            return (from r in collection
+                    where r.Name.StartsWith(userQuery, StringComparison.OrdinalIgnoreCase)
+                    select r).FirstOrDefault() ??
+                   (from r in collection
+                    where r.Name.Contains(userQuery, StringComparison.OrdinalIgnoreCase)
+                    select r).FirstOrDefault();
         }
     }
 }

--- a/src/WarriorRogueMage/Talents/Talent.cs
+++ b/src/WarriorRogueMage/Talents/Talent.cs
@@ -5,16 +5,17 @@
 // </copyright>
 //-----------------------------------------------------------------------------
 
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using WheelMUD.Core;
+using WheelMUD.Interfaces;
+
 namespace WarriorRogueMage
 {
-    using Newtonsoft.Json;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using WheelMUD.Core;
-
     /// <summary>Class to represent the basic Talent in the Warrior, Rogue, and Mage game system.</summary>
-    public class Talent : IEquatable<Talent>
+    public class Talent : IEquatable<Talent>, INamed
     {
         // TODO: Talents and such should not make permanent modifications to base stats. This is being redesigned.
         //       Perhaps we will end up with a system to register class instances to an Active Modifiers list, to


### PR DESCRIPTION
Fixing priority selection of race/skills/talents and so on from user input by first finishing a search for ones which start with, then falling back to ones which contain, the specified string.  This works for the 'view' commands as well as just selecting them as well.

Added an "INamed" interface to allow a single generics method to accommodate each search with the same priority selection logic.

Also cleaned up a few "usings" that Visual Studio 2019 is insisting on for the touched files.