### PR TITLE
Move to storing RavenDB at our configured DataStoragePath

### DIFF
--- a/src/Data.RavenDb/DocumentStore.cs
+++ b/src/Data.RavenDb/DocumentStore.cs
@@ -5,12 +5,13 @@
 // </copyright>
 //-----------------------------------------------------------------------------
 
+using Raven.Client.Documents;
+using Raven.Embedded;
+using System;
+using WheelMUD.Utilities;
+
 namespace WheelMUD.Data.RavenDb
 {
-    using Raven.Client.Documents;
-    using Raven.Embedded;
-    using System;
-
     /// <summary>Encapsulates the RavenDB DocumentStore into a singleton.</summary>
     public class DocumentStoreHolder
     {
@@ -25,7 +26,10 @@ namespace WheelMUD.Data.RavenDb
                 throw new NotImplementedException("WheelMUD.Data.RavenDb only supports embedded mode.");
             }
 
-            EmbeddedServer.Instance.StartServer();
+            EmbeddedServer.Instance.StartServer(new ServerOptions()
+            {
+                DataDirectory = GameConfiguration.DataStoragePath
+            });
 
             // If you get here with an exception like "The specified framework 'Microsoft.NETCore.App',
             // version '...' was not found...", then that is probably the only basic pre-requisite you


### PR DESCRIPTION
Simple change to move RavenDB to get stored near the SQLite relational DB.
However this impacts discovery of any data you've created so far so active devs @JeremyTHolland / @octave-syndicate you may want to be aware this is coming.  (You'll probably just want/need to create new test characters after it merges.)