### PR TITLE
Removing "this."

### DIFF
--- a/Documentation/Development/CodingStandards.md
+++ b/Documentation/Development/CodingStandards.md
@@ -33,4 +33,5 @@ The file headers will look like this:
 // </copyright>
 //-----------------------------------------------------------------------------
 ```
-When creating a new file, just copy-paste an existing header and update the file name and the summary. Do not include any 'created', 'edited' or 'updated' elements in the header. Git is used as the history tracking solution for all files in this project. Please add comments to your commits explaining any changes made to the code.
+When creating a new file, just copy-paste an existing header and update the file name.
+Do not include any 'created', 'edited' or 'updated' elements in the header. Git is used as the history tracking solution for all files in this project. Please add comments to your commits explaining any changes made to the code.

--- a/Documentation/Development/HowTo_CustomizeCharacterCreation.md
+++ b/Documentation/Development/HowTo_CustomizeCharacterCreation.md
@@ -29,7 +29,7 @@ public override CharacterCreationSubState GetNextStep(CharacterCreationSubState 
     // entry point of the state machine
     if (current == null)
     {
-        return new ConfirmCreationEntryState(this.Session);
+        return new ConfirmCreationEntryState(Session);
     }
  
     if (previousStatus == StepStatus.Success)
@@ -53,19 +53,19 @@ private CharacterCreationSubState AdvanceState(CharacterCreationSubState current
     // they could of course reuse some/all of the states below in addition to their own.
     if (current is ConfirmCreationEntryState)
     {
-        return new GetNameState(this.Session);
+        return new GetNameState(Session);
     }
     else if (current is GetNameState)
     {
-        return new GetDescriptionState(this.Session);
+        return new GetDescriptionState(Session);
     }
     else if (current is GetDescriptionState)
     {
-        return new GetPasswordState(this.Session);
+        return new GetPasswordState(Session);
     }
     else if (current is GetPasswordState)
     {
-        return new ConfirmPasswordState(this.Session);
+        return new ConfirmPasswordState(Session);
     }
     else if (current is ConfirmPasswordState)
     {
@@ -85,7 +85,7 @@ private CharacterCreationSubState RegressState(CharacterCreationSubState current
     if (current is ConfirmPasswordState)
     {
         // If password confirmation failed, try selecting a new password.
-        return new GetPasswordState(this.Session);
+        return new GetPasswordState(Session);
     }
  
     throw new InvalidOperationException("The character state machine does not know how to calculate the next step after '" + current.GetType().Name + "' fails");
@@ -156,10 +156,10 @@ ProcessInput is where you will do the bulk of the work for the custom state. Let
 ```
 public PickGenderState(Session session) : base(session)
 {
-    this.Session.Write("You will now pick your character's gender.");
-    this.Session.SetPrompt("Selecting the character's gender ==>");
+    Session.Write("You will now pick your character's gender.");
+    Session.SetPrompt("Selecting the character's gender ==>");
  
-    this.RefreshScreen();
+    RefreshScreen();
 }
 ```
 
@@ -174,13 +174,13 @@ private void RefreshScreen()
     sb.Append("Female" + Environment.NewLine);
     sb.Append("Eunuch" + Environment.NewLine);
     sb.Append(Environment.NewLine);
-    if (string.IsNullOrEmpty(this.playerGender))
+    if (string.IsNullOrEmpty(playerGender))
     {
         sb.Append("<%b%><%red%>No gender has been selected.<%n%>" + Environment.NewLine);
     }
     else
     {
-        sb.AppendFormat("<%green%>The chosen gender is {0}.<%n%>" + Environment.NewLine, this.playerGender);
+        sb.AppendFormat("<%green%>The chosen gender is {0}.<%n%>" + Environment.NewLine, playerGender);
     }
  
     sb.Append("<%yellow%>===============================================================" + Environment.NewLine);
@@ -188,7 +188,7 @@ private void RefreshScreen()
     sb.Append("When you are done picking a gender type done." + Environment.NewLine);
     sb.Append("===============================================================<%n%>");
  
-    this.Session.Write(sb.ToString());
+    Session.Write(sb.ToString());
 }
 ```
 
@@ -196,18 +196,18 @@ I'm not doing anything fancy there. Just putting together some text. At the bott
 ```
 public override void ProcessInput(string command)
 {
-    string currentCommand = this.GetCommandPart(command.ToLower());
+    string currentCommand = GetCommandPart(command.ToLower());
  
     switch (currentCommand)
     {
         case "select":
-            this.SetGender(command.ToLower());
+            SetGender(command.ToLower());
             break;
         case "done":
-            this.ProcessDone();
+            ProcessDone();
             break;
         default:
-            OneHitWonderChargenCommon.SendErrorMessage(this.Session, "Invalid command. Please use select or done.");
+            OneHitWonderChargenCommon.SendErrorMessage(Session, "Invalid command. Please use select or done.");
             break;
     }
 } 
@@ -240,14 +240,14 @@ private void SetGender(string command)
         case "male":
         case "female":
         case "eunuch":
-            this.playerGender = currentGender;
+            playerGender = currentGender;
             break;
         default:
-            OneHitWonderChargenCommon.SendErrorMessage(this.Session, string.Format("'{0}' is an invalid gender selection.", currentGender));
+            OneHitWonderChargenCommon.SendErrorMessage(Session, string.Format("'{0}' is an invalid gender selection.", currentGender));
             break;
     }
  
-    this.RefreshScreen();
+    RefreshScreen();
 }
 ```
 I'm just setting a private variable to what is sent through the command parameter to the playerGender private global variable. If the player sends something other than the what the range of selections are, I send error text to the player. I created a class that contains some helpful methods. SendErrorMessage is used through other steps. Here is what's in there:
@@ -274,8 +274,8 @@ This is just formatting the text in red, sandwiched between rows of =, on the to
 private void ProcessDone()
 {
     // Proceed to the next step.
-    this.Session.SetPrompt(">");
-    this.StateMachine.HandleNextStep(this, StepStatus.Success);
+    Session.SetPrompt(">");
+    StateMachine.HandleNextStep(this, StepStatus.Success);
 }
 ```
 I'm first setting the prompt to >, to alert the player that we are done. Then we tell the state machine to do the next step. The StepStatus.Success tells the state machine that it was successful, and that it need to move to the next step. So now we are done creating this custom step. We still have one more thing to do, before this state/step becomes active. We need to go back to the OneHitWonderCharacterCreationStateMachine class, and wire up our new state. Here is what the original looked like: 
@@ -288,19 +288,19 @@ private CharacterCreationSubState AdvanceState(CharacterCreationSubState current
     // they could of course reuse some/all of the states below in addition to their own.
     if (current is ConfirmCreationEntryState)
     {
-        return new GetNameState(this.Session);
+        return new GetNameState(Session);
     }
     else if (current is GetNameState)
     {
-        return new GetDescriptionState(this.Session);
+        return new GetDescriptionState(Session);
     }
     else if (current is GetDescriptionState)
     {
-        return new GetPasswordState(this.Session);
+        return new GetPasswordState(Session);
     }
     else if (current is GetPasswordState)
     {
-        return new ConfirmPasswordState(this.Session);
+        return new ConfirmPasswordState(Session);
     }
     else if (current is ConfirmPasswordState)
     {
@@ -321,23 +321,23 @@ private CharacterCreationSubState AdvanceState(CharacterCreationSubState current
     // they could of course reuse some/all of the states below in addition to their own.
     if (current is ConfirmCreationEntryState)
     {
-        return new GetNameState(this.Session);
+        return new GetNameState(Session);
     }
     else if (current is GetNameState)
     {
-        return new GetDescriptionState(this.Session);
+        return new GetDescriptionState(Session);
     }
     else if (current is GetDescriptionState)
     {
-        return new GetPasswordState(this.Session);
+        return new GetPasswordState(Session);
     }
     else if (current is GetPasswordState)
     {
-        return new ConfirmPasswordState(this.Session);
+        return new ConfirmPasswordState(Session);
     }
     else if (current is ConfirmPasswordState)
     {
-        return new PickGenderState(this.Session);
+        return new PickGenderState(Session);
     }
     else if (current is PickGenderState)
     {

--- a/Documentation/Development/HowTo_SensoryMessages.md
+++ b/Documentation/Development/HowTo_SensoryMessages.md
@@ -13,12 +13,12 @@ This example is from the Yell action, from WheelMUD v0.4:
 ```
   var contextMessage = new ContextualString(entity, null)
   {
-      ToOriginator = "You yell: " + this.yellSentence,
-      ToReceiver = "You hear $ActiveThing.Name yell: " + this.yellSentence,
-      ToOthers = "You hear $ActiveThing.Name yell: " + this.yellSentence,
+      ToOriginator = "You yell: " + yellSentence,
+      ToReceiver = "You hear $ActiveThing.Name yell: " + yellSentence,
+      ToOthers = "You hear $ActiveThing.Name yell: " + yellSentence,
   };
   var sm = new SensoryMessage(SensoryType.Hearing, 100, contextMessage);
-  this.yellEvent = new VerbalCommunicationEvent(entity, sm, VerbalCommunicationType.Yell);
+  yellEvent = new VerbalCommunicationEvent(entity, sm, VerbalCommunicationType.Yell);
 ```
 As that event gets broadcasted:
 * If you were deaf, you'd see nothing at all from it.

--- a/src/Actions/Activities/Emote.cs
+++ b/src/Actions/Activities/Emote.cs
@@ -58,7 +58,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Activities/Quit.cs
+++ b/src/Actions/Activities/Quit.cs
@@ -33,7 +33,7 @@ namespace WheelMUD.Actions
         /// <param name="actionInput">The full input specified for executing the command.</param>
         public override void Execute(ActionInput actionInput)
         {
-            this.playerBehavior.LogOut();
+            playerBehavior.LogOut();
         }
 
         /// <summary>Checks against the guards for the command.</summary>
@@ -42,14 +42,14 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
             // This initiator is already guaranteed by VerifyCommonGuards to be a player, hence no null check.
-            this.playerBehavior = sender.Thing.Behaviors.FindFirst<PlayerBehavior>();
+            playerBehavior = sender.Thing.Behaviors.FindFirst<PlayerBehavior>();
 
             return null;
         }

--- a/src/Actions/Activities/Rest.cs
+++ b/src/Actions/Activities/Rest.cs
@@ -38,7 +38,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Activities/RollDie.cs
+++ b/src/Actions/Activities/RollDie.cs
@@ -39,7 +39,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Activities/Sleep.cs
+++ b/src/Actions/Activities/Sleep.cs
@@ -37,7 +37,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Activities/StandUp.cs
+++ b/src/Actions/Activities/StandUp.cs
@@ -41,7 +41,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Activities/WakeUp.cs
+++ b/src/Actions/Activities/WakeUp.cs
@@ -39,7 +39,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Admin/Announce.cs
+++ b/src/Actions/Admin/Announce.cs
@@ -37,7 +37,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Admin/Ban.cs
+++ b/src/Actions/Admin/Ban.cs
@@ -37,7 +37,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Admin/Boot.cs
+++ b/src/Actions/Admin/Boot.cs
@@ -37,11 +37,11 @@ namespace WheelMUD.Actions
         {
             // TODO: Inform the player by sending a non-sensory event
             ////connection.Send("You have been booted from the server.");
-            this.playerBehavior.LogOut();
+            playerBehavior.LogOut();
 
             // Inform the admin
             IController sender = actionInput.Controller;
-            sender.Write(string.Format("The player named \"{0}\" was booted from game.", this.PlayerToBoot.Name));
+            sender.Write(string.Format("The player named \"{0}\" was booted from game.", PlayerToBoot.Name));
         }
 
         /// <summary>Checks against the guards for the command.</summary>
@@ -49,20 +49,20 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
             string playerName = actionInput.Tail;
-            this.PlayerToBoot = PlayerManager.Instance.FindLoadedPlayerByName(playerName, false);
-            if (this.PlayerToBoot != null)
+            PlayerToBoot = PlayerManager.Instance.FindLoadedPlayerByName(playerName, false);
+            if (PlayerToBoot != null)
             {
-                this.playerBehavior = this.PlayerToBoot.Behaviors.FindFirst<PlayerBehavior>();
+                playerBehavior = PlayerToBoot.Behaviors.FindFirst<PlayerBehavior>();
             }
 
-            if (this.PlayerToBoot == null || this.playerBehavior == null)
+            if (PlayerToBoot == null || playerBehavior == null)
             {
                 return string.Format("The player named \"{0}\" specified could not be found.", playerName);
             }

--- a/src/Actions/Admin/Buff.cs
+++ b/src/Actions/Admin/Buff.cs
@@ -54,14 +54,14 @@ namespace WheelMUD.Actions
             var originator = sender.Thing;
 
             // Strings to be displayed when the effect is applied/removed.
-            var buffString = new ContextualString(sender.Thing, this.target)
+            var buffString = new ContextualString(sender.Thing, target)
             {
-                ToOriginator = string.Format("\r\nThe '{0}' stat of {1} has changed by {2}.\r\n", this.stat.Name, this.target.Name, this.modAmount),
-                ToReceiver = string.Format("\r\nYour '{0}' stat has changed by {1}.\r\n", this.stat.Name, this.modAmount)
+                ToOriginator = string.Format("\r\nThe '{0}' stat of {1} has changed by {2}.\r\n", stat.Name, target.Name, modAmount),
+                ToReceiver = string.Format("\r\nYour '{0}' stat has changed by {1}.\r\n", stat.Name, modAmount)
             };
-            var unbuffString = new ContextualString(sender.Thing, this.target)
+            var unbuffString = new ContextualString(sender.Thing, target)
             {
-                ToReceiver = string.Format("\r\nYour '{0}' stat goes back to normal.", this.stat.Abbreviation)
+                ToReceiver = string.Format("\r\nYour '{0}' stat goes back to normal.", stat.Abbreviation)
             };
 
             // Turn the above sets of strings into sensory messages.
@@ -70,9 +70,9 @@ namespace WheelMUD.Actions
 
             // Remove all existing effects on stats with the same abbreviation
             // to prevent the effects from being stacked, at least for now.
-            foreach (var effect in this.target.Behaviors.OfType<StatEffect>())
+            foreach (var effect in target.Behaviors.OfType<StatEffect>())
             {
-                if (effect.Stat.Abbreviation == this.stat.Abbreviation)
+                if (effect.Stat.Abbreviation == stat.Abbreviation)
                 {
                     sender.Thing.Behaviors.Remove(effect);
                 }
@@ -80,23 +80,23 @@ namespace WheelMUD.Actions
 
             // Create the effect, based on the type of modification.
             StatEffect statEffect = null;
-            switch (this.modType)
+            switch (modType)
             {
                 case "value":
-                    statEffect = new StatEffect(sender.Thing, this.stat, this.modAmount, 0, 0, this.duration, sensoryMessage, expirationMessage);
+                    statEffect = new StatEffect(sender.Thing, stat, modAmount, 0, 0, duration, sensoryMessage, expirationMessage);
                     break;
                 case "min":
-                    statEffect = new StatEffect(sender.Thing, this.stat, 0, this.modAmount, 0, this.duration, sensoryMessage, expirationMessage);
+                    statEffect = new StatEffect(sender.Thing, stat, 0, modAmount, 0, duration, sensoryMessage, expirationMessage);
                     break;
                 case "max":
-                    statEffect = new StatEffect(sender.Thing, this.stat, 0, 0, this.modAmount, this.duration, sensoryMessage, expirationMessage);
+                    statEffect = new StatEffect(sender.Thing, stat, 0, 0, modAmount, duration, sensoryMessage, expirationMessage);
                     break;
             }
 
             // Apply the effect.
             if (statEffect != null)
             {
-                this.target.Behaviors.Add(statEffect);
+                target.Behaviors.Add(statEffect);
             }
         }
 
@@ -105,7 +105,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -119,7 +119,7 @@ namespace WheelMUD.Actions
             var args = actionInput.Params;
             string targetString = args[0];
             string statString = args[1];
-            this.modType = args[2].ToLower().Trim();
+            modType = args[2].ToLower().Trim();
             string amountString = args[3];
             string durationString = null;
             if (args.Length > 4)
@@ -128,26 +128,26 @@ namespace WheelMUD.Actions
             }
 
             // Find the player.
-            this.target = PlayerManager.Instance.FindLoadedPlayerByName(targetString, true);
-            if (this.target == null)
+            target = PlayerManager.Instance.FindLoadedPlayerByName(targetString, true);
+            if (target == null)
             {
                 return string.Format("Could not find a target named {0}.", targetString);
             }
 
             // Make sure a valid stat was specified.
-            if (!this.target.Stats.TryGetValue(statString, out this.stat))
+            if (!target.Stats.TryGetValue(statString, out stat))
             {
-                return string.Format("{0} does not have a stat called {1}.", this.target.Name, statString);
+                return string.Format("{0} does not have a stat called {1}.", target.Name, statString);
             }
 
             // Make sure the mod type ('value', 'min', or 'max') is valid.
-            if (!this.validModTypes.Contains(this.modType))
+            if (!validModTypes.Contains(modType))
             {
-                return string.Format("'{0}' is unrecognized. Try modifying the stat's 'value', 'min', or 'max'.", this.modType);
+                return string.Format("'{0}' is unrecognized. Try modifying the stat's 'value', 'min', or 'max'.", modType);
             }
 
             // Parse the mod amount and make sure it is an integer.
-            if (!int.TryParse(amountString, out this.modAmount))
+            if (!int.TryParse(amountString, out modAmount))
             {
                 return string.Format("The amount '{0}' was not valid.", amountString);
             }
@@ -156,14 +156,14 @@ namespace WheelMUD.Actions
             // Treat it as a number of minutes.
             if (string.IsNullOrEmpty(durationString))
             {
-                this.duration = TimeSpan.FromMinutes(5);
+                duration = TimeSpan.FromMinutes(5);
             }
             else
             {
                 double minutes;
                 if (double.TryParse(durationString, out minutes))
                 {
-                    this.duration = TimeSpan.FromMinutes(minutes);
+                    duration = TimeSpan.FromMinutes(minutes);
                 }
                 else
                 {

--- a/src/Actions/Admin/Clone.cs
+++ b/src/Actions/Admin/Clone.cs
@@ -59,7 +59,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Admin/Control.cs
+++ b/src/Actions/Admin/Control.cs
@@ -38,7 +38,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Admin/GoTo.cs
+++ b/src/Actions/Admin/GoTo.cs
@@ -99,7 +99,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Admin/Jail.cs
+++ b/src/Actions/Admin/Jail.cs
@@ -36,7 +36,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Admin/Locate.cs
+++ b/src/Actions/Admin/Locate.cs
@@ -49,7 +49,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Admin/Mute.cs
+++ b/src/Actions/Admin/Mute.cs
@@ -47,14 +47,14 @@ namespace WheelMUD.Actions
             IController sender = actionInput.Controller;
 
             // Strings to be displayed when the effect is applied/removed.
-            var muteString = new ContextualString(sender.Thing, this.playerToMute)
+            var muteString = new ContextualString(sender.Thing, playerToMute)
             {
-                ToOriginator = $"You mute {this.playerToMute.Name} for duration {this.muteDuration}.",
+                ToOriginator = $"You mute {playerToMute.Name} for duration {muteDuration}.",
                 ToReceiver = $"You are now mute. Please reflect on recent choices.",
             };
-            var unmuteString = new ContextualString(sender.Thing, this.playerToMute)
+            var unmuteString = new ContextualString(sender.Thing, playerToMute)
             {
-                ToOriginator = $"{this.playerToMute.Name} is no longer mute.",
+                ToOriginator = $"{playerToMute.Name} is no longer mute.",
                 ToReceiver = $"You are no longer mute."
             };
 
@@ -63,10 +63,10 @@ namespace WheelMUD.Actions
             var unmuteMessage = new SensoryMessage(SensoryType.Sight, 100, unmuteString);
 
             // Create the effect.
-            var muteEffect = new MutedEffect(sender.Thing, this.muteDuration, muteMessage, unmuteMessage);
+            var muteEffect = new MutedEffect(sender.Thing, muteDuration, muteMessage, unmuteMessage);
 
             // Apply the effect.
-            this.playerToMute.Behaviors.Add(muteEffect);
+            playerToMute.Behaviors.Add(muteEffect);
         }
 
         /// <summary>Checks against the guards for the command.</summary>
@@ -74,15 +74,15 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
             string playerName = actionInput.Params[0];
-            this.playerToMute = PlayerManager.Instance.FindLoadedPlayerByName(playerName, false);
-            if (this.playerToMute == null)
+            playerToMute = PlayerManager.Instance.FindLoadedPlayerByName(playerName, false);
+            if (playerToMute == null)
             {
                 return string.Format("The player named \"{0}\" could not be found.", playerName);
             }
@@ -96,7 +96,7 @@ namespace WheelMUD.Actions
 
                 if (double.TryParse(timeString, out double timeInMinutes))
                 {
-                    this.muteDuration = TimeSpan.FromMinutes(timeInMinutes);
+                    muteDuration = TimeSpan.FromMinutes(timeInMinutes);
                 }
                 else
                 {
@@ -106,7 +106,7 @@ namespace WheelMUD.Actions
             else
             {
                 // Default time if none was specified.
-                this.muteDuration = TimeSpan.FromSeconds(15);
+                muteDuration = TimeSpan.FromSeconds(15);
             }
 
             return null;

--- a/src/Actions/Admin/Relinquish.cs
+++ b/src/Actions/Admin/Relinquish.cs
@@ -39,7 +39,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Admin/RoleGrant.cs
+++ b/src/Actions/Admin/RoleGrant.cs
@@ -35,12 +35,12 @@ namespace WheelMUD.Actions
         public override void Execute(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            var userControlledBehavior = this.player.Behaviors.FindFirst<UserControlledBehavior>();
-            userControlledBehavior.SecurityRoles |= this.role;
-            sender.Write($"{this.player.Name} has been granted the {this.role.ToString()} role.");
-            sender.Write($"{this.player.Name} is now: {userControlledBehavior.SecurityRoles}.");
+            var userControlledBehavior = player.Behaviors.FindFirst<UserControlledBehavior>();
+            userControlledBehavior.SecurityRoles |= role;
+            sender.Write($"{player.Name} has been granted the {role.ToString()} role.");
+            sender.Write($"{player.Name} is now: {userControlledBehavior.SecurityRoles}.");
             // TODO: Should this notify the target user too?
-            this.player.FindBehavior<PlayerBehavior>()?.SavePlayer();
+            player.FindBehavior<PlayerBehavior>()?.SavePlayer();
         }
 
         /// <summary>Checks against the guards for the command.</summary>
@@ -48,7 +48,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -60,14 +60,14 @@ namespace WheelMUD.Actions
 
             // Rule: The targeted player must exist and be online. (For safety, this must be a full name match only.)
             // TODO: Consider a mode where the player document exists in the DB is enough; add ability to modify said doc.
-            this.player = PlayerManager.Instance.FindLoadedPlayerByName(playerName, false);
-            if (this.player == null)
+            player = PlayerManager.Instance.FindLoadedPlayerByName(playerName, false);
+            if (player == null)
             {
                 return $"The player '{playerName}' does not seem to be online. (Exact name must be used for role changes.)";
             }
 
             // Rule: The roleName must be a valid role.
-            if (!Enum.TryParse(roleName, true, out this.role))
+            if (!Enum.TryParse(roleName, true, out role))
             {
                 string rolesList = string.Join(", ", SecurityRoleHelpers.IndividualSecurityRoles);
                 return $"The role '{roleName}' is not a valid role. Try one of: {rolesList}";

--- a/src/Actions/Admin/RoleRevoke.cs
+++ b/src/Actions/Admin/RoleRevoke.cs
@@ -35,12 +35,12 @@ namespace WheelMUD.Actions
         public override void Execute(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            var userControlledBehavior = this.player.Behaviors.FindFirst<UserControlledBehavior>();
-            userControlledBehavior.SecurityRoles &= ~this.role;
-            sender.Write($"{this.player.Name} has been revoked the {this.role.ToString()} role.");
-            sender.Write($"{this.player.Name} is now: {userControlledBehavior.SecurityRoles}.");
+            var userControlledBehavior = player.Behaviors.FindFirst<UserControlledBehavior>();
+            userControlledBehavior.SecurityRoles &= ~role;
+            sender.Write($"{player.Name} has been revoked the {role.ToString()} role.");
+            sender.Write($"{player.Name} is now: {userControlledBehavior.SecurityRoles}.");
             // TODO: Should this notify the target user too?
-            this.player.FindBehavior<PlayerBehavior>()?.SavePlayer();
+            player.FindBehavior<PlayerBehavior>()?.SavePlayer();
         }
 
         /// <summary>Checks against the guards for the command.</summary>
@@ -48,7 +48,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -60,14 +60,14 @@ namespace WheelMUD.Actions
 
             // Rule: The targeted player must exist and be online. (For safety, this must be a full name match only.)
             // TODO: Consider a mode where the player document exists in the DB is enough; add ability to modify said doc.
-            this.player = PlayerManager.Instance.FindLoadedPlayerByName(playerName, false);
-            if (this.player == null)
+            player = PlayerManager.Instance.FindLoadedPlayerByName(playerName, false);
+            if (player == null)
             {
                 return $"The player '{playerName}' does not seem to be online. (Exact name must be used for role changes.)";
             }
 
             // Rule: The roleName must be a valid role.
-            if (!Enum.TryParse(roleName, true, out this.role))
+            if (!Enum.TryParse(roleName, true, out role))
             {
                 string rolesList = string.Join(", ", SecurityRoleHelpers.IndividualSecurityRoles);
                 return $"The role '{roleName}' is not a valid role. Try one of: {rolesList}";

--- a/src/Actions/Admin/Spawn.cs
+++ b/src/Actions/Admin/Spawn.cs
@@ -57,7 +57,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Admin/Unmute.cs
+++ b/src/Actions/Admin/Unmute.cs
@@ -34,7 +34,7 @@ namespace WheelMUD.Actions
         {
             // Remove all instances of MutedEffect (in case there are more than one).
             MutedEffect effect;
-            while ((effect = this.playerToUnmute.Behaviors.FindFirst<MutedEffect>()) != null)
+            while ((effect = playerToUnmute.Behaviors.FindFirst<MutedEffect>()) != null)
             {
                 // Cancel the event so it will be ignored by TimeSystem when the time expires.
                 effect.UnmuteEvent.Cancel("Mute cancelled.");
@@ -47,7 +47,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -55,16 +55,16 @@ namespace WheelMUD.Actions
 
             // Make sure the target exists.
             string playerName = actionInput.Params[0];
-            this.playerToUnmute = PlayerManager.Instance.FindLoadedPlayerByName(playerName, false);
-            if (this.playerToUnmute == null)
+            playerToUnmute = PlayerManager.Instance.FindLoadedPlayerByName(playerName, false);
+            if (playerToUnmute == null)
             {
                 return string.Format("The player named \"{0}\" could not be found.", playerName);
             }
 
             // Make sure the player has a MuteEffect applied.
-            if (!this.playerToUnmute.HasBehavior<MutedEffect>())
+            if (!playerToUnmute.HasBehavior<MutedEffect>())
             {
-                return string.Format("The player {0} was not muted!", this.playerToUnmute.Name);
+                return string.Format("The player {0} was not muted!", playerToUnmute.Name);
             }
 
             return null;

--- a/src/Actions/Commercial/Account.cs
+++ b/src/Actions/Commercial/Account.cs
@@ -40,7 +40,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Commercial/ShopBuy.cs
+++ b/src/Actions/Commercial/ShopBuy.cs
@@ -43,7 +43,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Commercial/ShopList.cs
+++ b/src/Actions/Commercial/ShopList.cs
@@ -40,7 +40,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Commercial/ShopSell.cs
+++ b/src/Actions/Commercial/ShopSell.cs
@@ -41,7 +41,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Communicate/Reply.cs
+++ b/src/Actions/Communicate/Reply.cs
@@ -37,7 +37,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Communicate/Retell.cs
+++ b/src/Actions/Communicate/Retell.cs
@@ -37,7 +37,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Communicate/Say.cs
+++ b/src/Actions/Communicate/Say.cs
@@ -39,9 +39,9 @@ namespace WheelMUD.Actions
             IController sender = actionInput.Controller;
             var contextMessage = new ContextualString(sender.Thing, sender.Thing.Parent)
             {
-                ToOriginator = $"You say: {this.sayText}",
-                ToReceiver = $"{sender.Thing.Name} says: {this.sayText}",
-                ToOthers = $"{sender.Thing.Name} says: {this.sayText}",
+                ToOriginator = $"You say: {sayText}",
+                ToReceiver = $"{sender.Thing.Name} says: {sayText}",
+                ToOthers = $"{sender.Thing.Name} says: {sayText}",
             };
             var sm = new SensoryMessage(SensoryType.Hearing, 100, contextMessage);
 
@@ -58,13 +58,13 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
-            this.sayText = actionInput.Tail.Trim();
+            sayText = actionInput.Tail.Trim();
             return null;
         }
     }

--- a/src/Actions/Communicate/Tell.cs
+++ b/src/Actions/Communicate/Tell.cs
@@ -39,10 +39,10 @@ namespace WheelMUD.Actions
         public override void Execute(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string fixedSentence = "\"<%yellow%>" + this.sentence + "<%n%>\"";
-            var contextMessage = new ContextualString(sender.Thing, this.target)
+            string fixedSentence = "\"<%yellow%>" + sentence + "<%n%>\"";
+            var contextMessage = new ContextualString(sender.Thing, target)
             {
-                ToOriginator = this.BuildOriginatorMessage(fixedSentence),
+                ToOriginator = BuildOriginatorMessage(fixedSentence),
                 ToReceiver = string.Format("{0} tells you: {1}", sender.Thing.Name, fixedSentence),
                 ToOthers = null,
             };
@@ -51,12 +51,12 @@ namespace WheelMUD.Actions
             var tellEvent = new VerbalCommunicationEvent(sender.Thing, sm, VerbalCommunicationType.Tell);
 
             // Make sure both the user is allowed to do the tell and the target is allowed to receive it.
-            this.target.Eventing.OnCommunicationRequest(tellEvent, EventScope.SelfDown);
+            target.Eventing.OnCommunicationRequest(tellEvent, EventScope.SelfDown);
             sender.Thing.Eventing.OnCommunicationRequest(tellEvent, EventScope.SelfDown);
             if (!tellEvent.IsCancelled)
             {
                 // Printing the sensory message is all that's left to do, which the event itself will take care of.
-                this.target.Eventing.OnCommunicationEvent(tellEvent, EventScope.SelfDown);
+                target.Eventing.OnCommunicationEvent(tellEvent, EventScope.SelfDown);
                 sender.Thing.Eventing.OnCommunicationEvent(tellEvent, EventScope.SelfDown);
             }
         }
@@ -66,7 +66,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -79,8 +79,8 @@ namespace WheelMUD.Actions
             // TODO: InterMUD support? string mudName = GameConfiguration.GameName;
 
             // Rule: Target must be an entity. TODO: REMOVE CHECK?
-            this.target = GetPlayerOrMobile(targetName);
-            if (this.target == null)
+            target = GetPlayerOrMobile(targetName);
+            if (target == null)
             {
                 // Make first char Upper?  IE textInfo.ToTitleCase.
                 return targetName + " is not part of reality.";
@@ -89,7 +89,7 @@ namespace WheelMUD.Actions
             //// TODO what if player offline ?
 
             // Rule: Prevent talking to yourself.
-            if (actionInput.Controller.Thing.Name.ToLower() == this.target.Name.ToLower())
+            if (actionInput.Controller.Thing.Name.ToLower() == target.Name.ToLower())
             {
                 return "Talking to yourself is the first sign of madness!";
             }
@@ -101,9 +101,9 @@ namespace WheelMUD.Actions
             }
 
             // The sentence to be relayed consists of all input beyond the first parameter, 
-            // which was used to identify this.entity already.
+            // which was used to identify entity already.
             int firstCommandLength = actionInput.Params[0].Length;
-            this.sentence = actionInput.Tail.Substring(firstCommandLength).Trim();
+            sentence = actionInput.Tail.Substring(firstCommandLength).Trim();
 
             return null;
         }
@@ -113,7 +113,7 @@ namespace WheelMUD.Actions
         /// <returns>The final string the sender of the tell will see.</returns>
         private string BuildOriginatorMessage(string fixedSentence)
         {
-            PlayerBehavior playerBehavior = this.target.Behaviors.FindFirst<PlayerBehavior>();
+            PlayerBehavior playerBehavior = target.Behaviors.FindFirst<PlayerBehavior>();
 
             if (playerBehavior != null && playerBehavior.IsAFK)
             {
@@ -128,11 +128,11 @@ namespace WheelMUD.Actions
                     afkMessage = "AFK";
                 }
 
-                return string.Format("You tell {0}: {1}<%nl%>{0} is {2}.", this.target.Name, fixedSentence, afkMessage);
+                return string.Format("You tell {0}: {1}<%nl%>{0} is {2}.", target.Name, fixedSentence, afkMessage);
             }
             else
             {
-                return string.Format("You tell {0}: {1}", this.target.Name, fixedSentence);
+                return string.Format("You tell {0}: {1}", target.Name, fixedSentence);
             }
         }
     }

--- a/src/Actions/Communicate/Typo.cs
+++ b/src/Actions/Communicate/Typo.cs
@@ -38,8 +38,8 @@ namespace WheelMUD.Actions
             TypoEntry typoEntry = new TypoEntry
             {
                 Note = actionInput.Tail,
-                PlaceID = this.player.Parent.Id,
-                SubmittedByPlayerID = this.player.Id,
+                PlaceID = player.Parent.Id,
+                SubmittedByPlayerID = player.Id,
                 SubmittedDateTime = DateTime.Now,
                 Resolved = false
             };
@@ -54,13 +54,13 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
-            this.player = actionInput.Controller.Thing;
+            player = actionInput.Controller.Thing;
 
             return null;
         }

--- a/src/Actions/Communicate/Yell.cs
+++ b/src/Actions/Communicate/Yell.cs
@@ -49,8 +49,8 @@ namespace WheelMUD.Actions
             // This is to keep track of the previous rooms we've yelled at, to prevent echoes.
             List<Thing> previousRooms = new List<Thing>();
 
-            this.CreateYellEvent(sender.Thing);
-            this.TraverseRoom(parent, actionInput, sender, RoomFallOff, previousRooms);
+            CreateYellEvent(sender.Thing);
+            TraverseRoom(parent, actionInput, sender, RoomFallOff, previousRooms);
         }
 
         /// <summary>Checks against the guards for the command.</summary>
@@ -58,13 +58,13 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
-            this.yellSentence = actionInput.Tail.Trim();
+            yellSentence = actionInput.Tail.Trim();
 
             return null;
         }
@@ -90,8 +90,8 @@ namespace WheelMUD.Actions
             visitedPlaces.Add(place);
 
             // Broadcast the yell request at the specified place.
-            place.Eventing.OnCommunicationRequest(this.yellEvent, EventScope.SelfDown);
-            if (!this.yellEvent.IsCancelled)
+            place.Eventing.OnCommunicationRequest(yellEvent, EventScope.SelfDown);
+            if (!yellEvent.IsCancelled)
             {
                 List<ExitBehavior> exits = place.FindAllChildrenBehaviors<ExitBehavior>();
                 foreach (ExitBehavior exit in exits)
@@ -100,7 +100,7 @@ namespace WheelMUD.Actions
                     if (opensClosesBehavior == null || opensClosesBehavior.IsOpen == true)
                     {
                         Thing destination = exit.GetDestination(place);
-                        this.TraverseRoom(destination, actionInput, sender, (timeToLive == -1) ? timeToLive : (timeToLive - 1), visitedPlaces);
+                        TraverseRoom(destination, actionInput, sender, (timeToLive == -1) ? timeToLive : (timeToLive - 1), visitedPlaces);
                     }
                 }
 
@@ -114,7 +114,7 @@ namespace WheelMUD.Actions
                 // doesn't necessarily mean all other branches of the yell should be suppressed too.  IE if
                 // something to the west of our position prevents noise from going through there, the noise 
                 // that was also going northwards shouldn't suddenly stop.
-                this.CreateYellEvent(sender.Thing);
+                CreateYellEvent(sender.Thing);
             }
         }
 
@@ -122,13 +122,13 @@ namespace WheelMUD.Actions
         {
             var contextMessage = new ContextualString(entity, null)
             {
-                ToOriginator = $"You yell: {this.yellSentence}",
-                ToReceiver = $"You hear {entity.Name} yell: {this.yellSentence}",
-                ToOthers = $"You hear {entity.Name} yell: {this.yellSentence}",
+                ToOriginator = $"You yell: {yellSentence}",
+                ToReceiver = $"You hear {entity.Name} yell: {yellSentence}",
+                ToOthers = $"You hear {entity.Name} yell: {yellSentence}",
             };
             var sm = new SensoryMessage(SensoryType.Hearing, 100, contextMessage);
 
-            this.yellEvent = new VerbalCommunicationEvent(entity, sm, VerbalCommunicationType.Yell);
+            yellEvent = new VerbalCommunicationEvent(entity, sm, VerbalCommunicationType.Yell);
         }
     }
 }

--- a/src/Actions/Configure/AFK.cs
+++ b/src/Actions/Configure/AFK.cs
@@ -75,7 +75,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Configure/AliasAdd.cs
+++ b/src/Actions/Configure/AliasAdd.cs
@@ -36,7 +36,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Configure/AliasRemove.cs
+++ b/src/Actions/Configure/AliasRemove.cs
@@ -36,7 +36,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Configure/Buffer.cs
+++ b/src/Actions/Configure/Buffer.cs
@@ -47,8 +47,8 @@ namespace WheelMUD.Actions
         public override void Execute(ActionInput actionInput)
         {
             // Not sure what would call this other than a player, but exit early just in case.
-            // Implicitly also verifies that this.sender exists.
-            if (this.userControlledBehavior == null)
+            // Implicitly also verifies that sender exists.
+            if (userControlledBehavior == null)
             {
                 return;
             }
@@ -56,19 +56,19 @@ namespace WheelMUD.Actions
             // No arguments were provided. Just show the current buffer setting and exit.
             if (string.IsNullOrEmpty(actionInput.Tail))
             {
-                this.ShowCurrentBuffer();
+                ShowCurrentBuffer();
                 return;
             }
 
             // Set the value for the current session
-            if (this.session.Connection != null)
+            if (session.Connection != null)
             {
-                this.session.Connection.PagingRowLimit = (this.parsedBufferLength == -1) ? this.session.Terminal.Height : this.parsedBufferLength;
+                session.Connection.PagingRowLimit = (parsedBufferLength == -1) ? session.Terminal.Height : parsedBufferLength;
             }
 
-            this.userControlledBehavior.PagingRowLimit = this.parsedBufferLength;
+            userControlledBehavior.PagingRowLimit = parsedBufferLength;
 
-            this.ShowCurrentBuffer();
+            ShowCurrentBuffer();
         }
 
         /// <summary>Checks against the guards for the command.</summary>
@@ -76,15 +76,15 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
-            this.PreprocessInput(actionInput);
+            PreprocessInput(actionInput);
 
-            if (!this.parseSucceeded || this.parsedBufferLength > 100 || this.parsedBufferLength < -1)
+            if (!parseSucceeded || parsedBufferLength > 100 || parsedBufferLength < -1)
             {
                 return "The screen buffer must be between 0 and 100 lines, or 'auto'.";
             }
@@ -98,16 +98,16 @@ namespace WheelMUD.Actions
         private void PreprocessInput(ActionInput actionInput)
         {
             // Make sure there is a sender.
-            this.sender = actionInput.Controller;
-            this.session = this.sender as Session;
-            if (this.sender == null || this.sender.Thing == null)
+            sender = actionInput.Controller;
+            session = sender as Session;
+            if (sender == null || sender.Thing == null)
             {
                 return;
             }
 
             // Make sure the sender is an actual connected user.
-            this.userControlledBehavior = this.sender.Thing.Behaviors.FindFirst<UserControlledBehavior>();
-            if (this.userControlledBehavior == null)
+            userControlledBehavior = sender.Thing.Behaviors.FindFirst<UserControlledBehavior>();
+            if (userControlledBehavior == null)
             {
                 return;
             }
@@ -116,16 +116,16 @@ namespace WheelMUD.Actions
             string lengthText = actionInput.Tail.ToLower().Trim();
             if (string.IsNullOrEmpty(lengthText))
             {
-                this.parseSucceeded = true;
+                parseSucceeded = true;
             }
             else if (lengthText == "auto")
             {
-                this.parsedBufferLength = -1;
-                this.parseSucceeded = true;
+                parsedBufferLength = -1;
+                parseSucceeded = true;
             }
             else
             {
-                this.parseSucceeded = this.TryParse(lengthText, out this.parsedBufferLength);
+                parseSucceeded = TryParse(lengthText, out parsedBufferLength);
             }
         }
 
@@ -153,13 +153,13 @@ namespace WheelMUD.Actions
         /// <summary>Displays the current buffer length to the user, handling the special case of "auto" instead of -1.</summary>
         private void ShowCurrentBuffer()
         {
-            if (this.userControlledBehavior.PagingRowLimit == -1)
+            if (userControlledBehavior.PagingRowLimit == -1)
             {
-                this.sender.Write($"Your screen buffer size is 'auto' (currently {this.session.Terminal.Height} lines).");
+                sender.Write($"Your screen buffer size is 'auto' (currently {session.Terminal.Height} lines).");
             }
             else
             {
-                this.sender.Write($"Your screen buffer is {this.userControlledBehavior.PagingRowLimit} lines.");
+                sender.Write($"Your screen buffer is {userControlledBehavior.PagingRowLimit} lines.");
             }
         }
     }

--- a/src/Actions/Configure/Description.cs
+++ b/src/Actions/Configure/Description.cs
@@ -38,9 +38,9 @@ namespace WheelMUD.Actions
                 Thing entity = sender.Thing;
                 if (entity != null)
                 {
-                    if (!string.IsNullOrEmpty(this.NewDescription))
+                    if (!string.IsNullOrEmpty(NewDescription))
                     {
-                        entity.Description = this.NewDescription;
+                        entity.Description = NewDescription;
                         entity.FindBehavior<PlayerBehavior>()?.SavePlayer();
                         sender.Write("Description successfully changed.");
                     }
@@ -61,13 +61,13 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
-            this.NewDescription = actionInput.Tail;
+            NewDescription = actionInput.Tail;
 
             return null;
         }

--- a/src/Actions/Configure/Password.cs
+++ b/src/Actions/Configure/Password.cs
@@ -56,7 +56,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -73,7 +73,7 @@ namespace WheelMUD.Actions
                     return "Passwords do not match.";
                 }
 
-                this.NewPassword = password1;
+                NewPassword = password1;
                 return null;
             }
 

--- a/src/Actions/Configure/Pretitle.cs
+++ b/src/Actions/Configure/Pretitle.cs
@@ -43,18 +43,18 @@ namespace WheelMUD.Actions
         public override void Execute(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            this.player.SingularPrefix = this.newPretitle;
+            player.SingularPrefix = newPretitle;
 
-            if (string.IsNullOrEmpty(this.newPretitle))
+            if (string.IsNullOrEmpty(newPretitle))
             {
-                sender.Write($"Your old pretitle was \"{this.oldPretitle}\" and is now removed.");
+                sender.Write($"Your old pretitle was \"{oldPretitle}\" and is now removed.");
             }
             else
             {
-                sender.Write($"Your old pretitle was \"{this.oldPretitle}\" and is now \"{this.newPretitle}\".");
+                sender.Write($"Your old pretitle was \"{oldPretitle}\" and is now \"{newPretitle}\".");
             }
 
-            this.player.FindBehavior<PlayerBehavior>()?.SavePlayer();
+            player.FindBehavior<PlayerBehavior>()?.SavePlayer();
         }
 
         /// <summary>Checks against the guards for the command.</summary>
@@ -63,23 +63,23 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
             // The comon guards already guarantees the sender is a player, hence no null checks here.
-            this.player = sender.Thing;
+            player = sender.Thing;
 
             // Rule: The new pretitle must be empty or meet the length requirements.
-            this.oldPretitle = this.player.SingularPrefix;
+            oldPretitle = player.SingularPrefix;
 
             if (!string.IsNullOrEmpty(actionInput.Tail))
             {
-                this.newPretitle = actionInput.Tail;
+                newPretitle = actionInput.Tail;
 
-                if (this.newPretitle.Length < 2 || this.newPretitle.Length > 15)
+                if (newPretitle.Length < 2 || newPretitle.Length > 15)
                 {
                     return "The pretitle may not be less than 2 nor more than 15 characters long.";
                 }

--- a/src/Actions/Configure/Save.cs
+++ b/src/Actions/Configure/Save.cs
@@ -36,7 +36,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Configure/Set.cs
+++ b/src/Actions/Configure/Set.cs
@@ -35,7 +35,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Configure/Settings.cs
+++ b/src/Actions/Configure/Settings.cs
@@ -36,7 +36,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Configure/Title.cs
+++ b/src/Actions/Configure/Title.cs
@@ -57,7 +57,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Inform/All.cs
+++ b/src/Actions/Inform/All.cs
@@ -49,7 +49,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Inform/Attributes.cs
+++ b/src/Actions/Inform/Attributes.cs
@@ -57,7 +57,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Inform/Commands.cs
+++ b/src/Actions/Inform/Commands.cs
@@ -57,7 +57,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Inform/Credits.cs
+++ b/src/Actions/Inform/Credits.cs
@@ -70,7 +70,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Inform/Effects.cs
+++ b/src/Actions/Inform/Effects.cs
@@ -74,7 +74,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Inform/Examine.cs
+++ b/src/Actions/Inform/Examine.cs
@@ -69,7 +69,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Inform/Glance.cs
+++ b/src/Actions/Inform/Glance.cs
@@ -36,7 +36,7 @@ namespace WheelMUD.Actions
         {
             // Simply send a sensory event to the glancer; If they can see it, they'll get the output.
             var sender = actionInput.Controller;
-            var message = new SensoryMessage(SensoryType.Sight, 100, this.BuildGlance(sender.Thing));
+            var message = new SensoryMessage(SensoryType.Sight, 100, BuildGlance(sender.Thing));
             var sensoryEvent = new SensoryEvent(sender.Thing, message);
             sender.Thing.Eventing.OnMiscellaneousEvent(sensoryEvent, EventScope.SelfOnly);
         }
@@ -46,15 +46,15 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
             // Rule: the sender must be capable of sensing/perceiving things.
-            this.sensesBehavior = actionInput.Controller.Thing.Behaviors.FindFirst<SensesBehavior>();
-            if (this.sensesBehavior == null)
+            sensesBehavior = actionInput.Controller.Thing.Behaviors.FindFirst<SensesBehavior>();
+            if (sensesBehavior == null)
             {
                 return "You are incapable of perceiving anything.";
             }
@@ -69,9 +69,9 @@ namespace WheelMUD.Actions
         {
             // Just basic generation of a general room description until furniture is implemented.
             var glanceString = new ContextualStringBuilder(sender, sender);
-            var perceivedExits = this.sensesBehavior.PerceiveExits();
-            var perceivedEntities = this.sensesBehavior.PerceiveEntities();
-            var perceivedItems = this.sensesBehavior.PerceiveItems();
+            var perceivedExits = sensesBehavior.PerceiveExits();
+            var perceivedEntities = sensesBehavior.PerceiveEntities();
+            var perceivedItems = sensesBehavior.PerceiveItems();
 
             glanceString.Append($"You are in <%red%>{sender.Parent.Name}<%n%>.  ", ContextualStringUsage.OnlyWhenBeingPassedToReceiver);
 

--- a/src/Actions/Inform/Help.cs
+++ b/src/Actions/Inform/Help.cs
@@ -77,7 +77,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Inform/Look.cs
+++ b/src/Actions/Inform/Look.cs
@@ -37,7 +37,7 @@ namespace WheelMUD.Actions
             string output;
             if (!string.IsNullOrEmpty(actionInput.Tail))
             {
-                output = this.TryLookAtThing(actionInput.Tail, sender.Thing);
+                output = TryLookAtThing(actionInput.Tail, sender.Thing);
                 if (string.IsNullOrEmpty(output))
                 {
                     output = string.Format("You cannot see {0}.", actionInput.Tail);
@@ -45,7 +45,7 @@ namespace WheelMUD.Actions
             }
             else
             {
-                output = this.LookAtRoom(sender.Thing);
+                output = LookAtRoom(sender.Thing);
                 if (string.IsNullOrEmpty(output))
                 {
                     output = "You cannot see.";
@@ -60,14 +60,14 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
-            this.sensesBehavior = actionInput.Controller.Thing.Behaviors.FindFirst<SensesBehavior>();
-            if (this.sensesBehavior == null)
+            sensesBehavior = actionInput.Controller.Thing.Behaviors.FindFirst<SensesBehavior>();
+            if (sensesBehavior == null)
             {
                 return "You do not have any senses to perceive with.";
             }
@@ -83,7 +83,7 @@ namespace WheelMUD.Actions
         {
             // Look for the target in the current room.
             Thing thing = sender.Parent.FindChild(thingToLookAt);
-            if (thing != null && this.sensesBehavior.CanPerceiveThing(thing))
+            if (thing != null && sensesBehavior.CanPerceiveThing(thing))
             {
                 return Renderer.Instance.RenderPerceivedThing(sender, thing);
             }
@@ -101,7 +101,7 @@ namespace WheelMUD.Actions
 
             // Otherwise, see if it is a thing the player has.
             thing = sender.FindChild(thingToLookAt);
-            if (thing != null && this.sensesBehavior.CanPerceiveThing(thing))
+            if (thing != null && sensesBehavior.CanPerceiveThing(thing))
             {
                 return Renderer.Instance.RenderPerceivedThing(sender, thing);
             }

--- a/src/Actions/Inform/More.cs
+++ b/src/Actions/Inform/More.cs
@@ -49,7 +49,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Inform/Previous.cs
+++ b/src/Actions/Inform/Previous.cs
@@ -49,7 +49,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Inform/Repeat.cs
+++ b/src/Actions/Inform/Repeat.cs
@@ -49,7 +49,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Inform/ServerStatus.cs
+++ b/src/Actions/Inform/ServerStatus.cs
@@ -85,7 +85,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Inform/Time.cs
+++ b/src/Actions/Inform/Time.cs
@@ -41,7 +41,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Item/Activate.cs
+++ b/src/Actions/Item/Activate.cs
@@ -39,7 +39,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Item/Drink.cs
+++ b/src/Actions/Item/Drink.cs
@@ -40,8 +40,8 @@ namespace WheelMUD.Actions
         public override void Execute(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            sender.Write("You take a drink from " + this.thingToDrink.Name + ".");
-            this.drinkableBehavior.Drink(sender.Thing);
+            sender.Write("You take a drink from " + thingToDrink.Name + ".");
+            drinkableBehavior.Drink(sender.Thing);
         }
 
         /// <summary>Checks against the guards for the command.</summary>
@@ -50,7 +50,7 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -59,15 +59,15 @@ namespace WheelMUD.Actions
             // Rule: Do we have an item matching in our inventory?
             // TODO: Support drinking from, for instance, a fountain sitting in the room.
             string itemIdentifier = actionInput.Tail.Trim();
-            this.thingToDrink = sender.Thing.FindChild(itemIdentifier.ToLower());
-            if (this.thingToDrink == null)
+            thingToDrink = sender.Thing.FindChild(itemIdentifier.ToLower());
+            if (thingToDrink == null)
             {
                 return "You do not hold " + actionInput.Tail.Trim() + ".";
             }
 
             // Rule: Is the item drinkable?
-            this.drinkableBehavior = this.thingToDrink.Behaviors.FindFirst<DrinkableBehavior>();
-            if (this.drinkableBehavior == null)
+            drinkableBehavior = thingToDrink.Behaviors.FindFirst<DrinkableBehavior>();
+            if (drinkableBehavior == null)
             {
                 return itemIdentifier + " is not drinkable";
             }

--- a/src/Actions/Item/Drop.cs
+++ b/src/Actions/Item/Drop.cs
@@ -49,20 +49,20 @@ namespace WheelMUD.Actions
             // Generate an item changed owner event.
             IController sender = actionInput.Controller;
 
-            var contextMessage = new ContextualString(sender.Thing, this.thingToDrop.Parent)
+            var contextMessage = new ContextualString(sender.Thing, thingToDrop.Parent)
             {
-                ToOriginator = $"You drop up {this.thingToDrop.Name}.",
+                ToOriginator = $"You drop up {thingToDrop.Name}.",
                 ToReceiver = $"{sender.Thing.Name} drops $Thing.Name in you.",
                 ToOthers = $"{sender.Thing.Name} drops $Thing.Name.",
             };
             var dropMessage = new SensoryMessage(SensoryType.Sight, 100, contextMessage);
 
             var actor = actionInput.Controller.Thing;
-            if (this.movableBehavior.Move(this.dropLocation, actor, null, dropMessage))
+            if (movableBehavior.Move(dropLocation, actor, null, dropMessage))
             {
                 // TODO: Transactionally save actors if applicable.
                 //actor.Save();
-                //this.dropLocation.Save();
+                //dropLocation.Save();
             }
         }
 
@@ -72,7 +72,7 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -83,9 +83,9 @@ namespace WheelMUD.Actions
             // Rule: if 2 params
             if (actionInput.Params.Length == 2)
             {
-                int.TryParse(actionInput.Params[0], out this.numberToDrop);
+                int.TryParse(actionInput.Params[0], out numberToDrop);
 
-                if (this.numberToDrop == 0)
+                if (numberToDrop == 0)
                 {
                     targetName = actionInput.Tail.ToLower();
                 }
@@ -101,20 +101,20 @@ namespace WheelMUD.Actions
                 return "What did you want to drop?";
             }
 
-            this.dropLocation = sender.Thing.Parent;
+            dropLocation = sender.Thing.Parent;
 
             // Rule: Is the target an item in the entity's inventory?
-            this.thingToDrop = sender.Thing.Children.Find(t => t.Name.Equals(targetName, StringComparison.CurrentCultureIgnoreCase));
-            if (this.thingToDrop == null)
+            thingToDrop = sender.Thing.Children.Find(t => t.Name.Equals(targetName, StringComparison.CurrentCultureIgnoreCase));
+            if (thingToDrop == null)
             {
                 return "You do not hold " + targetName + ".";
             }
 
             // Rule: The target thing must be movable.
-            this.movableBehavior = this.thingToDrop.Behaviors.FindFirst<MovableBehavior>();
-            if (this.movableBehavior == null)
+            movableBehavior = thingToDrop.Behaviors.FindFirst<MovableBehavior>();
+            if (movableBehavior == null)
             {
-                return this.thingToDrop.Name + " does not appear to be movable.";
+                return thingToDrop.Name + " does not appear to be movable.";
             }
 
             return null;

--- a/src/Actions/Item/DualWield.cs
+++ b/src/Actions/Item/DualWield.cs
@@ -42,7 +42,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Item/Empty.cs
+++ b/src/Actions/Item/Empty.cs
@@ -46,20 +46,20 @@ namespace WheelMUD.Actions
         public override void Execute(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            if (this.sourceContainer == null || this.sourceContainer.Count <= 0 || this.destinationParent == null)
+            if (sourceContainer == null || sourceContainer.Count <= 0 || destinationParent == null)
             {
                 return;
             }
 
             // Dump each child out of the targeted container.
             List<string> movedThingNames = new List<string>();
-            foreach (Thing thing in this.sourceContainer.Children)
+            foreach (Thing thing in sourceContainer.Children)
             {
                 var movableBehavior = thing.Behaviors.FindFirst<MovableBehavior>();
                 if (movableBehavior != null)
                 {
                     // Try to move the item without any messaging since we'll be sending a bulk message later.
-                    if (movableBehavior.Move(this.destinationParent, sender.Thing, null, null))
+                    if (movableBehavior.Move(destinationParent, sender.Thing, null, null))
                     {
                         movedThingNames.Add(thing.Name);
                     }
@@ -67,11 +67,11 @@ namespace WheelMUD.Actions
             }
 
             string commaSeparatedList = BuildCommaSeparatedList(movedThingNames);
-            var contextMessage = new ContextualString(sender.Thing, this.destinationParent)
+            var contextMessage = new ContextualString(sender.Thing, destinationParent)
             {
-                ToOriginator = $"You move {commaSeparatedList} from {this.sourceContainer.Name} into {this.destinationParent.Name}",
-                ToReceiver = $"{sender.Thing.Name} moves {commaSeparatedList} from {this.sourceContainer.Name} into you.",
-                ToOthers = $"{sender.Thing.Name} moves {commaSeparatedList} from {this.sourceContainer.Name} into {this.destinationParent.Name}.",
+                ToOriginator = $"You move {commaSeparatedList} from {sourceContainer.Name} into {destinationParent.Name}",
+                ToReceiver = $"{sender.Thing.Name} moves {commaSeparatedList} from {sourceContainer.Name} into you.",
+                ToOthers = $"{sender.Thing.Name} moves {commaSeparatedList} from {sourceContainer.Name} into {destinationParent.Name}.",
             };
             var message = new SensoryMessage(SensoryType.Sight, 100, contextMessage);
 
@@ -85,7 +85,7 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -124,10 +124,10 @@ namespace WheelMUD.Actions
             }
 
             // Rule: The targeted container must not be empty already.
-            this.sourceContainer = thing;
-            if (this.sourceContainer.Children.Count == 0)
+            sourceContainer = thing;
+            if (sourceContainer.Children.Count == 0)
             {
-                return string.Format("The {0} is already empty.", this.sourceContainer.Name);
+                return string.Format("The {0} is already empty.", sourceContainer.Name);
             }
 
             // TODO: Test; Not possible? If so, default to the current container's parent instead of failing?
@@ -137,7 +137,7 @@ namespace WheelMUD.Actions
                 destinationParentName.Equals("out", StringComparison.CurrentCultureIgnoreCase))
             {
                 // TODO: Test, this may be broken...
-                this.destinationParent = sender.Thing.Parent;
+                destinationParent = sender.Thing.Parent;
             }
             else
             {
@@ -154,7 +154,7 @@ namespace WheelMUD.Actions
                     return string.Format("{0} is not a container.", destinationParentName);
                 }
 
-                this.destinationParent = thing.Parent;
+                destinationParent = thing.Parent;
             }
 
             return null;

--- a/src/Actions/Item/Equip.cs
+++ b/src/Actions/Item/Equip.cs
@@ -40,7 +40,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Item/Fill.cs
+++ b/src/Actions/Item/Fill.cs
@@ -55,11 +55,11 @@ namespace WheelMUD.Actions
         /// <param name="actionInput">The full input specified for executing the command.</param>
         public override void Execute(ActionInput actionInput)
         {
-            if (this.sourceContainer != null && this.destinationContainer != null)
+            if (sourceContainer != null && destinationContainer != null)
             {
                 IController sender = actionInput.Controller;
-                var sourceHoldsLiquidBehavior = this.sourceContainer.Behaviors.FindFirst<HoldsLiquidBehavior>();
-                var destinationHoldsLiquidBehavior = this.destinationContainer.Behaviors.FindFirst<HoldsLiquidBehavior>();
+                var sourceHoldsLiquidBehavior = sourceContainer.Behaviors.FindFirst<HoldsLiquidBehavior>();
+                var destinationHoldsLiquidBehavior = destinationContainer.Behaviors.FindFirst<HoldsLiquidBehavior>();
                 if (sourceHoldsLiquidBehavior == null)
                 {
                     sender.Write("The source does not hold any liquid.");
@@ -82,14 +82,14 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
             int itemParam = 0;
-            this.parent = sender.Thing.Parent;
+            parent = sender.Thing.Parent;
 
             if (actionInput.Tail.ToLower().Contains("from"))
             {
@@ -106,85 +106,85 @@ namespace WheelMUD.Actions
                 // Destination container
                 for (int j = itemParam; j < itemMarker; j++)
                 {
-                    this.destinationContainerName += actionInput.Params[j] + ' ';
+                    destinationContainerName += actionInput.Params[j] + ' ';
                 }
 
-                this.destinationContainerName = this.destinationContainerName.Trim();
+                destinationContainerName = destinationContainerName.Trim();
 
                 // Source Container name is everything from the marker to the end.
-                this.sourceContainerName = string.Empty;
+                sourceContainerName = string.Empty;
                 for (int i = itemMarker + 1; i < actionInput.Params.Length; i++)
                 {
-                    this.sourceContainerName += actionInput.Params[i] + ' ';
+                    sourceContainerName += actionInput.Params[i] + ' ';
                 }
 
-                this.sourceContainerName = this.sourceContainerName.Trim();
+                sourceContainerName = sourceContainerName.Trim();
 
                 // Rule: Do we have an item matching the one specified in our inventory?
                 // If not then does the room have a container with the name.
                 // TODO: Fix: This Find pattern is probably broken...
-                this.destinationContainer = sender.Thing.Children.Find(t => t.Name == this.destinationContainerName.ToLower());
-                if (this.destinationContainer == null)
+                destinationContainer = sender.Thing.Children.Find(t => t.Name == destinationContainerName.ToLower());
+                if (destinationContainer == null)
                 {
-                    this.destinationContainer = this.parent.Children.Find(t => t.Name == this.destinationContainerName.ToLower());
-                    if (this.destinationContainer == null)
+                    destinationContainer = parent.Children.Find(t => t.Name == destinationContainerName.ToLower());
+                    if (destinationContainer == null)
                     {
-                        return "You cannot see " + this.destinationContainerName;
+                        return "You cannot see " + destinationContainerName;
                     }
                 }
 
                 // Rule: Is the item specified as a container actually a container?
-                this.containerBehavior = this.destinationContainer.Behaviors.FindFirst<ContainerBehavior>();
+                this.containerBehavior = destinationContainer.Behaviors.FindFirst<ContainerBehavior>();
                 if (this.containerBehavior == null)
                 {
-                    return this.destinationContainerName + " is not able to hold things.";
+                    return destinationContainerName + " is not able to hold things.";
                 }
                 else
                 {
-                    var holdsLiquidBehavior = this.destinationContainer.Behaviors.FindFirst<HoldsLiquidBehavior>();
+                    var holdsLiquidBehavior = destinationContainer.Behaviors.FindFirst<HoldsLiquidBehavior>();
                     if (holdsLiquidBehavior == null)
                     {
                         return string.Format(
                             "It does not appear that the {0} will hold liquid.",
-                            this.destinationContainerName);
+                            destinationContainerName);
                     }
                 }
 
                 // Rule: Is the item open?
-                var openableBehavior = this.destinationContainer.Behaviors.FindFirst<OpensClosesBehavior>();
+                var openableBehavior = destinationContainer.Behaviors.FindFirst<OpensClosesBehavior>();
                 if (openableBehavior != null && !openableBehavior.IsOpen)
                 {
-                    return string.Format("You cannot fill the {0} as it is closed.", this.destinationContainerName);
+                    return string.Format("You cannot fill the {0} as it is closed.", destinationContainerName);
                 }
 
                 // Rule: Do we have an item matching the one specified in our inventory?
                 // If not then does the room have a container with the name.
                 // TODO: Investigate; This search method is probably broken.
-                this.sourceContainer = sender.Thing.Children.Find(t => t.Name == this.sourceContainerName.ToLower());
-                if (this.sourceContainer == null)
+                sourceContainer = sender.Thing.Children.Find(t => t.Name == sourceContainerName.ToLower());
+                if (sourceContainer == null)
                 {
-                    this.sourceContainer = this.parent.Children.Find(t => t.Name == this.sourceContainerName.ToLower());
+                    sourceContainer = parent.Children.Find(t => t.Name == sourceContainerName.ToLower());
 
-                    if (this.sourceContainer == null)
+                    if (sourceContainer == null)
                     {
-                        return "You cannot see " + this.sourceContainerName;
+                        return "You cannot see " + sourceContainerName;
                     }
                 }
 
                 // Rule: Is the item specified as a container actually a container?
-                ContainerBehavior containerBehavior = this.sourceContainer.Behaviors.FindFirst<ContainerBehavior>();
+                ContainerBehavior containerBehavior = sourceContainer.Behaviors.FindFirst<ContainerBehavior>();
                 if (containerBehavior == null)
                 {
-                    return string.Format("The {0} does not hold anything to fill the {1} with.", this.sourceContainerName, this.destinationContainerName);
+                    return string.Format("The {0} does not hold anything to fill the {1} with.", sourceContainerName, destinationContainerName);
                 }
 
                 // TODO: HoldsLiquidBehavior?
 
                 // Rule: Is the item open?
-                OpensClosesBehavior opensClosesBehavior = this.sourceContainer.Behaviors.FindFirst<OpensClosesBehavior>();
+                OpensClosesBehavior opensClosesBehavior = sourceContainer.Behaviors.FindFirst<OpensClosesBehavior>();
                 if (!opensClosesBehavior.IsOpen)
                 {
-                    return string.Format("You cannot fill from the {0} as it is closed.", this.sourceContainerName);
+                    return string.Format("You cannot fill from the {0} as it is closed.", sourceContainerName);
                 }
             }
             else

--- a/src/Actions/Item/Get.cs
+++ b/src/Actions/Item/Get.cs
@@ -48,22 +48,22 @@ namespace WheelMUD.Actions
             // We have to do this before we attempt to add it because of the event subscriptions.
             // TODO: Test, this may be broken now...
             var actor = actionInput.Controller.Thing;
-            if (this.numberToGet <= 0)
+            if (numberToGet <= 0)
             {
-                this.numberToGet = 1;
+                numberToGet = 1;
             }
 
             // TODO: Prevent item duplication from specifying large numbers, or races for same item, etc.
             // TODO: Fix Implementation of numberToGet.
-            var contextMessage = new ContextualString(actor, this.thingToGet.Parent)
+            var contextMessage = new ContextualString(actor, thingToGet.Parent)
             {
-                ToOriginator = $"You pick up {this.thingToGet}.",
-                ToReceiver = $"{actor.Name} takes {this.thingToGet} from you.",
-                ToOthers = $"{actor.Name} picks up {this.thingToGet.Name}.",
+                ToOriginator = $"You pick up {thingToGet}.",
+                ToReceiver = $"{actor.Name} takes {thingToGet} from you.",
+                ToOthers = $"{actor.Name} picks up {thingToGet.Name}.",
             };
             var getMessage = new SensoryMessage(SensoryType.Sight, 100, contextMessage);
 
-            if (this.movableBehavior.Move(actor, actor, getMessage, null))
+            if (movableBehavior.Move(actor, actor, getMessage, null))
             {
                 // TODO: Transactionally move owners if applicable.
                 //actor.Save();
@@ -77,7 +77,7 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -86,13 +86,13 @@ namespace WheelMUD.Actions
             // Check to see if the first word is a number.
             // TODO: Is TryParse meant to be used this way? Character analysis may be better. I worry that
             //       this might be throwing a caught exception upon each fail, which is a typical case here.
-            int.TryParse(actionInput.Params[0], out this.numberToGet);
+            int.TryParse(actionInput.Params[0], out numberToGet);
 
             int itemParam = 0;
             string itemName = string.Empty;
 
             // Rule: If we have to get a number of something, shunt up the positions of our other params.
-            if (this.numberToGet > 0)
+            if (numberToGet > 0)
             {
                 itemParam = 1;
             }
@@ -167,17 +167,17 @@ namespace WheelMUD.Actions
             }
 
             // Rule: Do we have an item matching in the container?
-            this.thingToGet = targetParent.FindChild(itemName.ToLower());
-            if (this.thingToGet == null)
+            thingToGet = targetParent.FindChild(itemName.ToLower());
+            if (thingToGet == null)
             {
                 return string.Format("{0} does not contain {1}.", targetParent.Name, itemName);
             }
 
             // Rule: The targeted thing must be movable.
-            this.movableBehavior = this.thingToGet.Behaviors.FindFirst<MovableBehavior>();
-            if (this.movableBehavior == null)
+            movableBehavior = thingToGet.Behaviors.FindFirst<MovableBehavior>();
+            if (movableBehavior == null)
             {
-                return this.thingToGet.Name + " does not appear to be movable.";
+                return thingToGet.Name + " does not appear to be movable.";
             }
 
             return null;

--- a/src/Actions/Item/Give.cs
+++ b/src/Actions/Item/Give.cs
@@ -54,23 +54,23 @@ namespace WheelMUD.Actions
             // Remove the item from the character's posession.
             // TODO: Test, this may be broken now... esp for numberToGive != max
             IController sender = actionInput.Controller;
-            if (this.numberToGive > 0 && this.thing != null)
+            if (numberToGive > 0 && thing != null)
             {
-                this.thing.RemoveFromParents();
+                thing.RemoveFromParents();
             }
 
-            var contextMessage = new ContextualString(sender.Thing, this.target)
+            var contextMessage = new ContextualString(sender.Thing, target)
             {
-                ToOriginator = $"You gave {this.thing.Name} to {this.target}.",
-                ToReceiver = $"{sender.Thing.Name} gave you {this.thing.Name}.",
-                ToOthers = $"{sender.Thing.Name} gave {this.thing.Name} to {this.target.Name}.",
+                ToOriginator = $"You gave {thing.Name} to {target}.",
+                ToReceiver = $"{sender.Thing.Name} gave you {thing.Name}.",
+                ToOthers = $"{sender.Thing.Name} gave {thing.Name} to {target.Name}.",
             };
             var message = new SensoryMessage(SensoryType.Sight, 100, contextMessage);
 
             // Try to move the thing from the sender to the target; this handles eventing and whatnot for us.
-            if (!this.movableBehavior.Move(this.target, sender.Thing, null, message))
+            if (!movableBehavior.Move(target, sender.Thing, null, message))
             {
-                sender.Write($"Failed to give {this.thing.Name} to {this.target.Name}.");
+                sender.Write($"Failed to give {thing.Name} to {target.Name}.");
             }
         }
 
@@ -80,7 +80,7 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -90,12 +90,12 @@ namespace WheelMUD.Actions
             // If so, shunt up the positions of our other params.
             int itemParam = 0;
             int numberWords = actionInput.Params.Length;
-            if (int.TryParse(actionInput.Params[0], out this.numberToGive))
+            if (int.TryParse(actionInput.Params[0], out numberToGive))
             {
                 itemParam = 1;
 
                 // If the user specified a number, but it is less than 1, error!
-                if (this.numberToGive < 1)
+                if (numberToGive < 1)
                 {
                     return "You can't give less than 1 of something.";
                 }
@@ -112,8 +112,8 @@ namespace WheelMUD.Actions
             string itemName = actionInput.Params[itemParam];
 
             // Do we have an item matching the name in our inventory?
-            this.thing = sender.Thing.FindChild(itemName.ToLower());
-            if (this.thing == null)
+            thing = sender.Thing.FindChild(itemName.ToLower());
+            if (thing == null)
             {
                 return "You do not hold " + itemName + ".";
             }
@@ -128,7 +128,7 @@ namespace WheelMUD.Actions
             }
 
             // TODO: Shared targeting code should be used, and this rule should be implemented like:
-            //       if (this.target == sender.Thing) ...
+            //       if (target == sender.Thing) ...
             // Rule: The giver cannot also be the receiver.
             if (targetName == "me")
             {
@@ -136,20 +136,20 @@ namespace WheelMUD.Actions
             }
 
             // Rule: Is the target an entity?
-            this.target = GetPlayerOrMobile(targetName);
-            if (this.target == null)
+            target = GetPlayerOrMobile(targetName);
+            if (target == null)
             {
                 return "You cannot see " + targetName + ".";
             }
 
             // Rule: Is the target in the same room?
-            if (sender.Thing.Parent.Id != this.target.Parent.Id)
+            if (sender.Thing.Parent.Id != target.Parent.Id)
             {
                 return "You cannot see " + targetName + ".";
             }
 
             // Rule: The thing being given must be movable.
-            this.movableBehavior = this.thing.Behaviors.FindFirst<MovableBehavior>();
+            movableBehavior = thing.Behaviors.FindFirst<MovableBehavior>();
 
             return null;
         }

--- a/src/Actions/Item/Hold.cs
+++ b/src/Actions/Item/Hold.cs
@@ -40,7 +40,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Item/Install.cs
+++ b/src/Actions/Item/Install.cs
@@ -40,7 +40,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Item/Inventory.cs
+++ b/src/Actions/Item/Inventory.cs
@@ -41,7 +41,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Item/Put.cs
+++ b/src/Actions/Item/Put.cs
@@ -45,10 +45,10 @@ namespace WheelMUD.Actions
         {
             // TODO: Move item from one owner to another transactionally, if applicable.
             // TODO: Test, may be broken now... especially for only putting SOME of a stack...
-            this.thing.Parent.Remove(this.thing);
-            this.newParent.Add(this.thing);
+            thing.Parent.Remove(thing);
+            newParent.Add(thing);
 
-            string message = string.Format("You put {0} in {1}", this.thing.FullName, this.newParent.Name);
+            string message = string.Format("You put {0} in {1}", thing.FullName, newParent.Name);
             actionInput.Controller.Write(message);
         }
 
@@ -58,7 +58,7 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -71,12 +71,12 @@ namespace WheelMUD.Actions
             }
 
             // Rule: Is the first parameter numeric?
-            int.TryParse(actionInput.Params[0], out this.numberToPut);
+            int.TryParse(actionInput.Params[0], out numberToPut);
             int itemParam = 0;
             string itemName = string.Empty;
 
             // Rule: If we have an amount then we shift our itemParam along one.
-            if (this.numberToPut > 0)
+            if (numberToPut > 0)
             {
                 itemParam = 1;
             }
@@ -124,9 +124,9 @@ namespace WheelMUD.Actions
             }
 
             // Rule: Is the found thing capable of containing other things?
-            this.newParent = foundItem;
+            newParent = foundItem;
             var containerBehavior = foundItem.Behaviors.FindFirst<ContainerBehavior>();
-            if (this.newParent == null || containerBehavior == null)
+            if (newParent == null || containerBehavior == null)
             {
                 return containerName + " is not able to hold " + itemName + ".";
             }
@@ -141,8 +141,8 @@ namespace WheelMUD.Actions
             // TODO: Rule: If this item has a CapacityBehavior (or maybe just ContainerBehavior), does it have room left?
 
             // Rule: Do we have a matching item in our inventory?
-            this.thing = sender.Thing.Children.Find(i => i.Name == itemName.ToLower());
-            if (this.thing == null)
+            thing = sender.Thing.Children.Find(i => i.Name == itemName.ToLower());
+            if (thing == null)
             {
                 return "You do not hold " + itemName + ".";
             }

--- a/src/Actions/Item/Remove.cs
+++ b/src/Actions/Item/Remove.cs
@@ -42,7 +42,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Item/Uninstall.cs
+++ b/src/Actions/Item/Uninstall.cs
@@ -40,7 +40,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Item/Wear.cs
+++ b/src/Actions/Item/Wear.cs
@@ -41,7 +41,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Player/Finger.cs
+++ b/src/Actions/Player/Finger.cs
@@ -45,7 +45,7 @@ namespace WheelMUD.Actions
             bool isOnline = false;
             string addressIP = null;
 
-            PlayerBehavior playerBehavior = this.target.Behaviors.FindFirst<PlayerBehavior>();
+            PlayerBehavior playerBehavior = target.Behaviors.FindFirst<PlayerBehavior>();
             if (playerBehavior != null)
             {
                 // TODO: Mine this data in a less invasive/dangerous way; maybe the PlayerBehavior
@@ -58,11 +58,11 @@ namespace WheelMUD.Actions
                 ////    addressIP = connection.CurrentIPAddress;
                 ////}
 
-                sb.AppendLine("<%yellow%><%b%>Name: " + this.target.Name + " Title: " + this.target.Title + "<%n%>");
-                sb.AppendLine("Description: " + this.target.Description);
-                sb.AppendLine("Full Name: " + this.target.FullName);
-                sb.AppendLine("ID: " + this.target.Id);
-                sb.AppendLine("Type: " + this.target.GetType().Name); // identify npc ?
+                sb.AppendLine("<%yellow%><%b%>Name: " + target.Name + " Title: " + target.Title + "<%n%>");
+                sb.AppendLine("Description: " + target.Description);
+                sb.AppendLine("Full Name: " + target.FullName);
+                sb.AppendLine("ID: " + target.Id);
+                sb.AppendLine("Type: " + target.GetType().Name); // identify npc ?
                 sb.AppendLine("Race: TBA      Guild: TBA     Class: TBA");
                 sb.AppendLine("Religion: TBA");
                 sb.AppendLine("Gender: TBA");
@@ -75,7 +75,7 @@ namespace WheelMUD.Actions
                 if (isOnline)
                 {
                     sb.AppendLine("Status: <%green%>Online<%n%>"); // need way to report both offline and online
-                    sb.AppendLine("Location: " + this.target.Parent.Name);
+                    sb.AppendLine("Location: " + target.Parent.Name);
                     sb.AppendLine(string.Format("Last Login: {0}", playerBehavior.PlayerData.LastLogin));
                     sb.AppendLine(string.Format("Current IP Address: {0}", addressIP));
                 }
@@ -90,11 +90,11 @@ namespace WheelMUD.Actions
             }
             else
             {
-                sb.AppendLine("<%yellow%><%b%>Name: " + this.target.Name + " Title: " + this.target.Title + "<%n%>");
-                sb.AppendLine("Description: " + this.target.Description);
-                sb.AppendLine("Full Name: " + this.target.FullName);
-                sb.AppendLine("ID: " + this.target.Id);
-                sb.AppendLine("Type: " + this.target.GetType().Name); // identify npc ?
+                sb.AppendLine("<%yellow%><%b%>Name: " + target.Name + " Title: " + target.Title + "<%n%>");
+                sb.AppendLine("Description: " + target.Description);
+                sb.AppendLine("Full Name: " + target.FullName);
+                sb.AppendLine("ID: " + target.Id);
+                sb.AppendLine("Type: " + target.GetType().Name); // identify npc ?
                 sb.AppendLine("Race: TBA      Guild: TBA     Class: TBA");
                 sb.AppendLine("Religion: TBA");
                 sb.AppendLine("Gender: TBA");
@@ -113,7 +113,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -125,8 +125,8 @@ namespace WheelMUD.Actions
             string targetName = textInfo.ToTitleCase(actionInput.Tail.Trim().ToLower());
 
             // Rule: Is the target an entity?
-            this.target = GetPlayerOrMobile(targetName);
-            if (this.target == null)
+            target = GetPlayerOrMobile(targetName);
+            if (target == null)
             {
                 // Now we need to look for the user in the database.
                 // TODO: What if the player is offline? Player.Load probably adds them to the world, etc...
@@ -137,8 +137,8 @@ namespace WheelMUD.Actions
                 //     some sort of ghosting system for info-gathering, should be generic for all things?
                 //     Maybe the players all have a 'template' that can be loaded independently and gets
                 //     saved with the player instance saving.
-                //this.target = PlayerBehavior.Load(targetName);
-                if (this.target == null)
+                //target = PlayerBehavior.Load(targetName);
+                if (target == null)
                 {
                     return targetName + " has never visited " + GameConfiguration.Name + ".";
                 }

--- a/src/Actions/Player/Friends.cs
+++ b/src/Actions/Player/Friends.cs
@@ -40,7 +40,7 @@ namespace WheelMUD.Actions
             IController sender = actionInput.Controller;
             if ((actionInput.Params.Count() == 1 && actionInput.Params[0].ToLower() == "list") || actionInput.Params.Count() == 0)
             {
-                if (this.playerBehavior.Friends.Count == 0)
+                if (playerBehavior.Friends.Count == 0)
                 {
                     sender.Write("You currently have no friends listed.");
                 }
@@ -48,7 +48,7 @@ namespace WheelMUD.Actions
                 {
                     StringBuilder sb = new StringBuilder();
                     sb.AppendLine("Your Friends:");
-                    foreach (string friendName in this.playerBehavior.Friends)
+                    foreach (string friendName in playerBehavior.Friends)
                     {
                         string status = PlayerManager.Instance.FindLoadedPlayerByName(friendName, false) == null ? "Offline" : "Online";
                         sb.AppendLine(string.Format("{0} [{1}]", friendName, status));
@@ -73,11 +73,11 @@ namespace WheelMUD.Actions
 
             if (actionInput.Params[0].ToLower() == "add")
             {
-                this.AddFriend(sender, targetFriend);
+                AddFriend(sender, targetFriend);
             }
             else if (actionInput.Params[0].ToLower() == "remove")
             {
-                this.RemoveFriend(sender, targetedFriendName);
+                RemoveFriend(sender, targetedFriendName);
             }
         }
 
@@ -86,15 +86,15 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
             // The comon guards already guarantees the sender is a player, hence no null checks here.
-            this.player = actionInput.Controller.Thing;
-            this.playerBehavior = this.player.Behaviors.FindFirst<PlayerBehavior>();
+            player = actionInput.Controller.Thing;
+            playerBehavior = player.Behaviors.FindFirst<PlayerBehavior>();
 
             return null;
         }
@@ -107,25 +107,25 @@ namespace WheelMUD.Actions
                 return;
             }
 
-            if (targetFriend == this.player)
+            if (targetFriend == player)
             {
                 sender.Write("You cannot add yourself as a friend.");
                 return;
             }
 
-            if (this.playerBehavior.Friends.Contains(targetFriend.Name))
+            if (playerBehavior.Friends.Contains(targetFriend.Name))
             {
-                sender.Write(string.Format("{0} is already on your friends list.", this.player.Name));
+                sender.Write(string.Format("{0} is already on your friends list.", player.Name));
                 return;
             }
 
-            this.playerBehavior.AddFriend(this.player.Name);
+            playerBehavior.AddFriend(player.Name);
             sender.Write(string.Format("You have added {0} to your friends list.", targetFriend.Name));
         }
 
         private void RemoveFriend(IController sender, string targetedFriendName)
         {
-            string playerName = (from string f in this.playerBehavior.Friends
+            string playerName = (from string f in playerBehavior.Friends
                                  where f.Equals(targetedFriendName, System.StringComparison.CurrentCultureIgnoreCase)
                                  select f).FirstOrDefault();
 
@@ -135,9 +135,9 @@ namespace WheelMUD.Actions
                 return;
             }
 
-            this.playerBehavior.RemoveFriend(playerName);
+            playerBehavior.RemoveFriend(playerName);
 
-            sender.Write(string.Format("{0} has been removed from your friends list.", this.player.Name));
+            sender.Write(string.Format("{0} has been removed from your friends list.", player.Name));
         }
     }
 }

--- a/src/Actions/Player/Score.cs
+++ b/src/Actions/Player/Score.cs
@@ -44,7 +44,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Player/Who.cs
+++ b/src/Actions/Player/Who.cs
@@ -36,7 +36,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Temporary/Blind.cs
+++ b/src/Actions/Temporary/Blind.cs
@@ -45,7 +45,7 @@ namespace WheelMUD.Actions.Temporary
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Temporary/Chop.cs
+++ b/src/Actions/Temporary/Chop.cs
@@ -53,13 +53,13 @@ namespace WheelMUD.Actions
                 var userControlledBehavior = sender.Thing.BehaviorManager.FindFirst<UserControlledBehavior>();
                 userControlledBehavior.Controller.Write("You check your axe and begin to swing at the tree.");
 
-                ActionInput delayedAction = new ActionInput("chop " + this.tree.Id, sender) { Context = 1 };
+                ActionInput delayedAction = new ActionInput("chop " + tree.Id, sender) { Context = 1 };
                 bridge.CommandManager.Enqueue(delayedAction, new TimeSpan(0, 0, 2));
             }
             else if ((int)command.ActionInput.Context == 1)
             {
                 // TODO: Use consumable provider behavior to do the chopping.
-                //Item wood = this.tree.Chop();
+                //Item wood = tree.Chop();
                 //sender.Thing.Parent.Children.Add(wood);
                 //sender.Thing.Controller.Write("You chop some wood from the tree.");
             }
@@ -71,7 +71,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -92,9 +92,9 @@ namespace WheelMUD.Actions
             //    return string.Format("{0} is not a tree.", actionInput.Params[0]);
             //}
 
-            //this.tree = (Item) item;
+            //tree = (Item) item;
 
-            //if (this.tree.NumberOfResources <= 0)
+            //if (tree.NumberOfResources <= 0)
             //{
             //    return string.Format("The tree doesn't contain any suitable wood.");
             //}

--- a/src/Actions/Temporary/CreateConsumable.cs
+++ b/src/Actions/Temporary/CreateConsumable.cs
@@ -103,7 +103,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Temporary/CreateCurrency.cs
+++ b/src/Actions/Temporary/CreateCurrency.cs
@@ -55,7 +55,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Temporary/CreatePortal.cs
+++ b/src/Actions/Temporary/CreatePortal.cs
@@ -43,7 +43,7 @@ namespace WheelMUD.Actions
             Thing portalItem = new Thing();
             portalItem.Behaviors.Add(new PortalBehavior()
             {
-                DestinationThingID = this.targetPlace.Id,
+                DestinationThingID = targetPlace.Id,
             });
 
             // TODO: Should not be needed after OLC and instant-spawn commands which should work
@@ -59,7 +59,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -77,15 +77,15 @@ namespace WheelMUD.Actions
             if (string.IsNullOrEmpty(roomToGet))
             {
                 // Its not a number so it could be an entity... try it.
-                this.targetPlace = GetPlayerOrMobile(actionInput.Params[0]);
-                if (this.targetPlace == null)
+                targetPlace = GetPlayerOrMobile(actionInput.Params[0]);
+                if (targetPlace == null)
                 {
                     return "Could not convert " + actionInput.Params[0] + " to a room number.";
                 }
             }
 
-            this.targetPlace = PlacesManager.Instance.WorldBehavior.FindRoom(roomToGet);
-            if (this.targetPlace == null)
+            targetPlace = PlacesManager.Instance.WorldBehavior.FindRoom(roomToGet);
+            if (targetPlace == null)
             {
                 return string.Format("Could not find the room {0}.", roomToGet);
             }

--- a/src/Actions/Temporary/CreatePotion.cs
+++ b/src/Actions/Temporary/CreatePotion.cs
@@ -61,7 +61,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Temporary/Jump.cs
+++ b/src/Actions/Temporary/Jump.cs
@@ -45,7 +45,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/Actions/Temporary/Punch.cs
+++ b/src/Actions/Temporary/Punch.cs
@@ -64,20 +64,20 @@ namespace WheelMUD.Actions
             int defenseRoll = defenseDie.Roll();
 
             // Determine amount of damage, if any. Cannot exceed the target's current health.
-            int targetHealth = this.target.Stats["HP"].Value;
+            int targetHealth = target.Stats["HP"].Value;
             int damage = Math.Max(attackRoll - defenseRoll, 0);
             damage = Math.Min(damage, targetHealth);
 
             // Choose sensory messaging based on whether or not the hit landed.
-            SensoryMessage message = this.CreateResultMessage(sender.Thing, this.target, attackRoll, defenseRoll, damage);
+            SensoryMessage message = CreateResultMessage(sender.Thing, target, attackRoll, defenseRoll, damage);
 
-            var attackEvent = new AttackEvent(this.target, message, sender.Thing);
+            var attackEvent = new AttackEvent(target, message, sender.Thing);
 
             // Broadcast combat requests/events to the room they're happening in.
             sender.Thing.Eventing.OnCombatRequest(attackEvent, EventScope.ParentsDown);
             if (!attackEvent.IsCancelled)
             {
-                this.target.Stats["HP"].Decrease(damage, sender.Thing);
+                target.Stats["HP"].Decrease(damage, sender.Thing);
                 sender.Thing.Eventing.OnCombatEvent(attackEvent, EventScope.ParentsDown);
             }
         }
@@ -88,7 +88,7 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -96,30 +96,30 @@ namespace WheelMUD.Actions
 
             // Find the most appropriate matching target.
             string targetName = actionInput.Tail.Trim().ToLower();
-            this.target = GetPlayerOrMobile(targetName);
+            target = GetPlayerOrMobile(targetName);
 
             // Rule: Is the target an entity?
-            if (this.target == null)
+            if (target == null)
             {
                 return "You cannot see " + targetName + ".";
             }
 
             // Rule: Is the target the initator?
-            if (sender.Thing.Name.ToLower() == this.target.Name.ToLower())
+            if (sender.Thing.Name.ToLower() == target.Name.ToLower())
             {
                 return "You can't punch yourself.";
             }
 
             // Rule: Is the target in the same room?
-            if (sender.Thing.Parent.Id != this.target.Parent.Id)
+            if (sender.Thing.Parent.Id != target.Parent.Id)
             {
                 return "You cannot see " + targetName + ".";
             }
 
             // Rule: Is the target alive?
-            if (this.target.Stats["HP"].Value <= 0)
+            if (target.Stats["HP"].Value <= 0)
             {
-                return this.target.Name + " is dead.";
+                return target.Name + " is dead.";
             }
 
             var unbalanceEffect = sender.Thing.Behaviors.FindFirst<UnbalanceEffect>();

--- a/src/Actions/Temporary/Struggle.cs
+++ b/src/Actions/Temporary/Struggle.cs
@@ -43,7 +43,7 @@ namespace WheelMUD.Actions
             var userControlledBehavior = sender.Thing.Behaviors.FindFirst<UserControlledBehavior>();
             if (die.Roll() > 5)
             {
-                sender.Thing.Behaviors.Remove(this.immobileEffect);
+                sender.Thing.Behaviors.Remove(immobileEffect);
                 userControlledBehavior.Controller.Write("You manager to struggle free");
             }
             else
@@ -62,15 +62,15 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
             // Rule: The initiator must be currently immobilized.
-            this.immobileEffect = actionInput.Controller.Thing.Behaviors.FindFirst<ImmobileEffect>();
-            if (this.immobileEffect == null)
+            immobileEffect = actionInput.Controller.Thing.Behaviors.FindFirst<ImmobileEffect>();
+            if (immobileEffect == null)
             {
                 return "You are not immobile, so what is the point of struggling?";
             }

--- a/src/Actions/Temporary/ThunderClap.cs
+++ b/src/Actions/Temporary/ThunderClap.cs
@@ -39,15 +39,15 @@ namespace WheelMUD.Actions
         public override void Execute(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            var contextMessage = new ContextualString(sender.Thing, this.target)
+            var contextMessage = new ContextualString(sender.Thing, target)
             {
-                ToOriginator = $"You cast ThunderClap at {this.target.Name}!",
+                ToOriginator = $"You cast ThunderClap at {target.Name}!",
                 ToReceiver = $"{sender.Thing.Name} casts ThunderClap at you. You only hear a ringing in your ears now.",
-                ToOthers = $"You hear {sender.Thing.Name} cast ThunderClap at {this.target.Name}! It was very loud.",
+                ToOthers = $"You hear {sender.Thing.Name} cast ThunderClap at {target.Name}! It was very loud.",
             };
             var sm = new SensoryMessage(SensoryType.Hearing, 100, contextMessage);
 
-            var attackEvent = new AttackEvent(this.target, sm, sender.Thing);
+            var attackEvent = new AttackEvent(target, sm, sender.Thing);
             sender.Thing.Eventing.OnCombatRequest(attackEvent, EventScope.ParentsDown);
             if (!attackEvent.IsCancelled)
             {
@@ -58,7 +58,7 @@ namespace WheelMUD.Actions
                     Duration = new TimeSpan(0, 0, 45),
                 };
 
-                this.target.Behaviors.Add(deafenEffect);
+                target.Behaviors.Add(deafenEffect);
                 sender.Thing.Eventing.OnCombatEvent(attackEvent, EventScope.ParentsDown);
             }
         }
@@ -68,7 +68,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -77,22 +77,22 @@ namespace WheelMUD.Actions
             string targetName = actionInput.Tail.Trim().ToLower();
 
             // Rule: Is the target an entity?
-            this.target = GetPlayerOrMobile(targetName);
-            if (this.target == null)
+            target = GetPlayerOrMobile(targetName);
+            if (target == null)
             {
                 return "You cannot see " + targetName + ".";
             }
 
             // Rule: Is the target in the same room?
-            if (actionInput.Controller.Thing.Parent.Id != this.target.Parent.Id)
+            if (actionInput.Controller.Thing.Parent.Id != target.Parent.Id)
             {
                 return "You cannot see " + targetName + ".";
             }
 
             // Rule: Is the target alive?
-            if (this.target.Stats["health"].Value <= 0)
+            if (target.Stats["health"].Value <= 0)
             {
-                return this.target.Name + " is dead.";
+                return target.Name + " is dead.";
             }
 
             return null;

--- a/src/Actions/Temporary/Web.cs
+++ b/src/Actions/Temporary/Web.cs
@@ -41,8 +41,8 @@ namespace WheelMUD.Actions
 
             // TODO: Should use Request and Event pattern and avoid direct Controller.Writes.
             //var userControlledBehavior = sender.Thing.BehaviorManager.FindFirst<UserControlledBehavior>();
-            //userControlledBehavior.Controller.Write("You cast a web over " + this.target.Name);
-            //this.target.Controller.Write(sender.Thing.Name + " casts a web over you");
+            //userControlledBehavior.Controller.Write("You cast a web over " + target.Name);
+            //target.Controller.Write(sender.Thing.Name + " casts a web over you");
         }
 
         /// <summary>Prepare for, and determine if the command's prerequisites have been met.</summary>
@@ -51,7 +51,7 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -60,28 +60,28 @@ namespace WheelMUD.Actions
             string targetName = actionInput.Tail.Trim().ToLower();
 
             // Rule: Do we have a target?
-            this.target = GetPlayerOrMobile(targetName);
-            if (this.target == null)
+            target = GetPlayerOrMobile(targetName);
+            if (target == null)
             {
                 return "You cannot see " + targetName + ".";
             }
 
             // Rule: Is the target the initator?
-            if (sender.Thing.Name.ToLower() == this.target.Name.ToLower())
+            if (sender.Thing.Name.ToLower() == target.Name.ToLower())
             {
                 return "You can't punch yourself.";
             }
 
             // Rule: Is the target in the same room?
-            if (sender.Thing.Parent.Id != this.target.Parent.Id)
+            if (sender.Thing.Parent.Id != target.Parent.Id)
             {
                 return "You cannot see " + targetName + ".";
             }
 
             // Rule: Is the target alive?
-            if (this.target.Stats["health"].Value <= 0)
+            if (target.Stats["health"].Value <= 0)
             {
-                return this.target.Name + " is dead.";
+                return target.Name + " is dead.";
             }
 
             return null;

--- a/src/Actions/Travel/Enter.cs
+++ b/src/Actions/Travel/Enter.cs
@@ -42,7 +42,7 @@ namespace WheelMUD.Actions
         public override void Execute(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            this.enterableBehavior.Enter(sender.Thing);
+            enterableBehavior.Enter(sender.Thing);
         }
 
         /// <summary>Checks against the guards for the command.</summary>
@@ -51,7 +51,7 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -72,8 +72,8 @@ namespace WheelMUD.Actions
             else if (enterableThings.Count == 1)
             {
                 Thing thing = enterableThings.First();
-                this.enterableBehavior = thing.Behaviors.FindFirst<EnterableExitableBehavior>();
-                if (this.enterableBehavior == null)
+                enterableBehavior = thing.Behaviors.FindFirst<EnterableExitableBehavior>();
+                if (enterableBehavior == null)
                 {
                     return "You can not enter " + thing.Name + ".";
                 }

--- a/src/Actions/Travel/Follow.cs
+++ b/src/Actions/Travel/Follow.cs
@@ -41,13 +41,13 @@ namespace WheelMUD.Actions
 
             if (actionInput.Params.Length == 0)
             {
-                this.ShowStatus(actionInput);
+                ShowStatus(actionInput);
                 return;
             }
 
             // Check for existing FollowedBehavior on the target and create one if necessary.
             // Then add the sender to the list of followers.
-            var targetBehaviors = this.target.Behaviors;
+            var targetBehaviors = target.Behaviors;
             var followedBehavior = targetBehaviors.FindFirst<FollowedBehavior>();
             if (followedBehavior == null)
             {
@@ -80,7 +80,7 @@ namespace WheelMUD.Actions
                 }
             }
 
-            followingBehavior.Target = this.target;
+            followingBehavior.Target = target;
         }
 
         /// <summary>Checks against the guards for the command.</summary>
@@ -89,7 +89,7 @@ namespace WheelMUD.Actions
         public override string Guards(ActionInput actionInput)
         {
             IController sender = actionInput.Controller;
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
 
             if (commonFailure != null)
             {
@@ -106,29 +106,29 @@ namespace WheelMUD.Actions
             string targetFullName = actionInput.Tail.Trim().ToLower();
 
             // Try to find the target either by all the parameter text or by just the first parameter.
-            this.target = GetPlayerOrMobile(targetFullName) ?? GetPlayerOrMobile(targetName);
+            target = GetPlayerOrMobile(targetFullName) ?? GetPlayerOrMobile(targetName);
 
             // Rule: Is the target an entity?
-            if (this.target == null)
+            if (target == null)
             {
                 return "You cannot see " + targetName + ".";
             }
 
             // Rule: Is the target the initator?
-            if (sender.Thing.Name.ToLower() == this.target.Name.ToLower())
+            if (sender.Thing.Name.ToLower() == target.Name.ToLower())
             {
                 return "You can't follow yourself.";
             }
 
             // Rule: Is the target in the same room?
-            if (sender.Thing.Parent.Id != this.target.Parent.Id)
+            if (sender.Thing.Parent.Id != target.Parent.Id)
             {
                 return targetName + " does not appear to be in the vicinity.";
             }
 
             SenseManager senses = new SenseManager();
             senses.AddSense(new Sense { SensoryType = SensoryType.Sight, Enabled = true });
-            if (!this.target.IsDetectableBySense(senses))
+            if (!target.IsDetectableBySense(senses))
             {
                 return targetName + " does not appear to be in the vicinity.";
             }

--- a/src/Actions/Travel/Knock.cs
+++ b/src/Actions/Travel/Knock.cs
@@ -42,16 +42,16 @@ namespace WheelMUD.Actions
         {
             // Build our knock messages for this room and the next.  Only send message to the door-type thing once.
             IController sender = actionInput.Controller;
-            var thisRoomMessage = new ContextualString(sender.Thing, this.target)
+            var thisRoomMessage = new ContextualString(sender.Thing, target)
             {
-                ToOriginator = $"You knock on {this.target.Name}.",
-                ToOthers = $"{sender.Thing.Name} knocks on {this.target.Name}.",
+                ToOriginator = $"You knock on {target.Name}.",
+                ToOthers = $"{sender.Thing.Name} knocks on {target.Name}.",
                 ToReceiver = $"{sender.Thing.Name} knocks on you.",
             };
-            var nextRoomMessage = new ContextualString(sender.Thing, this.target)
+            var nextRoomMessage = new ContextualString(sender.Thing, target)
             {
                 ToOriginator = null,
-                ToOthers = $"Someone knocks on {this.target.Name}.",
+                ToOthers = $"Someone knocks on {target.Name}.",
                 ToReceiver = null,
             };
 
@@ -60,8 +60,8 @@ namespace WheelMUD.Actions
             var nextRoomSM = new SensoryMessage(SensoryType.Hearing, 100, nextRoomMessage);
 
             // Generate our knock events.
-            var thisRoomKnockEvent = new KnockEvent(this.target, thisRoomSM);
-            var nextRoomKnockEvent = new KnockEvent(this.target, nextRoomSM);
+            var thisRoomKnockEvent = new KnockEvent(target, thisRoomSM);
+            var nextRoomKnockEvent = new KnockEvent(target, nextRoomSM);
 
             // Broadcast the requests/events; the events handle sending the sensory messages.
             sender.Thing.Eventing.OnCommunicationRequest(thisRoomKnockEvent, EventScope.ParentsDown);
@@ -71,10 +71,10 @@ namespace WheelMUD.Actions
                 sender.Thing.Eventing.OnCommunicationEvent(thisRoomKnockEvent, EventScope.ParentsDown);
 
                 // Next try to send a knock event into the adjacent place too.
-                this.nextRoom.Eventing.OnCommunicationRequest(nextRoomKnockEvent, EventScope.SelfDown);
+                nextRoom.Eventing.OnCommunicationRequest(nextRoomKnockEvent, EventScope.SelfDown);
                 if (!nextRoomKnockEvent.IsCancelled)
                 {
-                    this.nextRoom.Eventing.OnCommunicationEvent(nextRoomKnockEvent, EventScope.SelfDown);
+                    nextRoom.Eventing.OnCommunicationEvent(nextRoomKnockEvent, EventScope.SelfDown);
                 }
             }
         }
@@ -84,7 +84,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -104,7 +104,7 @@ namespace WheelMUD.Actions
                 // Are they trying to knock on a door?
                 if (actionInput.Params[0].ToLower() == "door")
                 {
-                    return this.CheckForDoor(actionInput);
+                    return CheckForDoor(actionInput);
                 }
             }
 
@@ -189,16 +189,16 @@ namespace WheelMUD.Actions
                 return "That door is open. Why knock on an open door?";
             }
 
-            this.target = exit.Door;
+            target = exit.Door;
 
             // Which room does the door lead to?
             if (!Equals(exit.ExitEndA.Room, sender.Thing.Parent))
             {
-                this.adjacentRoom = exit.ExitEndA.Room;
+                adjacentRoom = exit.ExitEndA.Room;
             }
             else
             {
-                this.adjacentRoom = exit.ExitEndB.Room;
+                adjacentRoom = exit.ExitEndB.Room;
             }
             */
             return null;

--- a/src/Actions/Travel/Lock.cs
+++ b/src/Actions/Travel/Lock.cs
@@ -39,7 +39,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
 
             if (commonFailure != null)
             {

--- a/src/Actions/Travel/Unfollow.cs
+++ b/src/Actions/Travel/Unfollow.cs
@@ -81,7 +81,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
 
             if (commonFailure != null)
             {

--- a/src/Actions/Travel/Unlock.cs
+++ b/src/Actions/Travel/Unlock.cs
@@ -40,7 +40,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/ConnectionStates/CharacterCreation/CharacterCreationStateMachine.cs
+++ b/src/ConnectionStates/CharacterCreation/CharacterCreationStateMachine.cs
@@ -16,13 +16,13 @@ namespace WheelMUD.ConnectionStates
         /// <param name="session">The session.</param>
         public CharacterCreationStateMachine(Session session)
         {
-            this.Session = session;
+            Session = session;
 
             // If this is attached to a session, prepare a character for building upon.
-            if (this.Session != null)
+            if (Session != null)
             {
-                this.Session.Thing = PlayerManager.PrepareBaseCharacter(session);
-                this.HandleNextStep(null, StepStatus.Success);
+                Session.Thing = PlayerManager.PrepareBaseCharacter(session);
+                HandleNextStep(null, StepStatus.Success);
             }
         }
 
@@ -51,7 +51,7 @@ namespace WheelMUD.ConnectionStates
             // Pass on any input to the current sub state character creation step.
             if (command != string.Empty)
             {
-                this.CurrentStep.ProcessInput(command);
+                CurrentStep.ProcessInput(command);
             }
         }
 
@@ -60,29 +60,29 @@ namespace WheelMUD.ConnectionStates
         /// <param name="result">The result of the current step</param>
         public void HandleNextStep(CharacterCreationSubState step, StepStatus result)
         {
-            this.CurrentStep = this.GetNextStep(step, result);
+            CurrentStep = GetNextStep(step, result);
 
             // If there were no remaining steps found, we're done.
-            if (this.CurrentStep == null)
+            if (CurrentStep == null)
             {
-                this.OnCreationComplete();
+                OnCreationComplete();
                 return;
             }
 
-            this.CurrentStep.StateMachine = this;
-            this.Session.WritePrompt();
+            CurrentStep.StateMachine = this;
+            Session.WritePrompt();
         }
 
         /// <summary>Signals abortion of character creation.</summary>
         internal void AbortCreation()
         {
-            this.CharacterCreationAborted?.Invoke();
+            CharacterCreationAborted?.Invoke();
         }
 
         /// <summary>Signals completion of character creation.</summary>
         internal void OnCreationComplete()
         {
-            this.CharacterCreationCompleted?.Invoke(this.Session);
+            CharacterCreationCompleted?.Invoke(Session);
         }
     }
 }

--- a/src/ConnectionStates/CharacterCreation/CharacterCreationStateMachineManager.cs
+++ b/src/ConnectionStates/CharacterCreation/CharacterCreationStateMachineManager.cs
@@ -35,7 +35,7 @@ namespace WheelMUD.ConnectionStates
         /// <summary>Prevents a default instance of the <see cref="CharacterCreationStateMachineManager"/> class from being created.</summary>
         private CharacterCreationStateMachineManager()
         {
-            this.Recompose();
+            Recompose();
         }
 
         /// <summary>Gets the singleton instance of the <see cref="CharacterCreationStateMachineManager"/> class.</summary>
@@ -54,7 +54,7 @@ namespace WheelMUD.ConnectionStates
             lock (LockObject)
             {
                 var parameters = new object[] { session };
-                return (CharacterCreationStateMachine)this.defaultCharacterCreationStateMachineConstructor.Invoke(parameters);
+                return (CharacterCreationStateMachine)defaultCharacterCreationStateMachineConstructor.Invoke(parameters);
             }
         }
 
@@ -68,7 +68,7 @@ namespace WheelMUD.ConnectionStates
                 // Find the constructor of the current priority character creation state machine that takes a Session parameter.
                 // We'll use this info to quickly create each CharacterCreationStateMachines instance for new character creation sessions.
                 var constructorTypes = new Type[] { typeof(Session) };
-                this.defaultCharacterCreationStateMachineConstructor = DefaultComposer.GetConstructor(this.CharacterCreationStateMachines, constructorTypes);
+                defaultCharacterCreationStateMachineConstructor = DefaultComposer.GetConstructor(CharacterCreationStateMachines, constructorTypes);
             }
         }
     }

--- a/src/ConnectionStates/CharacterCreation/CharacterCreationSubState.cs
+++ b/src/ConnectionStates/CharacterCreation/CharacterCreationSubState.cs
@@ -16,7 +16,7 @@ namespace WheelMUD.ConnectionStates
         /// <param name="session">The session.</param>
         protected CharacterCreationSubState(Session session)
         {
-            this.Session = session;
+            Session = session;
         }
 
         /// <summary>Gets or sets the state machine managing this creation state.</summary>

--- a/src/ConnectionStates/CharacterCreation/ConfirmCreationEntryState.cs
+++ b/src/ConnectionStates/CharacterCreation/ConfirmCreationEntryState.cs
@@ -27,15 +27,15 @@ namespace WheelMUD.ConnectionStates
         {
             if (command.ToLower() == "yes" || command.ToLower() == "y")
             {
-                this.Session.User = new User()
+                Session.User = new User()
                 {
                     AccountCreationDate = DateTime.Now,
                 };
-                this.StateMachine.HandleNextStep(this, StepStatus.Success);
+                StateMachine.HandleNextStep(this, StepStatus.Success);
             }
             else
             {
-                this.StateMachine.AbortCreation();
+                StateMachine.AbortCreation();
             }
         }
 

--- a/src/ConnectionStates/CharacterCreation/ConfirmPasswordState.cs
+++ b/src/ConnectionStates/CharacterCreation/ConfirmPasswordState.cs
@@ -25,14 +25,14 @@ namespace WheelMUD.ConnectionStates
         {
             // Do not use the command parameter here. It is trimmed of whitespace, which will inhibit the use of passwords 
             // with whitespace on either end. Instead we need to respect the raw line of input for password entries.
-            if (this.Session.User.PasswordMatches(this.Session.Connection.LastRawInput))
+            if (Session.User.PasswordMatches(Session.Connection.LastRawInput))
             {
-                this.StateMachine.HandleNextStep(this, StepStatus.Success);
+                StateMachine.HandleNextStep(this, StepStatus.Success);
             }
             else
             {
-                this.Session.Write("I am afraid the passwords entered do not match.\r\n", false);
-                this.StateMachine.HandleNextStep(this, StepStatus.Failure);
+                Session.Write("I am afraid the passwords entered do not match.\r\n", false);
+                StateMachine.HandleNextStep(this, StepStatus.Failure);
             }
         }
 

--- a/src/ConnectionStates/CharacterCreation/DefaultCharacterCreationStateMachine.cs
+++ b/src/ConnectionStates/CharacterCreation/DefaultCharacterCreationStateMachine.cs
@@ -35,11 +35,11 @@ namespace WheelMUD.ConnectionStates
             // If there is no state yet, set up the initial character creation state.
             if (current == null)
             {
-                return new ConfirmCreationEntryState(this.Session);
+                return new ConfirmCreationEntryState(Session);
             }
 
             // Otherwise either go forward to the next state, or back to the previous state if requested.
-            return previousStatus == StepStatus.Success ? this.AdvanceState(current) : this.RegressState(current);
+            return previousStatus == StepStatus.Success ? AdvanceState(current) : RegressState(current);
         }
 
         private CharacterCreationSubState AdvanceState(CharacterCreationSubState current)
@@ -50,19 +50,19 @@ namespace WheelMUD.ConnectionStates
             // they could of course reuse some/all of the states below in addition to their own.
             if (current is ConfirmCreationEntryState)
             {
-                return new GetNameState(this.Session);
+                return new GetNameState(Session);
             }
             else if (current is GetNameState)
             {
-                return new GetPasswordState(this.Session);
+                return new GetPasswordState(Session);
             }
             else if (current is GetPasswordState)
             {
-                return new ConfirmPasswordState(this.Session);
+                return new ConfirmPasswordState(Session);
             }
             else if (current is ConfirmPasswordState)
             {
-                return new GetDescriptionState(this.Session);
+                return new GetDescriptionState(Session);
             }
             else if (current is GetDescriptionState)
             {
@@ -78,7 +78,7 @@ namespace WheelMUD.ConnectionStates
             if (current is ConfirmPasswordState)
             {
                 // If password confirmation failed, try selecting a new password.
-                return new GetPasswordState(this.Session);
+                return new GetPasswordState(Session);
             }
 
             throw new InvalidOperationException("The character state machine does not know how to calculate the next step after '" + current.GetType().Name + "' fails");

--- a/src/ConnectionStates/CharacterCreation/ExportCharacterCreationStateMachineAttribute.cs
+++ b/src/ConnectionStates/CharacterCreation/ExportCharacterCreationStateMachineAttribute.cs
@@ -23,7 +23,7 @@ namespace WheelMUD.ConnectionStates
         public ExportCharacterCreationStateMachineAttribute(int stateMachinePriority)
             : base(typeof(CharacterCreationStateMachine))
         {
-            this.Priority = stateMachinePriority;
+            Priority = stateMachinePriority;
         }
 
         /// <summary>Initializes a new instance of the <see cref="ExportCharacterCreationStateMachineAttribute"/> class.</summary>

--- a/src/ConnectionStates/CharacterCreation/GetDescriptionState.cs
+++ b/src/ConnectionStates/CharacterCreation/GetDescriptionState.cs
@@ -23,8 +23,8 @@ namespace WheelMUD.ConnectionStates
         /// <param name="command">The command text to be processed.</param>
         public override void ProcessInput(string command)
         {
-            this.Session.Thing.Description = command;
-            this.StateMachine.HandleNextStep(this, StepStatus.Success);
+            Session.Thing.Description = command;
+            StateMachine.HandleNextStep(this, StepStatus.Success);
         }
 
         public override string BuildPrompt()

--- a/src/ConnectionStates/CharacterCreation/GetNameState.cs
+++ b/src/ConnectionStates/CharacterCreation/GetNameState.cs
@@ -37,25 +37,25 @@ namespace WheelMUD.ConnectionStates
         /// <param name="command">The command text to be processed.</param>
         public override void ProcessInput(string command)
         {
-            if (this.ValidateUserName(ref command))
+            if (ValidateUserName(ref command))
             {
                 // The name is valid, but has it been taken already?
                 if (PlayerRepositoryExtensions.UserNameExists(command))
                 {
-                    this.Session.Write("I'm sorry, that name is already taken. Please choose another.");
+                    Session.Write("I'm sorry, that name is already taken. Please choose another.");
                 }
-                else if (this.StateMachine != null)
+                else if (StateMachine != null)
                 {
-                    this.Session.User.UserName = command;
+                    Session.User.UserName = command;
                     if (AppConfigInfo.Instance.UserAccountIsPlayerCharacter)
                     {
-                        this.Session.Thing.Name = command;
+                        Session.Thing.Name = command;
                     }
                     else
                     {
                         throw new System.NotImplementedException("Need to ensure correct flow into character selection state.");
                     }
-                    this.StateMachine.HandleNextStep(this, StepStatus.Success);
+                    StateMachine.HandleNextStep(this, StepStatus.Success);
                 }
             }
         }
@@ -86,7 +86,7 @@ namespace WheelMUD.ConnectionStates
             // Rule: User and character names may not be missing or empty.
             if (string.IsNullOrEmpty(newUserName))
             {
-                this.Session.Write("You must supply a name.");
+                Session.Write("You must supply a name.");
                 return false;
             }
 
@@ -96,7 +96,7 @@ namespace WheelMUD.ConnectionStates
             if (isAlsoPlayerName && (newUserName.Length < MinimumPlayerCharacterNameLength || newUserName.Length > MaximumPlayerCharacterNameLength))
             {
                 var format = "Player name must be between {0} and {1} letters long. Please choose another.";
-                this.Session.Write(string.Format(format, MinimumPlayerCharacterNameLength, MaximumPlayerCharacterNameLength));
+                Session.Write(string.Format(format, MinimumPlayerCharacterNameLength, MaximumPlayerCharacterNameLength));
                 return false;
             }
 
@@ -104,7 +104,7 @@ namespace WheelMUD.ConnectionStates
             if (newUserName.Length < MinimumUserNameLength || newUserName.Length > MaximumUserNameLength)
             {
                 var format = "User name must be between {0} and {1} letters long. Please choose another.";
-                this.Session.Write(string.Format(format, MinimumUserNameLength, MaximumUserNameLength));
+                Session.Write(string.Format(format, MinimumUserNameLength, MaximumUserNameLength));
                 return false;
             }
 
@@ -117,7 +117,7 @@ namespace WheelMUD.ConnectionStates
                 {
                     if (!char.IsLetter(c))
                     {
-                        this.Session.Write("Character name must include only letters. Please choose another.");
+                        Session.Write("Character name must include only letters. Please choose another.");
                         return false;
                     }
                 }
@@ -145,14 +145,14 @@ namespace WheelMUD.ConnectionStates
                 // Rule: Character name must include at least one vowel or equivalent character.
                 if (vowelCount <= 0)
                 {
-                    this.Session.Write("Character name may not exclude vowels. Please choose another.");
+                    Session.Write("Character name may not exclude vowels. Please choose another.");
                     return false;
                 }
 
                 // Rule: Character name may not only consist too heavily of uppercase characters.
                 if (capitalCount > 1 && capitalCount >= newUserName.Length / 2)
                 {
-                    this.Session.Write("Character name may not be heavily uppercased. Please choose another.");
+                    Session.Write("Character name may not be heavily uppercased. Please choose another.");
                     return false;
                 }
 

--- a/src/ConnectionStates/CharacterCreation/GetPasswordState.cs
+++ b/src/ConnectionStates/CharacterCreation/GetPasswordState.cs
@@ -25,10 +25,10 @@ namespace WheelMUD.ConnectionStates
         {
             // Do not use the command parameter here. It is trimmed of whitespace, which will inhibit the use of passwords 
             // with whitespace on either end. Instead we need to respect the raw line of input for password entries.
-            this.Session.User.SetPassword(this.Session.Connection.LastRawInput);
-            this.Session.Connection.LastRawInput = null;
+            Session.User.SetPassword(Session.Connection.LastRawInput);
+            Session.Connection.LastRawInput = null;
 
-            this.StateMachine.HandleNextStep(this, StepStatus.Success);
+            StateMachine.HandleNextStep(this, StepStatus.Success);
         }
 
         public override string BuildPrompt()

--- a/src/ConnectionStates/CombatState.cs
+++ b/src/ConnectionStates/CombatState.cs
@@ -22,15 +22,15 @@ namespace WheelMUD.ConnectionStates
         /// <param name="command">The input to process.</param>
         public override void ProcessInput(string command)
         {
-            this.Session.AtPrompt = false;
+            Session.AtPrompt = false;
             if (command != string.Empty)
             {
-                var actionInput = new ActionInput(command, this.Session);
-                this.Session.ExecuteAction(actionInput);
+                var actionInput = new ActionInput(command, Session);
+                Session.ExecuteAction(actionInput);
             }
             else
             {
-                this.Session.SendPrompt();
+                Session.SendPrompt();
             }
         }
 

--- a/src/ConnectionStates/ConnectedState.cs
+++ b/src/ConnectionStates/ConnectedState.cs
@@ -33,23 +33,23 @@ namespace WheelMUD.ConnectionStates
         /// <param name="command">The input to process.</param>
         public override void ProcessInput(string command)
         {
-            this.Session.AtPrompt = false;
+            Session.AtPrompt = false;
             switch (command.ToLower())
             {
                 case "":
                     break;
                 case "new":
-                    this.Session.State = new CreationState(this.Session);
-                    this.Session.WritePrompt();
+                    Session.State = new CreationState(Session);
+                    Session.WritePrompt();
                     break;
                 case "quit":
                 case "close":
                 case "exit":
-                    this.Session.Connection.Disconnect();
+                    Session.Connection.Disconnect();
                     break;
                 default:
-                    this.Session.State = new LoginState(this.Session, command);
-                    this.Session.WritePrompt();
+                    Session.State = new LoginState(Session, command);
+                    Session.WritePrompt();
                     break;
             }
         }

--- a/src/ConnectionStates/CreationState.cs
+++ b/src/ConnectionStates/CreationState.cs
@@ -23,24 +23,24 @@ namespace WheelMUD.ConnectionStates
             : base(session)
         {
             // Get the default CharacterCreationStateMachine via MEF to drive character creation sub-states.
-            this.subStateHandler = CharacterCreationStateMachineManager.Instance.CreateDefaultCharacterCreationStateMachine(session);
-            this.subStateHandler.CharacterCreationAborted += this.SubState_CharacterCreationAborted;
-            this.subStateHandler.CharacterCreationCompleted += SubState_CharacterCreationCompleted;
+            subStateHandler = CharacterCreationStateMachineManager.Instance.CreateDefaultCharacterCreationStateMachine(session);
+            subStateHandler.CharacterCreationAborted += SubState_CharacterCreationAborted;
+            subStateHandler.CharacterCreationCompleted += SubState_CharacterCreationCompleted;
         }
 
         /// <summary>Process the specified input.</summary>
         /// <param name="command">The input to process.</param>
         public override void ProcessInput(string command)
         {
-            this.Session.AtPrompt = false;
-            this.subStateHandler.ProcessInput(command);
+            Session.AtPrompt = false;
+            subStateHandler.ProcessInput(command);
         }
 
         public override string BuildPrompt()
         {
-            if (this.subStateHandler != null && this.subStateHandler.CurrentStep != null)
+            if (subStateHandler != null && subStateHandler.CurrentStep != null)
             {
-                return this.subStateHandler.CurrentStep.BuildPrompt();
+                return subStateHandler.CurrentStep.BuildPrompt();
             }
 
             return "> ";
@@ -87,8 +87,8 @@ namespace WheelMUD.ConnectionStates
         /// <summary>Called upon the abortion of character creation.</summary>
         private void SubState_CharacterCreationAborted()
         {
-            this.Session.State = new ConnectedState(this.Session);
-            this.Session.WritePrompt();
+            Session.State = new ConnectedState(Session);
+            Session.WritePrompt();
         }
     }
 }

--- a/src/ConnectionStates/LoginState.cs
+++ b/src/ConnectionStates/LoginState.cs
@@ -30,46 +30,46 @@ namespace WheelMUD.ConnectionStates
         /// <param name="command">The input to process.</param>
         public override void ProcessInput(string command)
         {
-            this.Session.AtPrompt = false;
+            Session.AtPrompt = false;
             if (command != string.Empty)
             {
-                var authenticatedUser = this.Authenticate(command);
+                var authenticatedUser = Authenticate(command);
                 if (authenticatedUser != null)
                 {
-                    this.Session.User = authenticatedUser;
+                    Session.User = authenticatedUser;
                     if (!AppConfigInfo.Instance.UserAccountIsPlayerCharacter)
                     {
                         throw new NotImplementedException("Need to build a ChooseCharacterState!");
                     }
                     else
                     {
-                        var characterId = this.Session.User.PlayerCharacterIds[0];
-                        this.Session.Thing = DocumentRepository<Thing>.Load(characterId);
-                        this.Session.Thing.Behaviors.SetParent(this.Session.Thing);
-                        var playerBehavior = this.Session.Thing.FindBehavior<PlayerBehavior>();
+                        var characterId = Session.User.PlayerCharacterIds[0];
+                        Session.Thing = DocumentRepository<Thing>.Load(characterId);
+                        Session.Thing.Behaviors.SetParent(Session.Thing);
+                        var playerBehavior = Session.Thing.FindBehavior<PlayerBehavior>();
                         if (playerBehavior != null)
                         {
-                            this.Session.Thing.Behaviors.FindFirst<UserControlledBehavior>().Controller = this.Session;
-                            playerBehavior.LogIn(this.Session);
-                            this.Session.AuthenticateSession();
-                            this.Session.State = new PlayingState(this.Session);
+                            Session.Thing.Behaviors.FindFirst<UserControlledBehavior>().Controller = Session;
+                            playerBehavior.LogIn(Session);
+                            Session.AuthenticateSession();
+                            Session.State = new PlayingState(Session);
 
                         }
                         else
                         {
-                            this.Session.Write("This character player state is broken. You may need to contact an admin for a possible recovery attempt.");
-                            this.Session.InformSubscribedSystem(this.Session.ID + " failed to load due to missing player behavior.");
-                            this.Session.State = new ConnectedState(this.Session);
-                            this.Session.WritePrompt();
+                            Session.Write("This character player state is broken. You may need to contact an admin for a possible recovery attempt.");
+                            Session.InformSubscribedSystem(Session.ID + " failed to load due to missing player behavior.");
+                            Session.State = new ConnectedState(Session);
+                            Session.WritePrompt();
                         }
                     }
                 }
                 else
                 {
-                    this.Session.Write("Incorrect user name or password.\r\n\r\n", false);
-                    this.Session.InformSubscribedSystem(this.Session.ID + " failed to log in");
-                    this.Session.State = new ConnectedState(this.Session);
-                    this.Session.WritePrompt();
+                    Session.Write("Incorrect user name or password.\r\n\r\n", false);
+                    Session.InformSubscribedSystem(Session.ID + " failed to log in");
+                    Session.State = new ConnectedState(Session);
+                    Session.WritePrompt();
                 }
             }
         }
@@ -83,7 +83,7 @@ namespace WheelMUD.ConnectionStates
         /// <returns>True if authenticated, else false.</returns>
         private User Authenticate(string password)
         {
-            return PlayerRepositoryExtensions.Authenticate(this.userName, password);
+            return PlayerRepositoryExtensions.Authenticate(userName, password);
         }
     }
 }

--- a/src/ConnectionStates/PlayingState.cs
+++ b/src/ConnectionStates/PlayingState.cs
@@ -25,26 +25,26 @@ namespace WheelMUD.ConnectionStates
             if (session.Thing != null)
             {
                 var behavior = session.Thing.Behaviors.FindFirst<PlayerBehavior>();
-                this.playerBehavior = new SimpleWeakReference<PlayerBehavior>(behavior);
+                playerBehavior = new SimpleWeakReference<PlayerBehavior>(behavior);
             }
 
             string nl = Environment.NewLine;
-            session.Write(string.Format("{0}Welcome, {1}.{0}{0}", nl, this.Session.Thing.FullName), false);
+            session.Write(string.Format("{0}Welcome, {1}.{0}{0}", nl, Session.Thing.FullName), false);
         }
 
         /// <summary>Process the specified input.</summary>
         /// <param name="command">The input to process.</param>
         public override void ProcessInput(string command)
         {
-            this.Session.AtPrompt = false;
+            Session.AtPrompt = false;
             if (command != string.Empty)
             {
-                var actionInput = new ActionInput(command, this.Session);
-                this.Session.ExecuteAction(actionInput);
+                var actionInput = new ActionInput(command, Session);
+                Session.ExecuteAction(actionInput);
             }
             else
             {
-                this.Session.SendPrompt();
+                Session.SendPrompt();
             }
         }
 

--- a/src/Core/AAA_TEMP.cs
+++ b/src/Core/AAA_TEMP.cs
@@ -104,9 +104,9 @@ namespace WheelMUD.Effects
         {
             get
             {
-                if (this.completesAt > DateTime.Now)
+                if (completesAt > DateTime.Now)
                 {
-                    return this.completesAt.Subtract(DateTime.Now);
+                    return completesAt.Subtract(DateTime.Now);
                 }
 
                 return new TimeSpan(0, 0, 0, 0, 0);
@@ -135,8 +135,8 @@ namespace WheelMUD.Effects
         /// <param name="duration">The duration for the effect.</param>
         public virtual void Apply(TimeSpan duration)
         {
-            this.Duration = new Timer(this.TickElapsed, null, (int)duration.TotalMilliseconds, Timeout.Infinite);
-            this.completesAt = DateTime.Now.Add(duration);
+            Duration = new Timer(TickElapsed, null, (int)duration.TotalMilliseconds, Timeout.Infinite);
+            completesAt = DateTime.Now.Add(duration);
         }
 
         /// <summary>The method that is called when an effect is to be removed.</summary>
@@ -150,10 +150,10 @@ namespace WheelMUD.Effects
         /// <summary>Raises the Effect Elapsed event.</summary>
         protected void RaiseEffectElapsed()
         {
-            this.Duration.Change(Timeout.Infinite, Timeout.Infinite);
-            if (this.EffectElapsed != null)
+            Duration.Change(Timeout.Infinite, Timeout.Infinite);
+            if (EffectElapsed != null)
             {
-                this.EffectElapsed(this);
+                EffectElapsed(this);
             }
         }
     }
@@ -189,14 +189,14 @@ namespace WheelMUD.Effects
         /// <param name="thing">The host of the effects manager.</param>
         public EffectsManager(Thing thing)
         {
-            this.host = thing;
+            host = thing;
         }
 
         /// <summary>Gets the count of the number of effects effecting this Thing.</summary>
         /// <returns>The number of effects in the effects manager.</returns>
         public int Count
         {
-            get { return this.effects.Count; }
+            get { return effects.Count; }
         }
 
         /// <summary>Tries to create a new effect and add it to the collection of effects applied to this thing.</summary>
@@ -212,16 +212,16 @@ namespace WheelMUD.Effects
 
             if (availableEffects.Contains(effect.GetType()))
             {
-                if (effect.IsAllowed(this.host, creator))
+                if (effect.IsAllowed(host, creator))
                 {
-                    effect.Host = this.host;
+                    effect.Host = host;
                     effect.Creator = creator;
 
-                    effect.EffectElapsed += this.EffectElapsed;
+                    effect.EffectElapsed += EffectElapsed;
 
-                    lock (this.lockObject)
+                    lock (lockObject)
                     {
-                        this.effects.Add(Guid.NewGuid().ToString(), effect);
+                        effects.Add(Guid.NewGuid().ToString(), effect);
                     }
 
                     return true;
@@ -258,16 +258,16 @@ namespace WheelMUD.Effects
         /// <param name="effect">The effect to remove.</param>
         private void EffectElapsed(IEffect effect)
         {
-            this.CancelEffect(effect);
+            CancelEffect(effect);
         }
 
         /// <summary>Cancels an effect.</summary>
         /// <param name="effect">The effect to cancel.</param>
         private void CancelEffect(IEffect effect)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                this.effects.Remove(effect.Name.ToLower());
+                effects.Remove(effect.Name.ToLower());
             }
         }
     }
@@ -364,13 +364,13 @@ namespace WheelMUD.Universe
         public Item()
             : base()
         {
-            this.Id = 0;
-            this.KeyWords = new List<string>();
-            this.SingularPrefix = string.Empty;
-            this.PluralSuffix = string.Empty;
-            this.BehaviorManager = new BehaviorManager(this);
-            this.SingularPrefix = "a ";
-            this.PluralSuffix = "s";
+            Id = 0;
+            KeyWords = new List<string>();
+            SingularPrefix = string.Empty;
+            PluralSuffix = string.Empty;
+            BehaviorManager = new BehaviorManager(this);
+            SingularPrefix = "a ";
+            PluralSuffix = "s";
         }
 
         /// <summary>Initializes a new instance of the Item class, based on the specified item template.</summary>
@@ -386,7 +386,7 @@ namespace WheelMUD.Universe
         /// <summary>Gets the name with prepended with its prefix and appended with its suffix.</summary>
         public override string FullName
         {
-            get { return string.Format("{0} {1} {2}", this.SingularPrefix, this.Name, this.PluralSuffix).Trim(); }
+            get { return string.Format("{0} {1} {2}", SingularPrefix, Name, PluralSuffix).Trim(); }
         }
 
         /* TODO: Make base thing save then extract this example
@@ -395,19 +395,19 @@ namespace WheelMUD.Universe
         {
             ItemRepository itemRepository = new ItemRepository();
 
-            if (this.DataRecord.ID == 0)
+            if (DataRecord.ID == 0)
             {
-                itemRepository.Add(this.DataRecord);
+                itemRepository.Add(DataRecord);
 
-                this.Id = this.DataRecord.ID;
+                Id = DataRecord.ID;
             }
             else
             {
-                itemRepository.Update(this.DataRecord);
+                itemRepository.Update(DataRecord);
             }
 
-            this.BehaviorManager.ItemId = this.Id;
-            this.BehaviorManager.Save();
+            BehaviorManager.ItemId = Id;
+            BehaviorManager.Save();
         }
     }
 }*/
@@ -460,7 +460,7 @@ namespace WheelMUD.Universe.Things
         public ListeningDevice()
             : base()
         {
-            this.OwnerName = string.Empty;
+            OwnerName = string.Empty;
         }
 
         /// <summary>Initializes a new instance of the ListeningDevice class.</summary>
@@ -475,7 +475,7 @@ namespace WheelMUD.Universe.Things
                 Reactions = new List<string>()
             })
         {
-            this.OwnerName = string.Empty;
+            OwnerName = string.Empty;
         }
 
         /// <summary>Gets or sets the owner name.</summary>
@@ -495,9 +495,9 @@ namespace WheelMUD.Universe.Things
         {
             get
             {
-                if (this.Count > 1)
+                if (Count > 1)
                 {
-                    return string.Format("{0}{1}{2}", this.SingularPrefix, this.Name, this.PluralSuffix);
+                    return string.Format("{0}{1}{2}", SingularPrefix, Name, PluralSuffix);
                 }
 
                 return base.FullName;
@@ -509,12 +509,12 @@ namespace WheelMUD.Universe.Things
         {
             get
             {
-                if (this.Count == 1)
+                if (Count == 1)
                 {
                     return base.SingularPrefix;
                 }
 
-                return this.Count + " ";
+                return Count + " ";
             }
 
             set
@@ -528,7 +528,7 @@ namespace WheelMUD.Universe.Things
         {
             get
             {
-                if (this.Count == 1)
+                if (Count == 1)
                 {
                     return base.PluralSuffix;
                 }
@@ -547,7 +547,7 @@ namespace WheelMUD.Universe.Things
         /// <returns>True if the items can be combined/stacked, else false.</returns>
         public bool CanStack(IStackableItem stackableItem)
         {
-            if (this.TemplateID != null && stackableItem.TemplateID == this.TemplateID)
+            if (TemplateID != null && stackableItem.TemplateID == TemplateID)
             {
                 return true;
             }
@@ -564,16 +564,16 @@ namespace WheelMUD.Universe.Things
         /// operations; one would have to add explicit checks for Count prior to RemoveFromContainer.</remarks>
         public bool RemoveFromContainer(long numberToRemove)
         {
-            if (numberToRemove < this.Count)
+            if (numberToRemove < Count)
             {
-                IStackableItem stackableItem = this.SplitStack(this.Count - numberToRemove);
-                IItemCollection container = this.Container;
-                this.RemoveFromContainer();
+                IStackableItem stackableItem = SplitStack(Count - numberToRemove);
+                IItemCollection container = Container;
+                RemoveFromContainer();
                 container.AddItem(stackableItem);
                 return true;
             }
 
-            return this.RemoveFromContainer();
+            return RemoveFromContainer();
         }
 
         // RemoveFromContainer() is not overrided because if no count is specified,
@@ -587,14 +587,14 @@ namespace WheelMUD.Universe.Things
             // Ensure that we can't make negative count on either item.  Ensure the null
             // return case is handled anywhere SplitStack is used if count was not already
             // verified by the caller.
-            if (numberToSplitOff >= this.Count)
+            if (numberToSplitOff >= Count)
             {
                 return null;
             }
 
-            StackableItem newStack = (StackableItem)this.Clone();
+            StackableItem newStack = (StackableItem)Clone();
             newStack.Count = numberToSplitOff;
-            this.Count -= numberToSplitOff;
+            Count -= numberToSplitOff;
             return newStack;
         }
     }
@@ -624,29 +624,26 @@ namespace WheelMUD.Universe.Things
             : base(ids)
         {            
             // Keep a reference of this item's potion behavior.
-            this.potionBehavior = this.BehaviorManager.FindFirst<PotionItemBehavior>();
-            if (this.potionBehavior == null)
+            potionBehavior = BehaviorManager.FindFirst<PotionItemBehavior>();
+            if (potionBehavior == null)
             {
                 // TODO: Loud warning if a Potion doesn't have an associated PotionItemBehavior, 
                 //       but for now, until DAL reflects Behaviors properly, we'll default a test one.
-                this.potionBehavior = new PotionItemBehavior();
-                this.potionBehavior.MaxSips = 5;
-                this.potionBehavior.SipsLeft = 2;
-                this.potionBehavior.PotionType = "health";
-                this.potionBehavior.Modifier = 100;
-                this.potionBehavior.Duration = new TimeSpan(0, 0, 0, 15);
+                potionBehavior = new PotionItemBehavior();
+                potionBehavior.MaxSips = 5;
+                potionBehavior.SipsLeft = 2;
+                potionBehavior.PotionType = "health";
+                potionBehavior.Modifier = 100;
+                potionBehavior.Duration = new TimeSpan(0, 0, 0, 15);
             }
 
-            base.Description = "A " + this.PotionType + " potion.  It appears to have around %numSipsLeft% sips left";
-        }
-
-            base.Description = "A " + this.PotionType + " potion.  It appears to have around %numSipsLeft% sips left";
+            base.Description = "A " + PotionType + " potion.  It appears to have around %numSipsLeft% sips left";
         }
 
         /// <summary>Ges or sets the description of this potion.</summary>
         public override string Description
         {
-            get { return base.Description.Replace("%numSipsLeft%", this.SipsLeft.ToString()); }
+            get { return base.Description.Replace("%numSipsLeft%", SipsLeft.ToString()); }
             set { base.Description = value; }
         }
     }
@@ -667,40 +664,40 @@ namespace WheelMUD.Universe.Things
                 StringBuilder sb = new StringBuilder();
                 sb.AppendLine(base.Description);
 
-                if (this.LiquidSourceBehavior != null)
+                if (LiquidSourceBehavior != null)
                 {
-                    string sound = this.LiquidSourceBehavior.FlowingSound;
-                    string liquid = this.LiquidSourceBehavior.LiquidName;
+                    string sound = LiquidSourceBehavior.FlowingSound;
+                    string liquid = LiquidSourceBehavior.LiquidName;
 
-                    if (this.LiquidSourceBehavior.IsFlowing)
+                    if (LiquidSourceBehavior.IsFlowing)
                     {
-                        if (this.HoldsLiquid)
+                        if (HoldsLiquid)
                         {
-                            sb.AppendLine(string.Format("{0} {1} in of the {2}.", liquid, sound, this.Name));
+                            sb.AppendLine(string.Format("{0} {1} in of the {2}.", liquid, sound, Name));
                         }
                         else
                         {
-                            sb.AppendLine(string.Format("{0} {1} out of the {2}.", liquid, sound, this.Name));
+                            sb.AppendLine(string.Format("{0} {1} out of the {2}.", liquid, sound, Name));
                         }
                     }
                     else
                     {
-                        if (this.HoldsLiquid)
+                        if (HoldsLiquid)
                         {
-                            sb.AppendLine(string.Format("Stagnant liquid sits in of the {0}.", this.Name));
+                            sb.AppendLine(string.Format("Stagnant liquid sits in of the {0}.", Name));
                         }
                         else
                         {
-                            sb.AppendLine(string.Format("No liquid flows out of the {0}.", this.Name));
+                            sb.AppendLine(string.Format("No liquid flows out of the {0}.", Name));
                         }
                     }
                 }
 
-                if (this.IsClosable)
+                if (IsClosable)
                 {
-                    if (this.OpenState == OpenState.Open)
+                    if (OpenState == OpenState.Open)
                     {
-                        if (this.Count > 0)
+                        if (Count > 0)
                         {
                             sb.AppendLine("Inside, you see:");
                             foreach (Item item in this)
@@ -711,19 +708,19 @@ namespace WheelMUD.Universe.Things
                         }
                         else
                         {
-                            sb.Append(string.Format("The interior of {0} ({1}) is empty", this.Name, this.Id));
+                            sb.Append(string.Format("The interior of {0} ({1}) is empty", Name, Id));
                         }
                     }
                     else
                     {
-                        sb.AppendLine(string.Format("The {0} appears to hold things, but is closed", this.Name));
+                        sb.AppendLine(string.Format("The {0} appears to hold things, but is closed", Name));
                     }
                 }
                 else
                 {
-                    if (this.Count > 0)
+                    if (Count > 0)
                     {
-                        sb.AppendLine(string.Format("On the {0} you see:", this.Name));
+                        sb.AppendLine(string.Format("On the {0} you see:", Name));
                         foreach (Item item in this)
                         {
                             sb.Append(item.Id.ToString().PadRight(20));
@@ -732,7 +729,7 @@ namespace WheelMUD.Universe.Things
                     }
                     else
                     {
-                        sb.Append(string.Format("There is nothing on the {0}.", this.Name));
+                        sb.Append(string.Format("There is nothing on the {0}.", Name));
                     }
                 }
 
@@ -761,20 +758,20 @@ namespace WheelMUD.Universe.Things
             {
                 StringBuilder sb = new StringBuilder();
 
-                if (this.OpenState == OpenState.Open)
+                if (OpenState == OpenState.Open)
                 {
                     sb.AppendLine(base.Description);
 
-                    if (this.HoldsLiquid)
+                    if (HoldsLiquid)
                     {
-                        sb.AppendFormat("It appears that this {0} will hold liquids.", this.Name);
+                        sb.AppendFormat("It appears that this {0} will hold liquids.", Name);
                         sb.Append(Environment.NewLine);
                     }
 
-                    if (this.Count > 0)
+                    if (Count > 0)
                     {
                         sb.AppendLine("Inside, you see:");
-                        foreach (Item item in this.container)
+                        foreach (Item item in container)
                         {
                             sb.Append(item.Id.ToString().PadRight(20));
                             sb.AppendLine(item.Description);
@@ -782,7 +779,7 @@ namespace WheelMUD.Universe.Things
                     }
                     else
                     {
-                        sb.AppendFormat("The {0} ({1}) is empty", this.Name, this.Id);
+                        sb.AppendFormat("The {0} ({1}) is empty", Name, Id);
                         sb.Append(Environment.NewLine);
                     }
                 }
@@ -790,9 +787,9 @@ namespace WheelMUD.Universe.Things
                 {
                     sb.AppendLine(base.Description + " (closed)");
 
-                    if (this.HoldsLiquid)
+                    if (HoldsLiquid)
                     {
-                        sb.AppendFormat("It appears that this {0} will hold liquids.", this.Name);
+                        sb.AppendFormat("It appears that this {0} will hold liquids.", Name);
                         sb.Append(Environment.NewLine);
                     }
                 }
@@ -813,7 +810,7 @@ namespace WheelMUD.Universe.Things
             // We need to subscribe each of our items to the broadcaster,
             // as well as this item.
             broadcaster.Subscribe(this);
-            foreach (Item item in this.container)
+            foreach (Item item in container)
             {
                 item.Subscribe(broadcaster);
             }
@@ -826,7 +823,7 @@ namespace WheelMUD.Universe.Things
             // We need to unsubscribe each of our items to the broadcaster.
             // As well as this item
             broadcaster.UnSubscribe(this);
-            foreach (Item item in this.container)
+            foreach (Item item in container)
             {
                 item.UnSubscribe(broadcaster);
             }
@@ -849,11 +846,11 @@ namespace WheelMUD.Universe.Things
         internal AbstractContainer(IItemDataStructure ids) :
             base(ids)
         {
-            this.container = new ItemCollection(this);
-            this.containerBehavior = BehaviorManager.FindFirst<ContainerBehavior>();
-            if (this.containerBehavior == null)
+            container = new ItemCollection(this);
+            containerBehavior = BehaviorManager.FindFirst<ContainerBehavior>();
+            if (containerBehavior == null)
             {
-                this.containerBehavior = new ContainerBehavior()
+                containerBehavior = new ContainerBehavior()
                 {
                     Id = 0,
                     HoldsLiquid = false,
@@ -863,7 +860,7 @@ namespace WheelMUD.Universe.Things
                     VolumeUnitOfMeasurement = null
                 };
 
-                this.BehaviorManager.Add(this.containerBehavior);
+                BehaviorManager.Add(containerBehavior);
             }
         }
 
@@ -872,11 +869,11 @@ namespace WheelMUD.Universe.Things
         internal AbstractContainer(ItemRecord ids) :
             base(ids)
         {
-            this.container = new ItemCollection(this);
-            this.containerBehavior = BehaviorManager.FindFirst<ContainerBehavior>();           
-            if (this.containerBehavior == null)
+            container = new ItemCollection(this);
+            containerBehavior = BehaviorManager.FindFirst<ContainerBehavior>();           
+            if (containerBehavior == null)
             {
-                this.containerBehavior = new ContainerBehavior()
+                containerBehavior = new ContainerBehavior()
                                              {
                                                  Id = 0,
                                                  HoldsLiquid = false,
@@ -886,14 +883,14 @@ namespace WheelMUD.Universe.Things
                                                  VolumeUnitOfMeasurement = null
                                              };
 
-                this.BehaviorManager.Add(this.containerBehavior);
+                BehaviorManager.Add(containerBehavior);
             }
         }
 
         /// <summary>Gets the count of items in the container.</summary>
         public int Count
         {
-            get { return this.container.Count; }
+            get { return container.Count; }
         }
 
         /// <summary>Gets or sets a value indicating whether the thing is open or not.</summary>
@@ -901,9 +898,9 @@ namespace WheelMUD.Universe.Things
         {
             get
             {
-                if (this.containerBehavior != null)
+                if (containerBehavior != null)
                 {
-                    if (this.containerBehavior.IsOpen)
+                    if (containerBehavior.IsOpen)
                     {
                         return OpenState.Open;
                     }
@@ -916,15 +913,15 @@ namespace WheelMUD.Universe.Things
 
             set
             {
-                if (this.containerBehavior != null)
+                if (containerBehavior != null)
                 {
                     if (value == OpenState.Open)
                     {
-                        this.containerBehavior.IsOpen = true;
+                        containerBehavior.IsOpen = true;
                     }
                     else
                     {
-                        this.containerBehavior.IsOpen = false;
+                        containerBehavior.IsOpen = false;
                     }
                 }
             }
@@ -935,17 +932,17 @@ namespace WheelMUD.Universe.Things
         {
             get
             {
-                return this.containerBehavior;
+                return containerBehavior;
             }
 
             set
             {
-                if (this.containerBehavior != null)
+                if (containerBehavior != null)
                 {
-                    BehaviorManager.ManagedBehaviors.Remove(this.containerBehavior);
+                    BehaviorManager.ManagedBehaviors.Remove(containerBehavior);
                 }
 
-                this.containerBehavior = value;
+                containerBehavior = value;
                 BehaviorManager.Add(value);
             }
         }
@@ -954,7 +951,7 @@ namespace WheelMUD.Universe.Things
         /// <param name="index">Index of the item that is requested.</param>
         public Item this[int index]
         {
-            get { return this.container[index]; }
+            get { return container[index]; }
         }
 
         /// <summary>Subscribe to the specified broadcaster.</summary>
@@ -964,7 +961,7 @@ namespace WheelMUD.Universe.Things
             // We need to subscribe each of our items to the broadcaster,
             // as well as this item.
             broadcaster.Subscribe(this);
-            foreach (Item item in this.ContainerBehavior)
+            foreach (Item item in ContainerBehavior)
             {
                 item.Subscribe(broadcaster);
             }
@@ -977,7 +974,7 @@ namespace WheelMUD.Universe.Things
             // We need to unsubscribe each of our items to the broadcaster.
             // As well as this item
             broadcaster.UnSubscribe(this);
-            foreach (Item item in this.ContainerBehavior)
+            foreach (Item item in ContainerBehavior)
             {
                 item.UnSubscribe(broadcaster);
             }
@@ -1007,10 +1004,10 @@ namespace WheelMUD.Universe.Things
         public Consumable(ConsumableType consumableType)
             : base()
         {
-            this.consumableType = consumableType;
-            this.Description = string.Format("A piece of {0}", this.consumableType.ToString());
-            this.IsAdornment = false;
-            this.Name = this.consumableType.ToString();
+            consumableType = consumableType;
+            Description = string.Format("A piece of {0}", consumableType.ToString());
+            IsAdornment = false;
+            Name = consumableType.ToString();
 
             // TODO: Implement.
         }
@@ -1030,8 +1027,8 @@ namespace WheelMUD.Universe.Things
         public Tree(int numberResources)
             : base()
         {
-            this.NumberOfResources = numberResources;
-            this.ResourceType = string.Empty;
+            NumberOfResources = numberResources;
+            ResourceType = string.Empty;
         }
 
         /// <summary>Prevents a default instance of the Tree class from being created.</summary>
@@ -1069,9 +1066,9 @@ namespace WheelMUD.Universe.Things
         /// <returns>A new instance of a Consumable that came from the tree.</returns>
         public Thing Chop()
         {
-            if (this.NumberOfResources > 0)
+            if (NumberOfResources > 0)
             {
-                this.NumberOfResources--;
+                NumberOfResources--;
                 return new Consumable(ConsumableType.Wood);
             }
             
@@ -1093,8 +1090,8 @@ namespace WheelMUD.Universe.Things
         /// <param name="direction">The direction of the ExitEnd.</param>
         public ExitEnd(Thing room, string direction)
         {
-            this.Room = room;
-            this.Direction = direction;
+            Room = room;
+            Direction = direction;
         }
 
         /// <summary>Gets the direction this exit end faces.</summary>
@@ -1298,7 +1295,7 @@ namespace WheelMUD.Actions
         /// <param name="actionInput">The full input specified for executing the command.</param>
         public override void Execute(ActionInput actionInput)
         {
-            this.portalBehavior.Use(sender.Thing, bridge.World);
+            portalBehavior.Use(sender.Thing, bridge.World);
         }
 
         /// <summary>Checks against the guards for the command.</summary>
@@ -1306,7 +1303,7 @@ namespace WheelMUD.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -1326,8 +1323,8 @@ namespace WheelMUD.Actions
             foreach (Thing portal in portals)
             {
                 // If we can find an actual portal that is rigged right now, use that one.
-                this.portalBehavior = portal.BehaviorManager.FindFirst<PortalBehavior>();
-                if (this.portalBehavior != null)
+                portalBehavior = portal.BehaviorManager.FindFirst<PortalBehavior>();
+                if (portalBehavior != null)
                 {
                     return null;
                 }
@@ -1349,9 +1346,9 @@ namespace WheelMUD.Effects
         /// <param name="duration">duration of the effect</param>
         public override void Apply(TimeSpan duration)
         {
-            if (this.Host.Senses.Contains(SensoryType.Hearing))
+            if (Host.Senses.Contains(SensoryType.Hearing))
             {
-                this.Host.Senses[SensoryType.Hearing].Enabled = false;
+                Host.Senses[SensoryType.Hearing].Enabled = false;
             }
 
             base.Apply(duration);
@@ -1360,23 +1357,23 @@ namespace WheelMUD.Effects
         /// <summary>When effect is removed, cleanup.</summary>
         public override void Remove()
         {
-            this.RestoreHearing();
+            RestoreHearing();
         }
 
         /// <summary>What occurs when timer wears off.</summary>
         /// <param name="state">Not sure what this is.</param>
         protected override void TickElapsed(object state)
         {
-            this.RestoreHearing();
+            RestoreHearing();
             RaiseEffectElapsed();
         }
 
         /// <summary>Turn off the changes that the effect caused.</summary>
         private void RestoreHearing()
         {
-            if (this.Host.Senses.Contains(SensoryType.Hearing))
+            if (Host.Senses.Contains(SensoryType.Hearing))
             {
-                this.Host.Senses[SensoryType.Hearing].Enabled = true;
+                Host.Senses[SensoryType.Hearing].Enabled = true;
             }
         }
     }
@@ -1403,32 +1400,32 @@ namespace WheelMUD.Universe.MobileBuilders
         /// <param name="mob">The mobile data structure.</param>
         public BasicGuardianBuilder(MobRecord mob)
         {
-            this.mds = mob;
+            mds = mob;
         }
 
         /// <summary>Use the Mobile constructor to create a mobile. TODO: This seems awkward...</summary>
         public void UseMobileConstructor(Dictionary<string, object> args)
         {
-            this.mob = new Mobile(this.brain, CoreManager.Instance.PlacesManager.World, this.mds);
-            this.brain.Entity = this.mob;
+            mob = new Mobile(brain, CoreManager.Instance.PlacesManager.World, mds);
+            brain.Entity = mob;
         }
 
         /// <summary>Configures the Mobile.</summary>
         public void ConfigureMobile()
         {
-            this.mob.Name = this.mds.Name;
-            this.mob.Description = this.mds.Description;
-            this.mob.Id = this.mds.ID;
+            mob.Name = mds.Name;
+            mob.Description = mds.Description;
+            mob.Id = mds.ID;
 
- //           this.mob.Load();
-            this.brain.Start();
+ //           mob.Load();
+            brain.Start();
         }
 
         /// <summary>Creates an instanciated Mobile.</summary>
         /// <returns>The instanciated Mobile.</returns>
         public IMobile GetInstanciatedMobile()
         {
-            return this.mob;
+            return mob;
         }
     }
 }
@@ -1516,7 +1513,7 @@ public interface IEventObserver
         /// <summary>Method that will go through all adornments and save them.</summary>
         protected void SaveAdornments()
         {
-            foreach (IThingAdornment adornment in this.adornments)
+            foreach (IThingAdornment adornment in adornments)
             {
                 var thing = adornment as Thing;
                 if (thing != null)
@@ -1550,9 +1547,9 @@ public interface IEventObserver
         public Mobile(IController controller, World world, MobRecord mobDataRecord)
             : base(controller, world)
         {
-            this.Id = mobDataRecord.ID;
-            this.DataRecord = mobDataRecord;
-            this.brain.ActionReceived += this.Brain_ActionReceived;
+            Id = mobDataRecord.ID;
+            DataRecord = mobDataRecord;
+            brain.ActionReceived += Brain_ActionReceived;
         }
 
     }
@@ -1569,7 +1566,7 @@ public interface IEventObserver
             ItemBehaviorPropertyRepository itemBehaviorPropertyRepository =
                 new ItemBehaviorPropertyRepository();
 
-            foreach (Behavior behavior in this.ManagedBehaviors)
+            foreach (Behavior behavior in ManagedBehaviors)
             {
                 long behaviorId = behavior.Id;
 
@@ -1579,7 +1576,7 @@ public interface IEventObserver
                     {
                         // TODO: Track behavior by its name for reflection/MEF usage.
                         //ItemBehaviorTypeID = (long)behavior.ItemBehaviorType,
-                        ItemID = this.ItemId
+                        ItemID = ItemId
                     };
 
                     itemBehaviorRepository.Add(itemBehaviorRecord);

--- a/src/Core/ActionInput.cs
+++ b/src/Core/ActionInput.cs
@@ -20,9 +20,9 @@ namespace WheelMUD.Core
         /// <param name="controller">The controller which originated the input.</param>
         public ActionInput(string fullText, IController controller)
         {
-            this.Controller = controller;
-            this.FullText = fullText;
-            this.ParseText(this.FullText);
+            Controller = controller;
+            FullText = fullText;
+            ParseText(FullText);
         }
 
         /// <summary>Gets the full text of this action.</summary>
@@ -52,9 +52,9 @@ namespace WheelMUD.Core
             string[] words = fullText.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
             if (words.Length > 0)
             {
-                this.Noun = words[0].ToLower();
-                this.Tail = fullText.Remove(0, this.Noun.Length).Trim();
-                this.Params = words.Skip(1).ToArray();
+                Noun = words[0].ToLower();
+                Tail = fullText.Remove(0, Noun.Length).Trim();
+                Params = words.Skip(1).ToArray();
             }
         }
     }

--- a/src/Core/Attributes/ActionAliasAttribute.cs
+++ b/src/Core/Attributes/ActionAliasAttribute.cs
@@ -18,8 +18,8 @@ namespace WheelMUD.Core.Attributes
         /// <param name="category">Category that this action is part of.</param>
         public ActionAliasAttribute(string alias, CommandCategory category)
         {
-            this.Alias = alias.ToLower();
-            this.Category = category;
+            Alias = alias.ToLower();
+            Category = category;
         }
 
         /// <summary>Gets the alias attribute for the action.</summary>

--- a/src/Core/Attributes/ActionDescriptionAttribute.cs
+++ b/src/Core/Attributes/ActionDescriptionAttribute.cs
@@ -17,7 +17,7 @@ namespace WheelMUD.Core.Attributes
         /// <param name="description">The description of the action.</param>
         public ActionDescriptionAttribute(string description)
         {
-            this.Description = description;
+            Description = description;
         }
 
         /// <summary>Gets the description of this action.</summary>

--- a/src/Core/Attributes/ActionExampleAttribute.cs
+++ b/src/Core/Attributes/ActionExampleAttribute.cs
@@ -17,7 +17,7 @@ namespace WheelMUD.Core.Attributes
         /// <param name="example">The example of the action.</param>
         public ActionExampleAttribute(string example)
         {
-            this.Example = example;
+            Example = example;
         }
 
         /// <summary>Gets the description of this action.</summary>

--- a/src/Core/Attributes/ActionPrimaryAliasAttribute.cs
+++ b/src/Core/Attributes/ActionPrimaryAliasAttribute.cs
@@ -18,8 +18,8 @@ namespace WheelMUD.Core.Attributes
         /// <param name="category">The category that this action is under.</param>
         public ActionPrimaryAliasAttribute(string alias, CommandCategory category)
         {
-            this.Alias = alias;
-            this.Category = category;
+            Alias = alias;
+            Category = category;
         }
 
         /// <summary>Gets the alias attribute for the action.</summary>

--- a/src/Core/Attributes/ActionSecurityAttribute.cs
+++ b/src/Core/Attributes/ActionSecurityAttribute.cs
@@ -109,7 +109,7 @@ namespace WheelMUD.Core.Attributes
         /// <param name="role">The security role.</param>
         public ActionSecurityAttribute(SecurityRole role)
         {
-            this.Role = role;
+            Role = role;
         }
 
         /// <summary>Gets the security role specified by this attribute.</summary>

--- a/src/Core/Attributes/ExportActionAttribute.cs
+++ b/src/Core/Attributes/ExportActionAttribute.cs
@@ -24,7 +24,7 @@ namespace WheelMUD.Core
         public ExportGameActionAttribute(int priority)
             : base(typeof(GameAction))
         {
-            this.Priority = priority;
+            Priority = priority;
         }
 
         /// <summary>Initializes a new instance of the class.</summary>

--- a/src/Core/Attributes/ExportSystemAttribute.cs
+++ b/src/Core/Attributes/ExportSystemAttribute.cs
@@ -23,7 +23,7 @@ namespace WheelMUD.Core
         public ExportSystemAttribute(int systemPriority)
             : base(typeof(SystemExporter))
         {
-            this.Priority = systemPriority;
+            Priority = systemPriority;
         }
 
         /// <summary>Initializes a new instance of the ExportSystemAttribute class.</summary>

--- a/src/Core/Attributes/PlayerPromptableAttribute.cs
+++ b/src/Core/Attributes/PlayerPromptableAttribute.cs
@@ -18,8 +18,8 @@ namespace WheelMUD.Core.Attributes
         /// <param name="description">String description to be provided to the player, for example "Displays your current health,"</param>
         public PlayerPromptableAttribute(string token, string description)
         {
-            this.Token = token;
-            this.Description = description;
+            Token = token;
+            Description = description;
         }
 
         public string Token { get; private set; }

--- a/src/Core/Behaviors/AreaBehavior.cs
+++ b/src/Core/Behaviors/AreaBehavior.cs
@@ -31,7 +31,7 @@ namespace WheelMUD.Core
         public void Load()
         {
             var areaRepository = new RelationalRepository<AreaRecord>();
-            string areaNumber = this.Parent.Id.Replace("area/", string.Empty);
+            string areaNumber = Parent.Id.Replace("area/", string.Empty);
             long persistedAreaID = long.Parse(areaNumber);
             ICollection<RoomRecord> rooms = areaRepository.GetRoomsForArea(persistedAreaID);
 
@@ -50,7 +50,7 @@ namespace WheelMUD.Core
 
                 // Load this room and it's children.
                 roomBehavior.Load();
-                this.Parent.Add(currRoom);
+                Parent.Add(currRoom);
             }
         }
 

--- a/src/Core/Behaviors/Behavior.cs
+++ b/src/Core/Behaviors/Behavior.cs
@@ -24,8 +24,8 @@ namespace WheelMUD.Core
         /// <param name="instanceProperties">Dictionary of properties to spawn this behavior instance with, if any.</param>
         protected Behavior(Dictionary<string, object> instanceProperties)
         {
-            this.ID = 0;
-            this.SetDefaultProperties();
+            ID = 0;
+            SetDefaultProperties();
 
             // If we're handed a set of propertyName-propertyValue pairs (as may have come from
             // persistence of the behavior or whatnot) then restore those as actual properties.
@@ -47,27 +47,27 @@ namespace WheelMUD.Core
         public void SetParent(Thing newParent)
         {
             // Ignore SetParent requests that are already satisfied; avoid redundant eventing.
-            if (this.Parent != newParent)
+            if (Parent != newParent)
             {
-                if (this.Parent != null)
+                if (Parent != null)
                 {
-                    this.OnRemoveBehavior();
+                    OnRemoveBehavior();
                 }
-                this.Parent = newParent;
+                Parent = newParent;
                 if (newParent != null)
                 {
-                    this.OnAddBehavior();
+                    OnAddBehavior();
                 }
             }
         }
 
-        /// <summary>Called when a parent has just been assigned to this behavior. (Refer to this.Parent)</summary>
+        /// <summary>Called when a parent has just been assigned to this behavior. (Refer to Parent)</summary>
         /// <remarks>Especially helpful for registering to relevant parent events.</remarks>
         protected virtual void OnAddBehavior()
         {
         }
 
-        /// <summary>Called when the current parent of this behavior is about to be removed. (Refer to this.Parent)</summary>
+        /// <summary>Called when the current parent of this behavior is about to be removed. (Refer to Parent)</summary>
         /// <remarks>Especially helpful for unregistering from relevant parent events.</remarks>
         protected virtual void OnRemoveBehavior()
         {
@@ -79,11 +79,11 @@ namespace WheelMUD.Core
         ////    where T : Behavior, new()
         public Behavior Clone()
         {
-            Type t = this.GetType();
+            Type t = GetType();
 
             ////TODO: EXPERIMENT OPTIONS:
             ////newBehavior.CloneProperties(this);
-            ////newBehavior = (Behavior)this.MemberwiseClone();
+            ////newBehavior = (Behavior)MemberwiseClone();
 
             // Create an instance of the most-derived-type (then as Behavior for local storage).
             Behavior newBehavior = (Behavior)Activator.CreateInstance(t);
@@ -91,20 +91,20 @@ namespace WheelMUD.Core
             // Then clone this instance of that type's properties into the new instance.  We lock
             // during the operation to ensure none of our property values change as we iterate them;
             // we don't have to lock the newBehavior since nobody else has it yet.
-            lock (this.lockObject)
+            lock (lockObject)
             {
                 // All Items should be cloneable, and most derived classes should find it sufficient 
                 // to allow this base Item.Clone to take care of all the cloning.
                 // TODO: Test this.  Especially if any properties have indexers.
                 // TODO: Make sure this deep-copies things like behaviors.
-                var properties = this.GetType().GetProperties();
+                var properties = GetType().GetProperties();
                 foreach (var property in properties)
                 {
                     object value = property.GetValue(this, null);
                     property.SetValue(newBehavior, value, null);
                 }
 
-                this.ID = 0;
+                ID = 0;
             }
 
             newBehavior.ID = 0;

--- a/src/Core/Behaviors/BehaviorManager.cs
+++ b/src/Core/Behaviors/BehaviorManager.cs
@@ -20,8 +20,8 @@ namespace WheelMUD.Core
         /// <param name="parent">The parent.</param>
         public BehaviorManager(Thing parent)
         {
-            this.ManagedBehaviors = new List<Behavior>();
-            this.Parent = parent;
+            ManagedBehaviors = new List<Behavior>();
+            Parent = parent;
         }
 
         /// <summary>Gets the parent (container) of this instance.</summary>
@@ -34,9 +34,9 @@ namespace WheelMUD.Core
         {
             get
             {
-                lock (this.ManagedBehaviors)
+                lock (ManagedBehaviors)
                 {
-                    return this.ManagedBehaviors.ToList().AsReadOnly();
+                    return ManagedBehaviors.ToList().AsReadOnly();
                 }
             }
         }
@@ -66,10 +66,10 @@ namespace WheelMUD.Core
         /// </remarks>
         public void SetParent(Thing parent)
         {
-            this.Parent = parent;
-            lock (this.ManagedBehaviors)
+            Parent = parent;
+            lock (ManagedBehaviors)
             {
-                foreach (var behavior in this.ManagedBehaviors)
+                foreach (var behavior in ManagedBehaviors)
                 {
                     behavior.SetParent(parent);
                 }
@@ -92,9 +92,9 @@ namespace WheelMUD.Core
         /// <returns>The first managed behavior of the specified type, if found, else null.</returns>
         public U FindFirst<U>() where U : Behavior
         {
-            lock (this.ManagedBehaviors)
+            lock (ManagedBehaviors)
             {
-                return this.ManagedBehaviors.OfType<U>().FirstOrDefault();
+                return ManagedBehaviors.OfType<U>().FirstOrDefault();
             }
         }
 
@@ -103,9 +103,9 @@ namespace WheelMUD.Core
         /// <returns>A filtered list of Behaviors of the specified type.</returns>
         public List<T> OfType<T>() where T : Behavior
         {
-            lock (this.ManagedBehaviors)
+            lock (ManagedBehaviors)
             {
-                return this.ManagedBehaviors.OfType<T>().ToList();
+                return ManagedBehaviors.OfType<T>().ToList();
             }
         }
 
@@ -113,12 +113,12 @@ namespace WheelMUD.Core
         /// <param name="newBehavior">The new behavior to add.</param>
         public void Add(Behavior newBehavior)
         {
-            lock (this.ManagedBehaviors)
+            lock (ManagedBehaviors)
             {
-                if (!this.ManagedBehaviors.Contains(newBehavior))
+                if (!ManagedBehaviors.Contains(newBehavior))
                 {
-                    this.ManagedBehaviors.Add(newBehavior);
-                    newBehavior.SetParent(this.Parent);
+                    ManagedBehaviors.Add(newBehavior);
+                    newBehavior.SetParent(Parent);
                 }
             }
         }
@@ -127,11 +127,11 @@ namespace WheelMUD.Core
         /// <param name="behavior">The behavior to remove.</param>
         public void Remove(Behavior behavior)
         {
-            lock (this.ManagedBehaviors)
+            lock (ManagedBehaviors)
             {
-                if (this.ManagedBehaviors.Contains(behavior))
+                if (ManagedBehaviors.Contains(behavior))
                 {
-                    this.ManagedBehaviors.Remove(behavior);
+                    ManagedBehaviors.Remove(behavior);
                     behavior.SetParent(null);
                 }
             }
@@ -153,13 +153,13 @@ namespace WheelMUD.Core
             // stacks have their Count property set appropriately.
             lock (existingManager.ManagedBehaviors)
             {
-                lock (this.ManagedBehaviors)
+                lock (ManagedBehaviors)
                 {
-                    this.ManagedBehaviors.Clear();
+                    ManagedBehaviors.Clear();
                     foreach (Behavior behavior in existingManager.ManagedBehaviors)
                     {
                         Behavior clonedBehavior = behavior.Clone();
-                        this.ManagedBehaviors.Add(clonedBehavior);
+                        ManagedBehaviors.Add(clonedBehavior);
                     }
                 }
             }

--- a/src/Core/Behaviors/EnterableExitableBehavior.cs
+++ b/src/Core/Behaviors/EnterableExitableBehavior.cs
@@ -29,7 +29,7 @@ namespace WheelMUD.Core
         public EnterableExitableBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets the exit command.</summary>
@@ -62,14 +62,14 @@ namespace WheelMUD.Core
             var message = new SensoryMessage(
                 SensoryType.Sight,
                 100,
-                new ContextualString(actor, this.Parent)
+                new ContextualString(actor, Parent)
                 {
-                    ToOriginator = $"You enter {this.Parent.Name}.",
+                    ToOriginator = $"You enter {Parent.Name}.",
                     ToReceiver = $"{actor.Name} enters you.",
-                    ToOthers = $"{actor.Name} enters {this.Parent.Name}.",
+                    ToOthers = $"{actor.Name} enters {Parent.Name}.",
                 });
 
-            movableBehavior.Move(this.Parent, this.Parent, message, message);
+            movableBehavior.Move(Parent, Parent, message, message);
         }
 
         /// <summary>Sets the default properties of this behavior instance.</summary>

--- a/src/Core/Behaviors/ExitBehavior.cs
+++ b/src/Core/Behaviors/ExitBehavior.cs
@@ -38,7 +38,7 @@ namespace WheelMUD.Core
         public ExitBehavior()
             : base(null)
         {
-            this.commands = new ExitBehaviorCommands(this);
+            commands = new ExitBehaviorCommands(this);
         }
 
         /// <summary>Initializes a new instance of the ExitBehavior class.</summary>
@@ -47,8 +47,8 @@ namespace WheelMUD.Core
         public ExitBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.commands = new ExitBehaviorCommands(this);
-            this.ID = instanceID;
+            commands = new ExitBehaviorCommands(this);
+            ID = instanceID;
         }
 
         /// <summary>Adds the destination.</summary>
@@ -56,10 +56,10 @@ namespace WheelMUD.Core
         /// <param name="destinationID">The destination ID.</param>
         public void AddDestination(string movementCommand, string destinationID)
         {
-            var existingDestination = (from d in this.destinations where d.TargetID == destinationID select d).FirstOrDefault();
+            var existingDestination = (from d in destinations where d.TargetID == destinationID select d).FirstOrDefault();
             if (existingDestination == null)
             {
-                this.destinations.Add(new DestinationInfo(movementCommand.ToLower(), destinationID));
+                destinations.Add(new DestinationInfo(movementCommand.ToLower(), destinationID));
             }
         }
 
@@ -69,7 +69,7 @@ namespace WheelMUD.Core
         public Thing GetDestination(Thing fromLocation)
         {
             // Find the first destination info that doesn't match this location.
-            var destinationInfo = (from d in this.destinations
+            var destinationInfo = (from d in destinations
                                    where d.TargetID != fromLocation.Id
                                    select d).FirstOrDefault();
 
@@ -114,7 +114,7 @@ namespace WheelMUD.Core
             }
 
             // Find the target location to be reached from here.
-            DestinationInfo destinationInfo = this.GetDestinationFrom(thingToMove.Parent.Id);
+            DestinationInfo destinationInfo = GetDestinationFrom(thingToMove.Parent.Id);
             if (destinationInfo == null)
             {
                 // There was no destination reachable from the thing's starting location.
@@ -152,7 +152,7 @@ namespace WheelMUD.Core
             var leaveMessage = new SensoryMessage(SensoryType.Sight, 100, leaveContextMessage);
             var arriveMessage = new SensoryMessage(SensoryType.Sight, 100, arriveContextMessage);
 
-            return movableBehavior.Move(destination, this.Parent, leaveMessage, arriveMessage);
+            return movableBehavior.Move(destination, Parent, leaveMessage, arriveMessage);
         }
 
         /// <summary>Gets the exit command from.</summary>
@@ -160,44 +160,44 @@ namespace WheelMUD.Core
         /// <returns>Returns the exit direction.</returns>
         public string GetExitCommandFrom(Thing fromLocation)
         {
-            var destination = this.GetDestinationFrom(fromLocation.Id);
+            var destination = GetDestinationFrom(fromLocation.Id);
             return destination?.ExitCommand;
         }
 
-        /// <summary>Called when a parent has just been assigned to this behavior. (Refer to this.Parent)</summary>
+        /// <summary>Called when a parent has just been assigned to this behavior. (Refer to Parent)</summary>
         protected override void OnAddBehavior()
         {
             // TODO: Greatly simplify: use shared logic with ParentMovementEvent! React to OnRemoveBehavior too!
             // When adding this behavior to an exit Thing, if that thing has a parent, rig up the appropriate
             // context command for that place to reach the other.
-            if (this.Parent.Parent != null)
+            if (Parent.Parent != null)
             {
                 // TODO: Reuse the same functionality as the movement event handler for command rigging (if we can).
-                this.ParentMovementEventHandler(this.Parent, null);
+                ParentMovementEventHandler(Parent, null);
             }
 
             // Rig up to the parent (exit) Thing's 'moved' events so we can fix the exit targets back up (or
             // rig them up the first time if it didn't yet have such a parent).
-            this.Parent.Eventing.MovementEvent += this.ParentMovementEventHandler;
+            Parent.Eventing.MovementEvent += ParentMovementEventHandler;
 
-            Thing initialPlace = this.Parent.Parent;
+            Thing initialPlace = Parent.Parent;
             if (initialPlace != null)
             {
                 // If the thing we already added the behavior to is already within something, add the initial exit command(s).
-                this.AddExitContextCommands(initialPlace);
+                AddExitContextCommands(initialPlace);
             }
 
             base.OnAddBehavior();
         }
 
-        /// <summary>Called when the current parent of this behavior is about to be removed. (Refer to this.Parent)</summary>
+        /// <summary>Called when the current parent of this behavior is about to be removed. (Refer to Parent)</summary>
         protected override void OnRemoveBehavior()
         {
             // When removing this behavior from a thing, we need to unrig any context commands we added to it.
-            string commandText = this.GetExitCommandFrom(this.Parent);
+            string commandText = GetExitCommandFrom(Parent);
             if (!string.IsNullOrEmpty(commandText))
             {
-                this.Parent.Commands.Remove(commandText);
+                Parent.Commands.Remove(commandText);
             }
 
             base.OnRemoveBehavior();
@@ -206,7 +206,7 @@ namespace WheelMUD.Core
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.destinations = new List<DestinationInfo>();
+            destinations = new List<DestinationInfo>();
         }
 
         /// <summary>Handle the events of our parent moving; need to adjust our exit context commands and such.</summary>
@@ -217,22 +217,22 @@ namespace WheelMUD.Core
             // If our parent (the thing with exit behavior) was removed from something (like a room)...
             var removeChildEvent = e as RemoveChildEvent;
             if (removeChildEvent != null &&
-                removeChildEvent.ActiveThing == this.Parent &&
+                removeChildEvent.ActiveThing == Parent &&
                 removeChildEvent.OldParent != null)
             {
                 // Remove the old exit command, if one was rigged up to the old location.
-                string oldExitCommand = this.GetExitCommandFrom(removeChildEvent.OldParent);
+                string oldExitCommand = GetExitCommandFrom(removeChildEvent.OldParent);
                 removeChildEvent.OldParent.Commands.Remove(oldExitCommand);
             }
 
             // If our parent (the thing with exit behavior) was placed in something (like a room)...
             var addChildEvent = e as AddChildEvent;
             if (addChildEvent != null &&
-                addChildEvent.ActiveThing == this.Parent &&
+                addChildEvent.ActiveThing == Parent &&
                 addChildEvent.NewParent != null)
             {
                 // Add the appropriate exit command for the new location.
-                this.AddExitContextCommands(addChildEvent.NewParent);
+                AddExitContextCommands(addChildEvent.NewParent);
             }
         }
 
@@ -240,11 +240,11 @@ namespace WheelMUD.Core
         /// <param name="location">The location to add exit context command(s) to.</param>
         private void AddExitContextCommands(Thing location)
         {
-            var mainExitCommand = this.GetExitCommandFrom(location);
-            var secondExitAlias = this.GetSecondaryExitAlias(mainExitCommand);
+            var mainExitCommand = GetExitCommandFrom(location);
+            var secondExitAlias = GetSecondaryExitAlias(mainExitCommand);
             if (!string.IsNullOrEmpty(mainExitCommand))
             {
-                var contextCommand = new ContextCommand(this.commands, mainExitCommand, ContextAvailability.ToChildren, SecurityRole.all);
+                var contextCommand = new ContextCommand(commands, mainExitCommand, ContextAvailability.ToChildren, SecurityRole.all);
                 // TODO: OLC should take care to avoid duplicate exits in a room, but we might need more advanced protections to prevent needing
                 //       multiple context commands of the same alias from having to be attached to one Thing. (Try to keep fast command-finding.)
                 Debug.Assert(!location.Commands.ContainsKey(mainExitCommand), "The Thing this ExitBehavior attached to already had command: " + mainExitCommand);
@@ -284,7 +284,7 @@ namespace WheelMUD.Core
         /// <returns>A destination for the specified origin Thing ID.</returns>
         private DestinationInfo GetDestinationFrom(string originID)
         {
-            return (from d in this.destinations where originID != d.TargetID select d).FirstOrDefault();
+            return (from d in destinations where originID != d.TargetID select d).FirstOrDefault();
         }
 
         /// <summary>A command handler for this exit's context commands.</summary>
@@ -315,7 +315,7 @@ namespace WheelMUD.Core
             public override void Execute(ActionInput actionInput)
             {
                 // If the user invoked the context command, move them through this exit.
-                this.exitBehavior.MoveThrough(actionInput.Controller.Thing);
+                exitBehavior.MoveThrough(actionInput.Controller.Thing);
             }
 
             /// <summary>Checks against the guards for the command.</summary>
@@ -323,7 +323,7 @@ namespace WheelMUD.Core
             /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
             public override string Guards(ActionInput actionInput)
             {
-                string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+                string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
                 if (commonFailure != null)
                 {
                     return commonFailure;
@@ -346,9 +346,9 @@ namespace WheelMUD.Core
             /// <param name="targetID">The ID of the target destination.</param>
             public DestinationInfo(string command, string targetID)
             {
-                this.ExitCommand = command;
-                this.TargetID = targetID;
-                this.CachedTarget = new SimpleWeakReference<Thing>(null);
+                ExitCommand = command;
+                TargetID = targetID;
+                CachedTarget = new SimpleWeakReference<Thing>(null);
             }
 
             /// <summary>Gets or sets the command which is used to reach the target destination.</summary>

--- a/src/Core/Behaviors/FollowedBehavior.cs
+++ b/src/Core/Behaviors/FollowedBehavior.cs
@@ -36,7 +36,7 @@ namespace WheelMUD.Core.Behaviors
         public FollowedBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets the list of followers.</summary>
@@ -46,7 +46,7 @@ namespace WheelMUD.Core.Behaviors
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.Followers = new HashSet<Thing>();
+            Followers = new HashSet<Thing>();
         }
     }
 }

--- a/src/Core/Behaviors/FollowingBehavior.cs
+++ b/src/Core/Behaviors/FollowingBehavior.cs
@@ -36,7 +36,7 @@ namespace WheelMUD.Core.Behaviors
         public FollowingBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets or sets the target being followed.</summary>
@@ -45,13 +45,13 @@ namespace WheelMUD.Core.Behaviors
         {
             get
             {
-                return (this.target == null) ? null : this.target.Target;
+                return (target == null) ? null : target.Target;
             }
 
             set
             {
                 // Strengthen the reference.
-                var localTarget = this.target;
+                var localTarget = target;
 
                 // Do nothing if the target isn't changing.
                 if ((localTarget != null && localTarget.Target == value) || (localTarget == null && value == null))
@@ -62,26 +62,26 @@ namespace WheelMUD.Core.Behaviors
                 if (value == null)
                 {
                     // localTarget won't also be null, per above
-                    this.RemoveTarget();
+                    RemoveTarget();
                 }
                 else if (localTarget == null || localTarget.Target == null)
                 {
                     // value won't also be null, per above
-                    this.AddTarget(value);
+                    AddTarget(value);
                 }
                 else
                 {
                     // localTarget and value are different objects
-                    this.ChangeTarget(value);
+                    ChangeTarget(value);
                 }
             }
         }
 
-        /// <summary>Called when the current parent of this behavior is about to be removed. (Refer to this.Parent.)</summary>
+        /// <summary>Called when the current parent of this behavior is about to be removed. (Refer to Parent.)</summary>
         protected override void OnRemoveBehavior()
         {
             // Setting Target to null ensures the MovementEvent handler is removed.
-            this.Target = null;
+            Target = null;
         }
 
         /// <summary>Sets the default properties of this behavior instance.</summary>
@@ -94,14 +94,14 @@ namespace WheelMUD.Core.Behaviors
         /// <param name="e">The e.</param>
         private void ProcessMovementEvent(Thing root, GameEvent e)
         {
-            var self = this.Parent;
+            var self = Parent;
             var currentRoom = self.Parent;
             var arriveEvent = e as ArriveEvent;
 
-            if (arriveEvent != null && arriveEvent.ActiveThing == this.Target && arriveEvent.GoingFrom == currentRoom)
+            if (arriveEvent != null && arriveEvent.ActiveThing == Target && arriveEvent.GoingFrom == currentRoom)
             {
-                var leaveMessage = this.CreateLeaveMessage(self);
-                var arriveMessage = this.CreateArriveMessage(self);
+                var leaveMessage = CreateLeaveMessage(self);
+                var arriveMessage = CreateArriveMessage(self);
 
                 var movableBehavior = self.Behaviors.FindFirst<MovableBehavior>();
                 movableBehavior.Move(arriveEvent.GoingTo, arriveEvent.GoingVia, leaveMessage, arriveMessage);
@@ -109,22 +109,22 @@ namespace WheelMUD.Core.Behaviors
         }
 
         /// <summary>Adds the new target.</summary>
-        /// <remarks>Precondition: this.target is null, newTarget is non-null.</remarks>
+        /// <remarks>Precondition: target is null, newTarget is non-null.</remarks>
         /// <param name="newTarget">The new target.</param>
         private void AddTarget(Thing newTarget)
         {
-            var self = this.Parent;
+            var self = Parent;
             if (self != null)
             {
-                var message = this.CreateFollowMessage(self, newTarget);
+                var message = CreateFollowMessage(self, newTarget);
                 var followEvent = new FollowEvent(self, message, self, newTarget);
 
                 self.Eventing.OnMovementRequest(followEvent, EventScope.ParentsDown);
 
                 if (!followEvent.IsCancelled)
                 {
-                    this.target = new SimpleWeakReference<Thing>(newTarget);
-                    newTarget.Eventing.MovementEvent += this.ProcessMovementEvent;
+                    target = new SimpleWeakReference<Thing>(newTarget);
+                    newTarget.Eventing.MovementEvent += ProcessMovementEvent;
                     self.Eventing.OnMovementEvent(followEvent, EventScope.ParentsDown);
                 }
             }
@@ -134,42 +134,42 @@ namespace WheelMUD.Core.Behaviors
         /// Changes the target being followed.
         /// Simply removes the existing target and adds the specified new target using existing
         /// methods. This will emit messages for both activities.
-        /// Precondition: this.target and newTarget are both non-null.
+        /// Precondition: target and newTarget are both non-null.
         /// </summary>
         /// <param name="newTarget">The new target.</param>
         private void ChangeTarget(Thing newTarget)
         {
-            this.RemoveTarget();
-            this.AddTarget(newTarget);
+            RemoveTarget();
+            AddTarget(newTarget);
         }
 
         /// <summary>Stops following the current target.</summary>
-        /// <remarks>Precondition: this.target is non-null.</remarks>
+        /// <remarks>Precondition: target is non-null.</remarks>
         private void RemoveTarget()
         {
-            var self = this.Parent;
+            var self = Parent;
             if (self != null)
             {
-                var oldTarget = this.target.Target;
+                var oldTarget = target.Target;
 
                 if (oldTarget != null)
                 {
                     // Stop tracking the old target's movements
-                    this.target.Target.Eventing.MovementEvent -= this.ProcessMovementEvent;
+                    target.Target.Eventing.MovementEvent -= ProcessMovementEvent;
 
                     // Create an event with the appropriate "unfollow" sensory messages
-                    var message = this.CreateUnfollowMessage(this.Parent, oldTarget);
-                    var followEvent = new FollowEvent(this.Parent, message, this.Parent, oldTarget);
+                    var message = CreateUnfollowMessage(Parent, oldTarget);
+                    var followEvent = new FollowEvent(Parent, message, Parent, oldTarget);
 
-                    this.Parent.Eventing.OnMovementRequest(followEvent, EventScope.ParentsDown);
+                    Parent.Eventing.OnMovementRequest(followEvent, EventScope.ParentsDown);
 
                     if (!followEvent.IsCancelled)
                     {
                         // Finally make the change
-                        this.target.Target = null;
+                        target.Target = null;
 
                         // Broadcast the change
-                        this.Parent.Eventing.OnMovementEvent(followEvent, EventScope.ParentsDown);
+                        Parent.Eventing.OnMovementEvent(followEvent, EventScope.ParentsDown);
                     }
                 }
             }
@@ -200,10 +200,10 @@ namespace WheelMUD.Core.Behaviors
 
         private SensoryMessage CreateArriveMessage(Thing self)
         {
-            var message = new ContextualString(self, this.Target)
+            var message = new ContextualString(self, Target)
             {
                 ToReceiver = $"{self.Name} arrives, following you.",
-                ToOthers = $"{self.Name} arrives, following {this.Target.Name}.",
+                ToOthers = $"{self.Name} arrives, following {Target.Name}.",
             };
 
             return new SensoryMessage(SensoryType.Sight, 100, message);
@@ -211,10 +211,10 @@ namespace WheelMUD.Core.Behaviors
 
         private SensoryMessage CreateLeaveMessage(Thing self)
         {
-            var message = new ContextualString(self, this.Target)
+            var message = new ContextualString(self, Target)
             {
-                ToOriginator = $"You follow {this.Target.Name}.",
-                ToOthers = $"{self.Name} leaves, following {this.Target.Name}."
+                ToOriginator = $"You follow {Target.Name}.",
+                ToOthers = $"{self.Name} leaves, following {Target.Name}."
             };
 
             return new SensoryMessage(SensoryType.Sight, 100, message);

--- a/src/Core/Behaviors/LivingBehavior.cs
+++ b/src/Core/Behaviors/LivingBehavior.cs
@@ -24,7 +24,7 @@ namespace WheelMUD.Core
         public LivingBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets or sets the consciousness of the entity.</summary>
@@ -33,7 +33,7 @@ namespace WheelMUD.Core
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.Consciousness = Consciousness.Awake;
+            Consciousness = Consciousness.Awake;
         }
     }
 }

--- a/src/Core/Behaviors/MobileBehavior.cs
+++ b/src/Core/Behaviors/MobileBehavior.cs
@@ -25,7 +25,7 @@ namespace WheelMUD.Core
         public MobileBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Receives an event.</summary>
@@ -33,7 +33,7 @@ namespace WheelMUD.Core
         /// <param name="theEvent">The event to be received.</param>
         public void Receive(Thing root, GameEvent theEvent)
         {
-            ////this.brain.ProcessStimulus(theEvent);
+            ////brain.ProcessStimulus(theEvent);
         }
 
         /// <summary>Sets the default properties of this behavior instance.</summary>
@@ -43,33 +43,33 @@ namespace WheelMUD.Core
             //       want to mess with AI too much right now especially since Fasta is working on it.
             // Prepare to handle receiving all relevant sensory events (not requests) which have 
             // happened within the player's perception, and relay the sensory message to the player.
-            if (this.Parent != null)
+            if (Parent != null)
             {
-                this.Parent.Eventing.CombatEvent += this.Receive;
-                this.Parent.Eventing.MovementEvent += this.Receive;
-                this.Parent.Eventing.CommunicationEvent += this.Receive;
-                this.Parent.Eventing.MiscellaneousEvent += this.Receive;
+                Parent.Eventing.CombatEvent += Receive;
+                Parent.Eventing.MovementEvent += Receive;
+                Parent.Eventing.CommunicationEvent += Receive;
+                Parent.Eventing.MiscellaneousEvent += Receive;
             }
         }
 
-        // TODO: After moving, do this.ProcessSurroundings();
+        // TODO: After moving, do ProcessSurroundings();
 
         /* TODO: Ensure mobile entities are loaded just like any other entity...
         /// <summary>Loads the mobile.</summary>
         public void Load()
         {
             // TODO: Stuff should be loaded from the Data Layer instead of using temp values.
-            this.Stats.Add("health", new StatHP(Controller, 100, 100));
-            this.Stats.Add("power", new Stat(Controller, "Power", 100, 0, 100, true));
-            this.Stats.Add("strength", new Stat(Controller, "Srength", 40, 0, 100, true));
-            this.Stats.Add("balance", new Stat(Controller, "Balance", 1, 0, 1, false));
-            this.Stats.Add("mobility", new Stat(Controller, "Mobility", 2, -10, 2, false));
-            this.Stats.Add("agility", new Stat(Controller, "Agility", 2, -10, 2, true));
-            this.Stats.Add("perception", new Stat(Controller, "Perception", 2, -10, 2, false));
+            Stats.Add("health", new StatHP(Controller, 100, 100));
+            Stats.Add("power", new Stat(Controller, "Power", 100, 0, 100, true));
+            Stats.Add("strength", new Stat(Controller, "Srength", 40, 0, 100, true));
+            Stats.Add("balance", new Stat(Controller, "Balance", 1, 0, 1, false));
+            Stats.Add("mobility", new Stat(Controller, "Mobility", 2, -10, 2, false));
+            Stats.Add("agility", new Stat(Controller, "Agility", 2, -10, 2, true));
+            Stats.Add("perception", new Stat(Controller, "Perception", 2, -10, 2, false));
 
-            this.Commands.Add("punch", new Command("punch", SecurityRole.mobile));
+            Commands.Add("punch", new Command("punch", SecurityRole.mobile));
 
-            this.LoadInventory();
+            LoadInventory();
         }
 
         /// <summary>Saves the mobile.</summary>
@@ -77,14 +77,14 @@ namespace WheelMUD.Core
         {
             var repository = new MobRepository();
 
-            if (this.Id == 0)
+            if (Id == 0)
             {
-                repository.Add(this.DataRecord);
-                this.Id = this.DataRecord.ID;
+                repository.Add(DataRecord);
+                Id = DataRecord.ID;
             }
             else
             {
-                repository.Update(this.DataRecord);
+                repository.Update(DataRecord);
             }
         }*/
     }

--- a/src/Core/Behaviors/MovableBehavior.cs
+++ b/src/Core/Behaviors/MovableBehavior.cs
@@ -25,7 +25,7 @@ namespace WheelMUD.Core
         public MovableBehavior(long instanceId, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceId;
+            ID = instanceId;
         }
 
         // TODO: OpensClosesBehavior needs to listen for movement events and set e.Cancel if the transition object
@@ -43,7 +43,7 @@ namespace WheelMUD.Core
         /// <returns>True if the entity was successfully moved, else false.</returns>
         public bool Move(Thing destination, Thing goingVia, SensoryMessage leavingMessage, SensoryMessage arrivingMessage)
         {
-            Thing actor = this.Parent;
+            Thing actor = Parent;
             Thing goingFrom = actor.Parent;
 
             // Prepare events to request and send (if not cancelled).
@@ -81,7 +81,7 @@ namespace WheelMUD.Core
             //       up by the ExitBehavior, so this shouldn't be needed?
             // TODO: Send a movement Request, then if not Cancelled, a movement Event.
             //direction = direction.ToLower();
-            //Thing currentRoom = this.Parent;
+            //Thing currentRoom = Parent;
             //if (currentRoom.Children.ContainsKey(direction))
             //{
             //    Exit exit = currentRoom.Exits[direction];

--- a/src/Core/Behaviors/MultipleParentsBehavior.cs
+++ b/src/Core/Behaviors/MultipleParentsBehavior.cs
@@ -26,7 +26,7 @@ namespace WheelMUD.Core
         public MultipleParentsBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets the secondary parents.</summary>
@@ -38,8 +38,8 @@ namespace WheelMUD.Core
         public void AddParent(Thing newParent)
         {
             // Tracking parents for our attached thing only makes sense if we are indeed attached to a thing.
-            // (Avoid race conditions against behavior attachment by using a temporary reference to this.Parent).
-            var thing = this.Parent;
+            // (Avoid race conditions against behavior attachment by using a temporary reference to Parent).
+            var thing = Parent;
             if (thing != null)
             {
                 // If the object we apply to does not have a primary Parent yet, simply Add it to set Parent.
@@ -51,12 +51,12 @@ namespace WheelMUD.Core
 
                 // Go through our current secondary parents, and if we don't already track this as one of the
                 // parents, then add it.
-                if (this.SecondaryParents.Contains(newParent))
+                if (SecondaryParents.Contains(newParent))
                 {
                     return;
                 }
 
-                this.SecondaryParents.Add(newParent);
+                SecondaryParents.Add(newParent);
             }
         }
 
@@ -65,8 +65,8 @@ namespace WheelMUD.Core
         public void RemoveParent(Thing oldParent)
         {
             // Tracking parents for our attached thing only makes sense if we are indeed attached to a thing.
-            // (Avoid race conditions against behavior attachment by using a temporary reference to this.Parent).
-            var thing = this.Parent;
+            // (Avoid race conditions against behavior attachment by using a temporary reference to Parent).
+            var thing = Parent;
             if (thing != null)
             {
                 // If our thing has the parent being removed as it's primary parent, we need to shift one of the
@@ -74,19 +74,19 @@ namespace WheelMUD.Core
                 // (If there are no remaining secondary parents, this will correctly set the Parent as null.)
                 if (thing.Parent == oldParent)
                 {
-                    var newPrimaryParent = (from p in this.SecondaryParents where p != oldParent select p).FirstOrDefault();
+                    var newPrimaryParent = (from p in SecondaryParents where p != oldParent select p).FirstOrDefault();
                     thing.RigParentUnsafe(newPrimaryParent);
                 }
 
                 // Remove this oldParent from our tracked parents (if tracked).
-                this.SecondaryParents.Remove(oldParent);
+                SecondaryParents.Remove(oldParent);
             }
         }
 
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.SecondaryParents = new List<Thing>();
+            SecondaryParents = new List<Thing>();
         }
     }
 }

--- a/src/Core/Behaviors/RoomBehavior.cs
+++ b/src/Core/Behaviors/RoomBehavior.cs
@@ -36,7 +36,7 @@ namespace WheelMUD.Core
         public RoomBehavior(long instanceId, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceId;
+            ID = instanceId;
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace WheelMUD.Core
         {
             get
             {
-                return this.visuals;
+                return visuals;
             }
         }
 
@@ -61,7 +61,7 @@ namespace WheelMUD.Core
         /// <returns>A string to describe the visual item, or null if the item was not found.</returns>
         public string FindVisual(string partialTerm)
         {
-            var matches = this.visuals.Where(pair => pair.Key.StartsWith(partialTerm)).Select(pair => pair.Value);
+            var matches = visuals.Where(pair => pair.Key.StartsWith(partialTerm)).Select(pair => pair.Value);
             return matches.FirstOrDefault();
         }
 
@@ -74,7 +74,7 @@ namespace WheelMUD.Core
             // non-standard exits should be loaded just like any other generic Thing.
             // TODO: These should come as part of the world areas with the document repository, so that
             //       exit Things could get customized with brand new Behaviors without difficulty, etc.
-            string roomNumber = this.Parent.Id.Replace("room/", string.Empty);
+            string roomNumber = Parent.Id.Replace("room/", string.Empty);
             long persistedRoomID = long.Parse(roomNumber);
             ICollection<ExitRecord> exits = roomRepository.LoadExitsForRoom(persistedRoomID);
 
@@ -99,7 +99,7 @@ namespace WheelMUD.Core
                 exitBehavior.AddDestination(exitRecord.DirectionB, exitRoomA);
 
                 // Add this Exit Thing as a child of the Room Thing.
-                this.Parent.Add(exit);
+                Parent.Add(exit);
 
                 // Look for the other room; if it exists, add this exit to that room too, else
                 // set up an event reaction to add the exit to the room when it gets loaded.
@@ -124,10 +124,10 @@ namespace WheelMUD.Core
             // If this room is the secondary parent for a pending exit rigging, rig it up.
             lock (pendingExitRiggings)
             {
-                var matchedExitRiggings = this.FindMatchedPendingExitRiggings(this.Parent.Id);
+                var matchedExitRiggings = FindMatchedPendingExitRiggings(Parent.Id);
                 foreach (var matchedExitRigging in matchedExitRiggings)
                 {
-                    this.Parent.Add(matchedExitRigging.ExitThing);
+                    Parent.Add(matchedExitRigging.ExitThing);
                     pendingExitRiggings.Remove(matchedExitRigging);
                 }
             }

--- a/src/Core/Behaviors/UserControlledBehavior.cs
+++ b/src/Core/Behaviors/UserControlledBehavior.cs
@@ -45,7 +45,7 @@ namespace WheelMUD.Core
         public UserControlledBehavior(long instanceId, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceId;
+            ID = instanceId;
 
             // TODO: Subscribe to movement events for the attached Thing: Whenever a user-controlled
             // thing is moved from one location to another, we want to respond by automatically "looking"
@@ -68,7 +68,7 @@ namespace WheelMUD.Core
         /// <summary>Gets the human-readable list of role names attached to this user-controlled thing.</summary>
         public IEnumerable<string> GetRoleNames()
         {
-            return from role in this.GetIndividualSecurityRoles() select role.ToString();
+            return from role in GetIndividualSecurityRoles() select role.ToString();
         }
 
         /// <summary>Gets the individual security roles associated with this user.</summary>
@@ -76,7 +76,7 @@ namespace WheelMUD.Core
         {
             foreach (var role in SecurityRoleHelpers.IndividualSecurityRoles)
             {
-                if ((this.SecurityRoles & role) != SecurityRole.none)
+                if ((SecurityRoles & role) != SecurityRole.none)
                 {
                     yield return role;
                 }
@@ -86,7 +86,7 @@ namespace WheelMUD.Core
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.Controller = null;
+            Controller = null;
         }
     }
 }

--- a/src/Core/Behaviors/WorldBehavior.cs
+++ b/src/Core/Behaviors/WorldBehavior.cs
@@ -34,7 +34,7 @@ namespace WheelMUD.Core
         public WorldBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Loads areas into the world.</summary>
@@ -57,7 +57,7 @@ namespace WheelMUD.Core
 
                 // Load this area and it's children.
                 areaBehavior.Load();
-                this.Parent.Add(area);
+                Parent.Add(area);
             }
         }
 
@@ -66,7 +66,7 @@ namespace WheelMUD.Core
         /// <returns>The Room found.</returns>
         public Thing FindRoom(string roomId)
         {
-            ////foreach (KeyValuePair<long, Thing> kvp in this.Areas)
+            ////foreach (KeyValuePair<long, Thing> kvp in Areas)
             ////{
             ////    if (kvp.Value.Rooms.ContainsKey(roomId))
             ////    {
@@ -74,7 +74,7 @@ namespace WheelMUD.Core
             ////    }
             ////}
 
-            ////Thing roomBehavior = this.roomsCache[roomId];
+            ////Thing roomBehavior = roomsCache[roomId];
             Thing roomBehavior = null;
 
             if (roomBehavior == null)
@@ -85,13 +85,13 @@ namespace WheelMUD.Core
             return roomBehavior.Parent;
         }
 
-        /// <summary>Called when a parent has just been assigned to this behavior. (Refer to this.Parent.)</summary>
+        /// <summary>Called when a parent has just been assigned to this behavior. (Refer to Parent.)</summary>
         protected override void OnAddBehavior()
         {
             // Once our WorldBehavior is attached to a thing, ensure that thing isn't currently a
             // child of anything else, and don't let that happen later either.
-            Debug.Assert(this.Parent.Parent == null, "A world cannot be a child of any other thing.");
-            this.Parent.Eventing.MovementRequest += this.DenyWorldParentChanges;
+            Debug.Assert(Parent.Parent == null, "A world cannot be a child of any other thing.");
+            Parent.Eventing.MovementRequest += DenyWorldParentChanges;
         }
 
         /// <summary>Sets the default properties of this behavior instance.</summary>
@@ -104,7 +104,7 @@ namespace WheelMUD.Core
         /// <param name="e">The event arguments.</param>
         private void DenyWorldParentChanges(Thing sender, CancellableGameEvent e)
         {
-            if (e.ActiveThing == this.Parent)
+            if (e.ActiveThing == Parent)
             {
                 var addChildRequest = e as AddChildEvent;
                 if (addChildRequest != null)

--- a/src/Core/CommandSystem/Command.cs
+++ b/src/Core/CommandSystem/Command.cs
@@ -23,13 +23,13 @@ namespace WheelMUD.Core
         {
             if (type != null)
             {
-                this.Constructor = type.GetConstructor(new Type[] { });
-                this.Name = type.Name;
+                Constructor = type.GetConstructor(new Type[] { });
+                Name = type.Name;
             }
 
-            this.Description = description;
-            this.Example = example;
-            this.SecurityRole = securityRole;
+            Description = description;
+            Example = example;
+            SecurityRole = securityRole;
         }
 
         /// <summary>Initializes a new instance of the Command class.</summary>

--- a/src/Core/CommandSystem/CommandCreator.cs
+++ b/src/Core/CommandSystem/CommandCreator.cs
@@ -45,10 +45,10 @@ namespace WheelMUD.CommandSystem
             //     want to select the context command attached to the closest match for "door" as our command; if
             //     there are still multiple targets, we can start a conflict resolution prompt, etc.  Individual non-
             //     context commands may also wish to use such targeting code, so it should be built to be reusable.
-            ScriptingCommand command = this.TryCreateMasterCommand(actionInput, 0) ??
-                                       this.TryCreateMasterCommand(actionInput, 1) ??
-                                       this.TryCreateContextCommand(actionInput, 0) ??
-                                       this.TryCreateContextCommand(actionInput, 1);
+            ScriptingCommand command = TryCreateMasterCommand(actionInput, 0) ??
+                                       TryCreateMasterCommand(actionInput, 1) ??
+                                       TryCreateContextCommand(actionInput, 0) ??
+                                       TryCreateContextCommand(actionInput, 1);
 
             if (command == null)
             {
@@ -60,7 +60,7 @@ namespace WheelMUD.CommandSystem
 
         private ScriptingCommand TryCreateMasterCommand(ActionInput actionInput, int lastKeywordIndex)
         {
-            string commandAlias = this.GetCommandAlias(actionInput, lastKeywordIndex);
+            string commandAlias = GetCommandAlias(actionInput, lastKeywordIndex);
 
             // If this isn't actually a command, bail now.
             ////if (string.IsNullOrEmpty(commandAlias) || !this.masterCommandList.ContainsKey(commandAlias))
@@ -82,7 +82,7 @@ namespace WheelMUD.CommandSystem
 
         private ScriptingCommand TryCreateContextCommand(ActionInput actionInput, int lastKeywordIndex)
         {
-            string commandAlias = this.GetCommandAlias(actionInput, lastKeywordIndex);
+            string commandAlias = GetCommandAlias(actionInput, lastKeywordIndex);
             if (string.IsNullOrEmpty(commandAlias))
             {
                 return null;

--- a/src/Core/CommandSystem/CommandProcessor.cs
+++ b/src/Core/CommandSystem/CommandProcessor.cs
@@ -36,47 +36,47 @@ namespace WheelMUD.Core
         /// <summary>Start this CommandProcessor SubSystem.</summary>
         public void Start()
         {
-            this.host.UpdateSubSystemHost(this, "Starting...");
-            this.workerThread = new Thread(this.ProcessCommandsThread);
-            this.workerThread.Start();
+            host.UpdateSubSystemHost(this, "Starting...");
+            workerThread = new Thread(ProcessCommandsThread);
+            workerThread.Start();
         }
 
         /// <summary>Stop this CommandProcessor SubSystem.</summary>
         public void Stop()
         {
-            this.host.UpdateSubSystemHost(this, "Stopping...");
-            this.shuttingDown = true;
-            this.workerThread.Join(5000);
-            if (this.workerThread.IsAlive)
+            host.UpdateSubSystemHost(this, "Stopping...");
+            shuttingDown = true;
+            workerThread.Join(5000);
+            if (workerThread.IsAlive)
             {
-                this.workerThread.Abort();
+                workerThread.Abort();
             }
-            this.workerThread = null;
+            workerThread = null;
         }
 
         /// <summary>Subscribe to receive system updates from this system.</summary>
         /// <param name="sender">The subscribing system; generally use 'this'.</param>
         public void SubscribeToSystem(ISubSystemHost sender)
         {
-            this.host = sender;
+            host = sender;
         }
 
         /// <summary>Inform subscribed system(s) of the specified update.</summary>
         /// <param name="msg">The message to be sent to subscribed system(s).</param>
         public void InformSubscribedSystem(string msg)
         {
-            this.host.UpdateSubSystemHost(this, msg);
+            host.UpdateSubSystemHost(this, msg);
         }
 
         /// <summary>Method executed as the worker thread to perform the work indefinitely.</summary>
         private void ProcessCommandsThread()
         {
-            while (!this.shuttingDown)
+            while (!shuttingDown)
             {
                 ActionInput action = CommandManager.Instance.DequeueAction();
                 if (action != null)
                 {
-                    this.TryExecuteAction(action);
+                    TryExecuteAction(action);
                 }
                 else
                 {

--- a/src/Core/CommandSystem/ContextCommand.cs
+++ b/src/Core/CommandSystem/ContextCommand.cs
@@ -25,10 +25,10 @@ namespace WheelMUD.Core
             ContextAvailability availability,
             SecurityRole securityRole)
         {
-            this.CommandScript = commandScript;
-            this.CommandKey = commandKey;
-            this.Availability = availability;
-            this.SecurityRole = securityRole;
+            CommandScript = commandScript;
+            CommandKey = commandKey;
+            Availability = availability;
+            SecurityRole = securityRole;
         }
 
         /// <summary>Gets the starting command text used to execute this command.</summary>

--- a/src/Core/ConnectionArgs.cs
+++ b/src/Core/ConnectionArgs.cs
@@ -17,7 +17,7 @@ namespace WheelMUD.Core
         /// <param name="connection">The connection.</param>
         public ConnectionArgs(IConnection connection)
         {
-            this.Connection = connection;
+            Connection = connection;
         }
 
         /// <summary>Gets the connection.</summary>

--- a/src/Core/ContextualStringBuilder.cs
+++ b/src/Core/ContextualStringBuilder.cs
@@ -53,8 +53,8 @@ namespace WheelMUD.Core
         /// <param name="receiver">The main target of the message.</param>
         public ContextualStringBuilder(Thing originator, Thing receiver)
         {
-            this.Originator = originator;
-            this.Receiver = receiver;
+            Originator = originator;
+            Receiver = receiver;
         }
 
         /// <summary>Gets the originator.</summary>
@@ -69,7 +69,7 @@ namespace WheelMUD.Core
         /// <returns>Returns a ContextualStringBuilder object.</returns>
         public ContextualStringBuilder Append(string text, ContextualStringUsage usage)
         {
-            this.texts.Add(new ContextualString(text, usage));
+            texts.Add(new ContextualString(text, usage));
             return this;
         }
 
@@ -78,7 +78,7 @@ namespace WheelMUD.Core
         /// <returns>Returns a ContextualStringBuilder.</returns>
         public ContextualStringBuilder Append(string text)
         {
-            this.Append(text, ContextualStringUsage.Anytime);
+            Append(text, ContextualStringUsage.Anytime);
             return this;
         }
 
@@ -89,40 +89,40 @@ namespace WheelMUD.Core
         {
             string output = string.Empty;
 
-            foreach (ContextualString text in this.texts)
+            foreach (ContextualString text in texts)
             {
                 switch (text.Usage)
                 {
                     case ContextualStringUsage.WhenNotBeingPassedToOriginator:
-                        if (this.Originator != currentReceiver)
+                        if (Originator != currentReceiver)
                         {
                             output += text.Text;
                         }
 
                         break;
                     case ContextualStringUsage.OnlyWhenBeingPassedToOriginator:
-                        if (this.Originator == currentReceiver)
+                        if (Originator == currentReceiver)
                         {
                             output += text.Text;
                         }
 
                         break;
                     case ContextualStringUsage.WhenNotBeingPassedToReceiver:
-                        if (this.Receiver != currentReceiver)
+                        if (Receiver != currentReceiver)
                         {
                             output += text.Text;
                         }
 
                         break;
                     case ContextualStringUsage.OnlyWhenBeingPassedToReceiver:
-                        if (this.Receiver == currentReceiver)
+                        if (Receiver == currentReceiver)
                         {
                             output += text.Text;
                         }
 
                         break;
                     case ContextualStringUsage.WhenNotBeingPassedToReceiverOrOriginator:
-                        if (this.Receiver != currentReceiver && this.Originator != currentReceiver)
+                        if (Receiver != currentReceiver && Originator != currentReceiver)
                         {
                             output += text.Text;
                         }
@@ -145,8 +145,8 @@ namespace WheelMUD.Core
             /// <param name="usage">The contextual usage of this string.</param>
             public ContextualString(string text, ContextualStringUsage usage)
             {
-                this.Text = text;
-                this.Usage = usage;
+                Text = text;
+                Usage = usage;
             }
 
             /// <summary>Gets the string text.</summary>

--- a/src/Core/CoreManager.cs
+++ b/src/Core/CoreManager.cs
@@ -41,19 +41,19 @@ namespace WheelMUD.Core
         /// <param name="sender">The subscribing system; generally use 'this'.</param>
         public void SubscribeToSystem(ISuperSystemSubscriber sender)
         {
-            if (this.subscribers.Contains(sender))
+            if (subscribers.Contains(sender))
             {
                 throw new DuplicateNameException("The subscriber is already subscribed to Super System events: " + sender);
             }
 
-            this.subscribers.Add(sender);
+            subscribers.Add(sender);
         }
 
         /// <summary>Unsubscribe from the specified super system subscriber.</summary>
         /// <param name="sender">The unsubscribing system; generally use 'this'.</param>
         public void UnSubscribeFromSystem(ISuperSystemSubscriber sender)
         {
-            this.subscribers.Remove(sender);
+            subscribers.Remove(sender);
         }
 
         /// <summary>Start the CoreManager.</summary>
@@ -64,17 +64,17 @@ namespace WheelMUD.Core
             // TODO: Implement file system watcher on the execution directory to trigger auto-recompositions.
             DefaultComposer.Container.ComposeParts(this);
 
-            this.SubscribeToSystems();
+            SubscribeToSystems();
 
-            foreach (var system in this.SubSystems)
+            foreach (var system in SubSystems)
             {
                 system.Start();
             }
 
-            if (this.SystemPlugIns != null)
+            if (SystemPlugIns != null)
             {
                 // Start all the plugins
-                foreach (var systemPlugIn in this.SystemPlugIns)
+                foreach (var systemPlugIn in SystemPlugIns)
                 {
                     systemPlugIn.Start();
                 }
@@ -86,15 +86,15 @@ namespace WheelMUD.Core
         {
             try
             {
-                foreach (var system in this.SubSystems)
+                foreach (var system in SubSystems)
                 {
                     system.Stop();
                 }
 
-                if (this.SystemPlugIns != null)
+                if (SystemPlugIns != null)
                 {
                     // Stop all the plugins
-                    foreach (var systemPlugIn in this.SystemPlugIns)
+                    foreach (var systemPlugIn in SystemPlugIns)
                     {
                         systemPlugIn.Stop();
                     }
@@ -112,14 +112,14 @@ namespace WheelMUD.Core
         /// <param name="msg">The message to be sent.</param>
         public void UpdateSystemHost(ISystem sender, string msg)
         {
-            this.NotifySubscribers(sender + " - " + msg);
+            NotifySubscribers(sender + " - " + msg);
         }
 
         /// <summary>Notify subscribers of the supplied message.</summary>
         /// <param name="message">The message to pass along.</param>
         private void NotifySubscribers(string message)
         {
-            foreach (ISuperSystemSubscriber subscriber in this.subscribers)
+            foreach (ISuperSystemSubscriber subscriber in subscribers)
             {
                 subscriber.Notify(message);
             }
@@ -129,15 +129,15 @@ namespace WheelMUD.Core
         private void SubscribeToSystems()
         {
             // Subscribe each system to the supersystem.
-            foreach (var system in this.SubSystems)
+            foreach (var system in SubSystems)
             {
                 system.SubscribeToSystemHost(this);
             }
 
-            if (this.SystemPlugIns != null)
+            if (SystemPlugIns != null)
             {
                 // Subscribe all the plugins to the host
-                foreach (var systemPlugIn in this.SystemPlugIns)
+                foreach (var systemPlugIn in SystemPlugIns)
                 {
                     systemPlugIn.SubscribeToSystemHost(this);
                 }

--- a/src/Core/Dice.cs
+++ b/src/Core/Dice.cs
@@ -28,7 +28,7 @@ namespace WheelMUD.Core
         /// <returns>A new die object.</returns>
         public Die GetDie(int numSides)
         {
-            return new Die(numSides, this.Random);
+            return new Die(numSides, Random);
         }
     }
 }

--- a/src/Core/Die.cs
+++ b/src/Core/Die.cs
@@ -24,14 +24,14 @@ namespace WheelMUD.Core
         public Die(int numberSides, Random randomGenerator)
         {
             this.numberSides = numberSides;
-            this.rand = randomGenerator;
+            rand = randomGenerator;
         }
 
         /// <summary>Rolls the die and returns the result.</summary>
         /// <returns>The result of the die roll.</returns>
         public int Roll()
         {
-            return this.rand.Next(1, this.numberSides + 1);
+            return rand.Next(1, numberSides + 1);
         }
     }
 }

--- a/src/Core/Effect.cs
+++ b/src/Core/Effect.cs
@@ -22,8 +22,8 @@ namespace WheelMUD.Effects
         public Effect(DateTime startTime, TimeSpan duration)
             : base(null)
         {
-            this.StartTime = startTime;
-            this.Duration = duration;
+            StartTime = startTime;
+            Duration = duration;
         }
 
         /// <summary>Initializes a new instance of the <see cref="Effect" /> class.</summary>
@@ -31,8 +31,8 @@ namespace WheelMUD.Effects
         public Effect(TimeSpan duration)
             : base(null)
         {
-            this.StartTime = DateTime.Now;
-            this.Duration = duration;
+            StartTime = DateTime.Now;
+            Duration = duration;
         }
 
         /// <summary>Initializes a new instance of the Effect class.</summary>
@@ -40,7 +40,7 @@ namespace WheelMUD.Effects
         protected Effect(Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.StartTime = DateTime.Now;
+            StartTime = DateTime.Now;
         }
 
         /// <summary>Gets or sets the effect duration.</summary>
@@ -53,7 +53,7 @@ namespace WheelMUD.Effects
         /// <summary>Gets the remaining effect duration.</summary>
         public TimeSpan RemainingDuration
         {
-            get { return this.Duration.Subtract(DateTime.Now - this.StartTime); }
+            get { return Duration.Subtract(DateTime.Now - StartTime); }
         }
 
         /// <summary>Gets the time when the effect was applied.</summary>
@@ -66,18 +66,18 @@ namespace WheelMUD.Effects
         {
             get
             {
-                return DateTime.Now + this.RemainingDuration;
+                return DateTime.Now + RemainingDuration;
             }
         }
 
         private void DisableEffect()
         {
-            if (this.Parent == null)
+            if (Parent == null)
             {
                 return;
             }
 
-            var behaviorManager = this.Parent.Behaviors;
+            var behaviorManager = Parent.Behaviors;
 
             var effects = behaviorManager.OfType<Effect>();
             if (effects.Count == 0)
@@ -85,7 +85,7 @@ namespace WheelMUD.Effects
                 return;
             }
 
-            var appliedEffects = effects.Where(effect => effect.ID == this.ID);
+            var appliedEffects = effects.Where(effect => effect.ID == ID);
             foreach (var appliedEffect in appliedEffects)
             {
                 // TODO: Are these the only references to the effect?

--- a/src/Core/Events/AddChildEvent.cs
+++ b/src/Core/Events/AddChildEvent.cs
@@ -15,7 +15,7 @@ namespace WheelMUD.Core.Events
         public AddChildEvent(Thing activeThing, Thing newParent)
             : base(activeThing, null)
         {
-            this.NewParent = newParent;
+            NewParent = newParent;
         }
 
         /// <summary>Gets the new parent.</summary>

--- a/src/Core/Events/AttackEvent.cs
+++ b/src/Core/Events/AttackEvent.cs
@@ -17,7 +17,7 @@ namespace WheelMUD.Core.Events
         public AttackEvent(Thing activeThing, SensoryMessage senseMessage, Thing aggressor)
             : base(activeThing, senseMessage)
         {
-            this.Aggressor = aggressor;
+            Aggressor = aggressor;
             senseMessage.Context.Add("Aggressor", aggressor);
         }
 

--- a/src/Core/Events/ChangeOwnerEvent.cs
+++ b/src/Core/Events/ChangeOwnerEvent.cs
@@ -19,12 +19,12 @@ namespace WheelMUD.Core.Events
         public ChangeOwnerEvent(Thing activeThing, SensoryMessage senseMessage, Thing oldOwner, Thing newOwner, Thing thing)
             : base(activeThing, senseMessage)
         {
-            this.OldOwner = oldOwner;
-            this.NewOwner = newOwner;
-            this.Thing = thing;
-            senseMessage.Context.Add("Thing", this.Thing);
-            senseMessage.Context.Add("OldOwner", this.OldOwner);
-            senseMessage.Context.Add("NewOwner", this.NewOwner);
+            OldOwner = oldOwner;
+            NewOwner = newOwner;
+            Thing = thing;
+            senseMessage.Context.Add("Thing", Thing);
+            senseMessage.Context.Add("OldOwner", OldOwner);
+            senseMessage.Context.Add("NewOwner", NewOwner);
         }
 
         /// <summary>Gets the new owner of the item.</summary>

--- a/src/Core/Events/DeathEvent.cs
+++ b/src/Core/Events/DeathEvent.cs
@@ -17,7 +17,7 @@ namespace WheelMUD.Core.Events
         public DeathEvent(Thing activeThing, SensoryMessage senseMessage, Thing killer)
             : base(activeThing, senseMessage)
         {
-            this.Killer = killer;
+            Killer = killer;
         }
 
         /// <summary>Gets the killer.</summary>

--- a/src/Core/Events/EffectEvent.cs
+++ b/src/Core/Events/EffectEvent.cs
@@ -25,10 +25,10 @@ namespace WheelMUD.Core.Events
         public EffectEvent(Thing activeThing, Thing target, SensoryMessage sensoryMessage)
             : base(activeThing, sensoryMessage)
         {
-            this.Target = target;
+            Target = target;
             if (sensoryMessage != null)
             {
-                sensoryMessage.Context.Add("Target", this.Target);
+                sensoryMessage.Context.Add("Target", Target);
             }
         }
 

--- a/src/Core/Events/EnterEvent.cs
+++ b/src/Core/Events/EnterEvent.cs
@@ -19,9 +19,9 @@ namespace WheelMUD.Core.Events
         public EnterEvent(Thing thingEntered, Thing activeThing, SensoryMessage sensoryMessage, Thing startLocation, Thing endLocation)
             : base(activeThing, sensoryMessage)
         {
-            this.ThingEntered = thingEntered;
-            this.StartLocation = startLocation;
-            this.EndLocation = endLocation;
+            ThingEntered = thingEntered;
+            StartLocation = startLocation;
+            EndLocation = endLocation;
         }
 
         /// <summary>Gets the thing that is being entered.</summary>

--- a/src/Core/Events/EventBase.cs
+++ b/src/Core/Events/EventBase.cs
@@ -15,21 +15,21 @@ namespace WheelMUD.Core.Events
         /// <param name="sensoryMessage">The sensory message.</param>
         public GameEvent(Thing activeThing, SensoryMessage sensoryMessage)
         {
-            this.ActiveThing = activeThing;
+            ActiveThing = activeThing;
             if (sensoryMessage != null)
             {
-                this.SensoryMessage = sensoryMessage;
+                SensoryMessage = sensoryMessage;
 
                 // TODO: This if-condition was added to deal with some cases where
                 // two ActiveThings are attempted for one action, e.g. "get".
                 // Should multiple ActiveThings be supported instead, or maybe
                 // there's a way to prevent this scenario?
-                if (!this.SensoryMessage.Context.ContainsKey("ActiveThing"))
+                if (!SensoryMessage.Context.ContainsKey("ActiveThing"))
                 {
-                    this.SensoryMessage.Context.Add("ActiveThing", this.ActiveThing);
+                    SensoryMessage.Context.Add("ActiveThing", ActiveThing);
                 }
 
-                this.SensoryMessage.Context.Add(this.GetType().Name, this);
+                SensoryMessage.Context.Add(GetType().Name, this);
             }
         }
 
@@ -64,17 +64,17 @@ namespace WheelMUD.Core.Events
         /// <param name="cancelMessage">The cancel message.</param>
         public void Cancel(string cancelMessage)
         {
-            this.IsCancelled = true;
-            if (!string.IsNullOrEmpty(cancelMessage) && !this.sentCancelMessage)
+            IsCancelled = true;
+            if (!string.IsNullOrEmpty(cancelMessage) && !sentCancelMessage)
             {
                 // Write up to one cancellation message directly to the user/initiator if appropriate.
-                var userControlledBehavior = this.ActiveThing.Behaviors.FindFirst<UserControlledBehavior>();
+                var userControlledBehavior = ActiveThing.Behaviors.FindFirst<UserControlledBehavior>();
                 if (userControlledBehavior != null && userControlledBehavior.Controller != null)
                 {
                     userControlledBehavior.Controller.Write(cancelMessage);
                 }
 
-                this.sentCancelMessage = true;
+                sentCancelMessage = true;
             }
         }
     }

--- a/src/Core/Events/EventProcessor.cs
+++ b/src/Core/Events/EventProcessor.cs
@@ -33,21 +33,21 @@ namespace WheelMUD.Core
         {
             // Prepare to handle receiving all relevant sensory events (not requests) which have 
             // happened within the player's perception, and relay the sensory message to the player.
-            var player = this.playerBehavior.Parent;
-            player.Eventing.CombatEvent += this.ProcessEvent;
-            player.Eventing.MovementEvent += this.ProcessEvent;
-            player.Eventing.CommunicationEvent += this.ProcessEvent;
-            player.Eventing.MiscellaneousEvent += this.ProcessEvent;
+            var player = playerBehavior.Parent;
+            player.Eventing.CombatEvent += ProcessEvent;
+            player.Eventing.MovementEvent += ProcessEvent;
+            player.Eventing.CommunicationEvent += ProcessEvent;
+            player.Eventing.MiscellaneousEvent += ProcessEvent;
         }
 
         /// <summary>Detaches all player-related events such as combat, movement, and communication.</summary>
         public void DetachEvents()
         {
-            var player = this.playerBehavior.Parent;
-            player.Eventing.CombatEvent -= this.ProcessEvent;
-            player.Eventing.MovementEvent -= this.ProcessEvent;
-            player.Eventing.CommunicationEvent -= this.ProcessEvent;
-            player.Eventing.MiscellaneousEvent -= this.ProcessEvent;
+            var player = playerBehavior.Parent;
+            player.Eventing.CombatEvent -= ProcessEvent;
+            player.Eventing.MovementEvent -= ProcessEvent;
+            player.Eventing.CommunicationEvent -= ProcessEvent;
+            player.Eventing.MiscellaneousEvent -= ProcessEvent;
         }
 
         /// <summary>Process a specified event.</summary>
@@ -58,10 +58,10 @@ namespace WheelMUD.Core
             // Events with no sensory component have no chance to be percieved/relayed to player's terminal...
             if (e.SensoryMessage != null)
             {
-                string output = this.ProcessMessage(e.SensoryMessage);
+                string output = ProcessMessage(e.SensoryMessage);
                 if (output != string.Empty)
                 {
-                    this.userControlledBehavior.Controller.Write(output);
+                    userControlledBehavior.Controller.Write(output);
                 }
             }
         }
@@ -69,15 +69,15 @@ namespace WheelMUD.Core
         /// <summary>Dispose of any resources used by this EventProcessor.</summary>
         public void Dispose()
         {
-            if (this.playerBehavior != null)
+            if (playerBehavior != null)
             {
-                var player = this.playerBehavior.Parent;
+                var player = playerBehavior.Parent;
                 if (player != null)
                 {
-                    player.Eventing.CombatEvent -= this.ProcessEvent;
-                    player.Eventing.MovementEvent -= this.ProcessEvent;
-                    player.Eventing.CommunicationEvent -= this.ProcessEvent;
-                    player.Eventing.MiscellaneousEvent -= this.ProcessEvent;
+                    player.Eventing.CombatEvent -= ProcessEvent;
+                    player.Eventing.MovementEvent -= ProcessEvent;
+                    player.Eventing.CommunicationEvent -= ProcessEvent;
+                    player.Eventing.MiscellaneousEvent -= ProcessEvent;
                 }
             }
         }
@@ -87,9 +87,9 @@ namespace WheelMUD.Core
         /// <returns>The rendered view of this sensory message.</returns>
         private string ProcessMessage(SensoryMessage message)
         {
-            if (this.sensesBehavior.Senses.CanProcessSensoryMessage(message) && message.Message != null && this.userControlledBehavior != null)
+            if (sensesBehavior.Senses.CanProcessSensoryMessage(message) && message.Message != null && userControlledBehavior != null)
             {
-                return message.Message.Parse(this.userControlledBehavior.Parent);
+                return message.Message.Parse(userControlledBehavior.Parent);
             }
 
             return string.Empty;

--- a/src/Core/Events/FollowEvent.cs
+++ b/src/Core/Events/FollowEvent.cs
@@ -18,10 +18,10 @@ namespace WheelMUD.Core.Events
         public FollowEvent(Thing activeThing, SensoryMessage senseMessage, Thing follower, Thing target)
             : base(activeThing, senseMessage)
         {
-            this.Follower = follower;
-            this.Target = target;
-            senseMessage.Context.Add("Follower", this.Follower);
-            senseMessage.Context.Add("Target", this.Target);
+            Follower = follower;
+            Target = target;
+            senseMessage.Context.Add("Follower", Follower);
+            senseMessage.Context.Add("Target", Target);
         }
 
         /// <summary>Gets the Thing doing the following.</summary>

--- a/src/Core/Events/LockUnlockEvent.cs
+++ b/src/Core/Events/LockUnlockEvent.cs
@@ -18,8 +18,8 @@ namespace WheelMUD.Core.Events
         public LockUnlockEvent(Thing target, bool isBeingLocked, Thing activeThing, SensoryMessage sensoryMessage)
             : base(activeThing, sensoryMessage)
         {
-            this.Target = target;
-            this.IsBeingLocked = isBeingLocked;
+            Target = target;
+            IsBeingLocked = isBeingLocked;
         }
 
         /// <summary>Gets a value indicating whether this event pertains to the target being locked (true) or unlocked (false).</summary>

--- a/src/Core/Events/MoveEvent.cs
+++ b/src/Core/Events/MoveEvent.cs
@@ -31,14 +31,14 @@ namespace WheelMUD.Core.Events
         public MovementEvent(Thing thingMoving, Thing goingFrom, Thing goingTo, Thing goingVia, SensoryMessage sensoryMessage)
             : base(thingMoving, sensoryMessage)
         {
-            this.GoingFrom = goingFrom;
-            this.GoingTo = goingTo;
-            this.GoingVia = goingVia;
+            GoingFrom = goingFrom;
+            GoingTo = goingTo;
+            GoingVia = goingVia;
             if (sensoryMessage != null)
             {
-                sensoryMessage.Context.Add("GoingFrom", this.GoingFrom);
-                sensoryMessage.Context.Add("GoingTo", this.GoingTo);
-                sensoryMessage.Context.Add("GoingVia", this.GoingVia);
+                sensoryMessage.Context.Add("GoingFrom", GoingFrom);
+                sensoryMessage.Context.Add("GoingTo", GoingTo);
+                sensoryMessage.Context.Add("GoingVia", GoingVia);
             }
         }
 

--- a/src/Core/Events/OpenCloseEvent.cs
+++ b/src/Core/Events/OpenCloseEvent.cs
@@ -18,8 +18,8 @@ namespace WheelMUD.Core.Events
         public OpenCloseEvent(Thing target, bool isBeingOpened, Thing activeThing, SensoryMessage sensoryMessage)
             : base(activeThing, sensoryMessage)
         {
-            this.Target = target;
-            this.IsBeingOpened = isBeingOpened;
+            Target = target;
+            IsBeingOpened = isBeingOpened;
         }
 
         /// <summary>Gets a value indicating whether this event pertains to the target being opened (true) or closed (false).</summary>

--- a/src/Core/Events/RemoveChildEvent.cs
+++ b/src/Core/Events/RemoveChildEvent.cs
@@ -15,7 +15,7 @@ namespace WheelMUD.Core.Events
         public RemoveChildEvent(Thing activeThing)
             : base(activeThing, null)
         {
-            this.OldParent = activeThing.Parent;
+            OldParent = activeThing.Parent;
         }
 
         /// <summary>Gets the parent of the thing before being removed.</summary>

--- a/src/Core/Events/StatChangeEvent.cs
+++ b/src/Core/Events/StatChangeEvent.cs
@@ -19,9 +19,9 @@ namespace WheelMUD.Core.Events
         public StatChangeEvent(Thing activeThing, SensoryMessage senseMessage, BaseStat stat, int modifier, int oldValue)
             : base(activeThing, senseMessage)
         {
-            this.Stat = stat;
-            this.OldValue = oldValue;
-            this.Modifier = modifier;
+            Stat = stat;
+            OldValue = oldValue;
+            Modifier = modifier;
         }
 
         /// <summary>Gets the applicable stat.</summary>

--- a/src/Core/Events/ThingEventing.cs
+++ b/src/Core/Events/ThingEventing.cs
@@ -54,7 +54,7 @@ namespace WheelMUD.Core.Events
         /// <param name="eventScope">The base target(s) to broadcast to, including their children.</param>
         public void OnCombatRequest(CancellableGameEvent e, EventScope eventScope)
         {
-            this.OnRequest(t => t.CombatRequest, e, eventScope);
+            OnRequest(t => t.CombatRequest, e, eventScope);
         }
 
         /// <summary>Raises the <see cref="MovementRequest"/> event.</summary>
@@ -62,7 +62,7 @@ namespace WheelMUD.Core.Events
         /// <param name="eventScope">The base target(s) to broadcast to, including their children.</param>
         public void OnMovementRequest(CancellableGameEvent e, EventScope eventScope)
         {
-            this.OnRequest(t => t.MovementRequest, e, eventScope);
+            OnRequest(t => t.MovementRequest, e, eventScope);
         }
 
         /// <summary>Raises the <see cref="CommunicationRequest"/> event.</summary>
@@ -70,7 +70,7 @@ namespace WheelMUD.Core.Events
         /// <param name="eventScope">The base target(s) to broadcast to, including their children.</param>
         public void OnCommunicationRequest(CancellableGameEvent e, EventScope eventScope)
         {
-            this.OnRequest(t => t.CommunicationRequest, e, eventScope);
+            OnRequest(t => t.CommunicationRequest, e, eventScope);
         }
 
         /// <summary>Raises the <see cref="MiscellaneousRequest"/> event.</summary>
@@ -78,7 +78,7 @@ namespace WheelMUD.Core.Events
         /// <param name="eventScope">The base target(s) to broadcast to, including their children.</param>
         public void OnMiscellaneousRequest(CancellableGameEvent e, EventScope eventScope)
         {
-            this.OnRequest(t => t.MiscellaneousRequest, e, eventScope);
+            OnRequest(t => t.MiscellaneousRequest, e, eventScope);
         }
 
         /// <summary>Raises the <see cref="CombatEvent"/> event.</summary>
@@ -86,7 +86,7 @@ namespace WheelMUD.Core.Events
         /// <param name="eventScope">The base target(s) to broadcast to, including their children.</param>
         public void OnCombatEvent(GameEvent e, EventScope eventScope)
         {
-            this.OnEvent(t => t.CombatEvent, e, eventScope);
+            OnEvent(t => t.CombatEvent, e, eventScope);
         }
 
         /// <summary>Raises the <see cref="MovementEvent"/> event.</summary>
@@ -94,7 +94,7 @@ namespace WheelMUD.Core.Events
         /// <param name="eventScope">The base target(s) to broadcast to, including their children.</param>
         public void OnMovementEvent(GameEvent e, EventScope eventScope)
         {
-            this.OnEvent(t => t.MovementEvent, e, eventScope);
+            OnEvent(t => t.MovementEvent, e, eventScope);
         }
 
         /// <summary>Raises the <see cref="CommunicationEvent"/> event.</summary>
@@ -102,7 +102,7 @@ namespace WheelMUD.Core.Events
         /// <param name="eventScope">The base target(s) to broadcast to, including their children.</param>
         public void OnCommunicationEvent(GameEvent e, EventScope eventScope)
         {
-            this.OnEvent(t => t.CommunicationEvent, e, eventScope);
+            OnEvent(t => t.CommunicationEvent, e, eventScope);
         }
 
         /// <summary>Raises the <see cref="MiscellaneousEvent"/> event.</summary>
@@ -110,7 +110,7 @@ namespace WheelMUD.Core.Events
         /// <param name="eventScope">The base target(s) to broadcast to, including their children.</param>
         public void OnMiscellaneousEvent(GameEvent e, EventScope eventScope)
         {
-            this.OnEvent(t => t.MiscellaneousEvent, e, eventScope);
+            OnEvent(t => t.MiscellaneousEvent, e, eventScope);
         }
 
         private void OnRequest(Func<ThingEventing, CancellableGameEventHandler> handlerSelector, CancellableGameEvent e, EventScope eventScope)
@@ -120,7 +120,7 @@ namespace WheelMUD.Core.Events
             {
                 case EventScope.ParentsDown:
                     // Send the request to each parent, until cancellation is noticed or we've finished.
-                    Queue<Thing> requestQueue = new Queue<Thing>(this.owner.Parents);
+                    Queue<Thing> requestQueue = new Queue<Thing>(owner.Parents);
                     while (requestQueue.Count > 0 && !e.IsCancelled)
                     {
                         Thing currentParent = requestQueue.Dequeue();
@@ -129,10 +129,10 @@ namespace WheelMUD.Core.Events
 
                     break;
                 case EventScope.SelfDown:
-                    this.OnRequest(handlerSelector, e, true);
+                    OnRequest(handlerSelector, e, true);
                     break;
                 case EventScope.SelfOnly:
-                    this.OnRequest(handlerSelector, e, false);
+                    OnRequest(handlerSelector, e, false);
                     break;
                 default:
                     throw new NotImplementedException();
@@ -146,7 +146,7 @@ namespace WheelMUD.Core.Events
             {
                 case EventScope.ParentsDown:
                     // Send the event to each parent.
-                    List<Thing> allParents = this.owner.Parents;
+                    List<Thing> allParents = owner.Parents;
                     foreach (var parent in allParents)
                     {
                         parent.Eventing.OnEvent(handlerSelector, e, true);
@@ -154,10 +154,10 @@ namespace WheelMUD.Core.Events
 
                     break;
                 case EventScope.SelfDown:
-                    this.OnEvent(handlerSelector, e, true);
+                    OnEvent(handlerSelector, e, true);
                     break;
                 case EventScope.SelfOnly:
-                    this.OnEvent(handlerSelector, e, false);
+                    OnEvent(handlerSelector, e, false);
                     break;
                 default:
                     throw new NotImplementedException();
@@ -173,7 +173,7 @@ namespace WheelMUD.Core.Events
             // Build a request target queue which starts with our owner Thing and visits all it's Children.
             // (This is a queue instead of recursion to help avoid stack overflows and such with very large object trees.)
             Queue<Thing> requestTargetQueue = new Queue<Thing>();
-            requestTargetQueue.Enqueue(this.owner);
+            requestTargetQueue.Enqueue(owner);
 
             while (requestTargetQueue.Count > 0)
             {
@@ -207,7 +207,7 @@ namespace WheelMUD.Core.Events
             // Build an event target queue which starts with our owner Thing and visits all it's Children.
             // (This is a queue instead of recursion to help avoid stack overflows and such with very large object trees.)
             Queue<Thing> eventTargetQueue = new Queue<Thing>();
-            eventTargetQueue.Enqueue(this.owner);
+            eventTargetQueue.Enqueue(owner);
 
             while (eventTargetQueue.Count > 0)
             {

--- a/src/Core/Events/TimeEvent.cs
+++ b/src/Core/Events/TimeEvent.cs
@@ -20,8 +20,8 @@ namespace WheelMUD.Core.Events
         public TimeEvent(Thing activeThing, Action callback, DateTime endTime, SensoryMessage sensoryMessage)
             : base(activeThing, sensoryMessage)
         {
-            this.Callback = callback;
-            this.EndTime = endTime;
+            Callback = callback;
+            EndTime = endTime;
         }
 
         /// <summary>Gets the end time.</summary>

--- a/src/Core/Events/UnfollowEvent.cs
+++ b/src/Core/Events/UnfollowEvent.cs
@@ -18,10 +18,10 @@ namespace WheelMUD.Core.Events
         public UnfollowEvent(Thing activeThing, SensoryMessage senseMessage, Thing follower, Thing target)
             : base(activeThing, senseMessage)
         {
-            this.Follower = follower;
-            this.Target = target;
-            senseMessage.Context.Add("Follower", this.Follower);
-            senseMessage.Context.Add("Target", this.Target);
+            Follower = follower;
+            Target = target;
+            senseMessage.Context.Add("Follower", Follower);
+            senseMessage.Context.Add("Target", Target);
         }
 
         /// <summary>Gets the Thing that was doing the following.</summary>

--- a/src/Core/Events/VerbalCommunicationEvent.cs
+++ b/src/Core/Events/VerbalCommunicationEvent.cs
@@ -36,7 +36,7 @@ namespace WheelMUD.Core.Events
             VerbalCommunicationType communicationType)
             : base(activeThing, sensoryMessage)
         {
-            this.CommunicationType = communicationType;
+            CommunicationType = communicationType;
         }
 
         /// <summary>Gets the type of the communication.</summary>

--- a/src/Core/Events/WieldUnwieldEvent.cs
+++ b/src/Core/Events/WieldUnwieldEvent.cs
@@ -18,9 +18,9 @@ namespace WheelMUD.Core.Events
         public WieldUnwieldEvent(Thing wieldedItem, bool isBeingWielded, Thing activeThing, SensoryMessage sensoryMessage)
             : base(activeThing, sensoryMessage)
         {
-            this.WieldedItem = wieldedItem;
-            this.IsBeingWielded = isBeingWielded;
-            sensoryMessage.Context.Add("WieldedItem", this.WieldedItem);
+            WieldedItem = wieldedItem;
+            IsBeingWielded = isBeingWielded;
+            sensoryMessage.Context.Add("WieldedItem", WieldedItem);
         }
 
         /// <summary>Gets a value indicating whether this event pertains to the target being wielded (true) or unwielded (false).</summary>

--- a/src/Core/GameEngine/ExportGameAttributeAttribute.cs
+++ b/src/Core/GameEngine/ExportGameAttributeAttribute.cs
@@ -20,7 +20,7 @@ namespace WheelMUD.Core
     {
         /// <summary>Initializes a new instance of the ExportGameAttributeAttribute class.</summary>
         public ExportGameAttributeAttribute(int priority)
-            : base(typeof(GameAttribute)) => this.Priority = priority;
+            : base(typeof(GameAttribute)) => Priority = priority;
 
         /// <summary>Initializes a new instance of the ExportGameAttributeAttribute class.</summary>
         /// <param name="metadata">The metadata.</param>

--- a/src/Core/GameEngine/ExportGameStatAttribute.cs
+++ b/src/Core/GameEngine/ExportGameStatAttribute.cs
@@ -20,7 +20,7 @@ namespace WheelMUD.Core
     {
         /// <summary>Initializes a new instance of the ExportGameStatAttribute class.</summary>
         public ExportGameStatAttribute(int priority)
-            : base(typeof(GameStat)) => this.Priority = priority;
+            : base(typeof(GameStat)) => Priority = priority;
 
         /// <summary>Initializes a new instance of the ExportGameStatAttribute class.</summary>
         /// <param name="metadata">The metadata.</param>

--- a/src/Core/GameEngine/GameCombatSession.cs
+++ b/src/Core/GameEngine/GameCombatSession.cs
@@ -18,21 +18,21 @@ namespace WheelMUD.Core
         /// <summary>Gets the entities that are part of this combat session.</summary>
         public Hashtable Combatants
         {
-            get { return this.combatantHashtable; }
+            get { return combatantHashtable; }
         }
 
         /// <summary>Adds a combatant to this session.</summary>
         /// <param name="combatant">The Entity that needs to be added.</param>
         public void AddCombatant(ref Thing combatant)
         {
-            this.combatantHashtable.Add(combatant.Name, combatant);
+            combatantHashtable.Add(combatant.Name, combatant);
         }
 
         /// <summary>Remove a combatant from this session.</summary>
         /// <param name="combatant">The Entity that needs to be removed.</param>
         public void RemoveCombatant(ref Thing combatant)
         {
-            this.combatantHashtable.Remove(combatant.Name);
+            combatantHashtable.Remove(combatant.Name);
         }
     }
 }

--- a/src/Core/GameEngine/GameGender.cs
+++ b/src/Core/GameEngine/GameGender.cs
@@ -15,8 +15,8 @@ namespace WheelMUD.Core
         /// <param name="abbreviation">The abbreviation.</param>
         public GameGender(string name, string abbreviation)
         {
-            this.Name = name;
-            this.Abbreviation = abbreviation;
+            Name = name;
+            Abbreviation = abbreviation;
         }
 
         /// <summary>Gets the abbreviation for this gender.</summary>

--- a/src/Core/GameEngine/GameModifier.cs
+++ b/src/Core/GameEngine/GameModifier.cs
@@ -15,7 +15,7 @@ namespace WheelMUD.Core
         /// <summary>Initializes a new instance of the GameModifier class.</summary>
         public GameModifier()
         {
-            this.Modifiers = new Dictionary<string, string>();
+            Modifiers = new Dictionary<string, string>();
         }
 
         /// <summary>Gets or sets the map to.</summary>

--- a/src/Core/GameEngine/GameSkill.cs
+++ b/src/Core/GameEngine/GameSkill.cs
@@ -28,12 +28,12 @@ namespace WheelMUD.Core
         [JsonIgnore]
         public Thing PlayerThing { get; set; }
 
-        /// <summary>Called when a parent has just been assigned to this skill. (Refer to this.PlayerThing)</summary>
+        /// <summary>Called when a parent has just been assigned to this skill. (Refer to PlayerThing)</summary>
         public virtual void OnAddSkill()
         {
         }
 
-        /// <summary>Called when the current parent of this skill is about to be removed. (Refer to this.PlayerThing.)</summary>
+        /// <summary>Called when the current parent of this skill is about to be removed. (Refer to PlayerThing.)</summary>
         public virtual void OnRemoveSkill()
         {
         }

--- a/src/Core/GameEngine/GameSystemController.cs
+++ b/src/Core/GameEngine/GameSystemController.cs
@@ -81,29 +81,29 @@ namespace WheelMUD.Core
         /// <param name="msg">The message to be sent.</param>
         public void UpdateSubSystemHost(ISubSystem sender, string msg)
         {
-            this.host.UpdateSystemHost(this, msg);
+            host.UpdateSystemHost(this, msg);
         }
 
         /// <summary>Subscribes this system to the specified system host, so that host can receive updates.</summary>
         /// <param name="sender">The system host to receive our updates.</param>
         public void SubscribeToSystemHost(ISystemHost sender)
         {
-            this.host = sender;
+            host = sender;
         }
 
         /// <summary>Starts this system's individual components.</summary>
         public void Start()
         {
-            this.host.UpdateSystemHost(this, "Starting...");
-            this.Recompose();
-            this.host.UpdateSystemHost(this, "Started");
+            host.UpdateSystemHost(this, "Starting...");
+            Recompose();
+            host.UpdateSystemHost(this, "Started");
         }
 
         /// <summary>Stops this system's individual components.</summary>
         public void Stop()
         {
-            this.host.UpdateSystemHost(this, "Stopping");
-            this.host.UpdateSystemHost(this, "Stopped");
+            host.UpdateSystemHost(this, "Stopping");
+            host.UpdateSystemHost(this, "Stopped");
         }
 
         /// <summary>Recompose the GameSystemController with the latest components available.</summary>
@@ -116,12 +116,12 @@ namespace WheelMUD.Core
                 // at any time because they may be actively being iterated by other threads.
                 DefaultComposer.Container.ComposeParts(this);
 
-                this.GameAttributeConstructors = DefaultComposer.GetConstructors(this.ImportedGameAttributes, NoTypes);
-                this.GameGenders = DefaultComposer.GetNonPrioritizedInstances(this.ImportedGameGenders);
-                this.GameModifiers = DefaultComposer.GetNonPrioritizedInstances(this.ImportedGameModifiers);
-                this.GameRaces = DefaultComposer.GetNonPrioritizedInstances(this.ImportedGameRaces);
-                this.GameSkills = DefaultComposer.GetNonPrioritizedInstances(this.ImportedGameSkills);
-                this.GameStatConstructors = DefaultComposer.GetConstructors(this.ImportedGameStats, NoTypes);
+                GameAttributeConstructors = DefaultComposer.GetConstructors(ImportedGameAttributes, NoTypes);
+                GameGenders = DefaultComposer.GetNonPrioritizedInstances(ImportedGameGenders);
+                GameModifiers = DefaultComposer.GetNonPrioritizedInstances(ImportedGameModifiers);
+                GameRaces = DefaultComposer.GetNonPrioritizedInstances(ImportedGameRaces);
+                GameSkills = DefaultComposer.GetNonPrioritizedInstances(ImportedGameSkills);
+                GameStatConstructors = DefaultComposer.GetConstructors(ImportedGameStats, NoTypes);
             }
         }
 
@@ -129,7 +129,7 @@ namespace WheelMUD.Core
         {
             lock (this)
             {
-                return this.GameAttributeConstructors.Select(ctor => ctor.Invoke(null) as GameAttribute).ToDictionary(a => a.Abbreviation);
+                return GameAttributeConstructors.Select(ctor => ctor.Invoke(null) as GameAttribute).ToDictionary(a => a.Abbreviation);
             }
         }
 
@@ -137,7 +137,7 @@ namespace WheelMUD.Core
         {
             lock (this)
             {
-                return this.GameStatConstructors.Select(ctor => ctor.Invoke(null) as GameStat).ToDictionary(a => a.Abbreviation);
+                return GameStatConstructors.Select(ctor => ctor.Invoke(null) as GameStat).ToDictionary(a => a.Abbreviation);
             }
         }
 

--- a/src/Core/GameEngine/GamingParty.cs
+++ b/src/Core/GameEngine/GamingParty.cs
@@ -19,14 +19,14 @@ namespace WheelMUD.Core
         /// <param name="partyMember">The Entity that needs to be added.</param>
         public void AddPartyMember(ref Thing partyMember)
         {
-            this.partyMembers.Add(partyMember.Name, partyMember);
+            partyMembers.Add(partyMember.Name, partyMember);
         }
 
         /// <summary>Remove a member from this party.</summary>
         /// <param name="partyMember">The Entity that needs to be removed.</param>
         public void RemovePartyMember(ref Thing partyMember)
         {
-            this.partyMembers.Remove(partyMember.Name);
+            partyMembers.Remove(partyMember.Name);
         }
     }
 }

--- a/src/Core/HelpTopic.cs
+++ b/src/Core/HelpTopic.cs
@@ -14,8 +14,8 @@ namespace WheelMUD.Core
     {
         public HelpTopic(string contents, List<string> aliases)
         {
-            this.Contents = contents;
-            this.Aliases = aliases;
+            Contents = contents;
+            Aliases = aliases;
         }
 
         /// <summary>Gets the contents of this help topic.</summary>

--- a/src/Core/Locators/BehaviorLocator.cs
+++ b/src/Core/Locators/BehaviorLocator.cs
@@ -21,8 +21,8 @@ namespace WheelMUD.Core.Locators
 
         private BehaviorLocator()
         {
-            this.instantiatedServices = new Dictionary<Type, object>();
-            this.servicesType = new Dictionary<Type, Type>();
+            instantiatedServices = new Dictionary<Type, object>();
+            servicesType = new Dictionary<Type, Type>();
         }
 
         /// <summary>Gets the singleton instance of the <see cref="BehaviorLocator"/> class.</summary>
@@ -33,7 +33,7 @@ namespace WheelMUD.Core.Locators
         /// <param name="behaviorToRegister">The behavior to register.</param>
         public void RegisterService<T>(T behaviorToRegister)
         {
-            this.instantiatedServices.Add(typeof(T), behaviorToRegister);
+            instantiatedServices.Add(typeof(T), behaviorToRegister);
         }
 
         /// <summary>Gets the service.</summary>
@@ -41,22 +41,22 @@ namespace WheelMUD.Core.Locators
         /// <returns>Returns an instance of the class in question, if it exists.</returns>
         public T GetService<T>()
         {
-            if (this.instantiatedServices.ContainsKey(typeof(T)))
+            if (instantiatedServices.ContainsKey(typeof(T)))
             {
-                return (T)this.instantiatedServices[typeof(T)];
+                return (T)instantiatedServices[typeof(T)];
             }
 
             // lazy initialization
             try
             {
                 // use reflection to invoke the service
-                ConstructorInfo constructor = this.servicesType[typeof(T)].GetConstructor(new Type[0]);
+                ConstructorInfo constructor = servicesType[typeof(T)].GetConstructor(new Type[0]);
                 Debug.Assert(constructor != null, "Cannot find a suitable constructor for " + typeof(T));
 
                 T service = (T)constructor.Invoke(null);
 
                 // add the service to the ones that we have already instantiated
-                this.instantiatedServices.Add(typeof(T), service);
+                instantiatedServices.Add(typeof(T), service);
 
                 return service;
             }

--- a/src/Core/ManagerSystems/CommandManager.cs
+++ b/src/Core/ManagerSystems/CommandManager.cs
@@ -31,7 +31,7 @@ namespace WheelMUD.Core
         /// <summary>Prevents a default instance of the <see cref="CommandManager"/> class from being created.</summary>
         private CommandManager()
         {
-            this.Recompose();
+            Recompose();
         }
 
         /// <summary>Gets the singleton instance of the <see cref="CommandManager"/> class.</summary>
@@ -58,7 +58,7 @@ namespace WheelMUD.Core
             var newPrimaryCommandList = new Dictionary<string, Command>();
             var newMasterCommandList = new Dictionary<string, Command>();
 
-            var actionTypes = DefaultComposer.GetTypes(this.GameActions);
+            var actionTypes = DefaultComposer.GetTypes(GameActions);
             foreach (Type type in actionTypes)
             {
                 // Find the description of this command.
@@ -108,15 +108,15 @@ namespace WheelMUD.Core
             // TODO: Exposing MasterCommandList this way is very likely NOT thread-safe. Change to a lock-protected getter?
             lock (this)
             {
-                this.primaryCommandList = newPrimaryCommandList;
-                this.MasterCommandList = newMasterCommandList;
+                primaryCommandList = newPrimaryCommandList;
+                MasterCommandList = newMasterCommandList;
             }
         }
 
         /// <summary>Starts this system.</summary>
         public override void Start()
         {
-            this.SystemHost.UpdateSystemHost(this, "Starting...");
+            SystemHost.UpdateSystemHost(this, "Starting...");
 
             // TODO: Test > 1, then allow total command processors to be configurable.
             //  This will take a significant effort to work out any race conditions which may leave
@@ -129,25 +129,25 @@ namespace WheelMUD.Core
             {
                 var commandProcessor = new CommandProcessor(this);
                 commandProcessor.Start();
-                this.commandProcessors.Add(commandProcessor);
+                commandProcessors.Add(commandProcessor);
             }
 
-            this.SystemHost.UpdateSystemHost(this, "Started");
+            SystemHost.UpdateSystemHost(this, "Started");
         }
 
         /// <summary>Stops this system.</summary>
         public override void Stop()
         {
-            this.SystemHost.UpdateSystemHost(this, "Stopping...");
+            SystemHost.UpdateSystemHost(this, "Stopping...");
 
-            foreach (var commandProcessor in this.commandProcessors)
+            foreach (var commandProcessor in commandProcessors)
             {
                 commandProcessor.Stop();
             }
 
-            this.commandProcessors.Clear();
+            commandProcessors.Clear();
 
-            this.SystemHost.UpdateSystemHost(this, "Stopped");
+            SystemHost.UpdateSystemHost(this, "Stopped");
         }
 
         /// <summary>Gets a list of commands that the controller has permissions to execute.</summary>
@@ -161,7 +161,7 @@ namespace WheelMUD.Core
                 // TODO: We could cache any built map of privelege-set to commands-list (so long as we invalidate
                 //       it whenever we recompose commands from MEF.)
                 List<Command> commands = new List<Command>();
-                foreach (Command command in this.primaryCommandList.Values)
+                foreach (Command command in primaryCommandList.Values)
                 {
                     commands.Add(command);
                 }
@@ -175,7 +175,7 @@ namespace WheelMUD.Core
             // TODO: Ascertain the ACTUAL sender's specific permissions, so we can check for fullAdmin, fullBuilder, and
             //       so on, instead of assuming just 'SecurityRole.player' (SEE ALSO CommandGuard.cs for another case...)
             SecurityRole playerRoles = SecurityRole.player | SecurityRole.minorBuilder | SecurityRole.fullBuilder | SecurityRole.minorAdmin | SecurityRole.fullAdmin;
-            return this.GetPossibleContextCommands(sender, alias, playerRoles).Where(cmd => cmd != null);
+            return GetPossibleContextCommands(sender, alias, playerRoles).Where(cmd => cmd != null);
         }
 
         private IEnumerable<ContextCommand> GetPossibleContextCommands(Thing sender, string alias, SecurityRole senderRoles)
@@ -228,9 +228,9 @@ namespace WheelMUD.Core
         public void EnqueueAction(ActionInput actionInput)
         {
             Debug.Assert(actionInput != null);
-            lock (this.actionQueue)
+            lock (actionQueue)
             {
-                this.actionQueue.Enqueue(actionInput);
+                actionQueue.Enqueue(actionInput);
             }
         }
 
@@ -238,14 +238,14 @@ namespace WheelMUD.Core
         /// <returns>The next action from the queue.</returns>
         internal ActionInput DequeueAction()
         {
-            lock (this.actionQueue)
+            lock (actionQueue)
             {
-                if (this.actionQueue.Count <= 0)
+                if (actionQueue.Count <= 0)
                 {
                     return null;
                 }
 
-                return this.actionQueue.Dequeue();
+                return actionQueue.Dequeue();
             }
         }
 

--- a/src/Core/ManagerSystems/HelpManager.cs
+++ b/src/Core/ManagerSystems/HelpManager.cs
@@ -19,7 +19,7 @@ namespace WheelMUD.Core
         /// <summary>Prevents a default instance of the <see cref="HelpManager"/> class from being created.</summary>
         private HelpManager()
         {
-            this.HelpTopics = new List<HelpTopic>();
+            HelpTopics = new List<HelpTopic>();
         }
 
         /// <summary>Gets the singleton instance of HelpManager.</summary>
@@ -32,7 +32,7 @@ namespace WheelMUD.Core
         /// <summary>Starts the manager and loads all help records into memory</summary>
         public override void Start()
         {
-            this.SystemHost.UpdateSystemHost(this, "Starting...");
+            SystemHost.UpdateSystemHost(this, "Starting...");
 
             string dataRoot = GameConfiguration.DataStoragePath;
             string helpDir = Path.Combine(dataRoot, "Help");
@@ -48,23 +48,23 @@ namespace WheelMUD.Core
                 string[] fileParts = file.Split(Path.DirectorySeparatorChar);
                 string[] fileAliases = fileParts[fileParts.Length - 1].Split(',');
                 var helpTopic = new HelpTopic(contents, new List<string>(fileAliases));
-                this.HelpTopics.Add(helpTopic);
+                HelpTopics.Add(helpTopic);
             }
 
-            this.SystemHost.UpdateSystemHost(this, "Started");
+            SystemHost.UpdateSystemHost(this, "Started");
         }
 
         /// <summary>Stops the manager and unloads all help records from memory.</summary>
         public override void Stop()
         {
-            this.SystemHost.UpdateSystemHost(this, "Stopping...");
+            SystemHost.UpdateSystemHost(this, "Stopping...");
 
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                this.HelpTopics.Clear();
+                HelpTopics.Clear();
             }
 
-            this.SystemHost.UpdateSystemHost(this, "Stopped");
+            SystemHost.UpdateSystemHost(this, "Stopped");
         }
 
         /// <summary>Find a HelpTopic via the help topic alias.</summary>
@@ -73,7 +73,7 @@ namespace WheelMUD.Core
         public HelpTopic FindHelpTopic(string helpTopic)
         {
             Predicate<HelpTopic> finder = (HelpTopic h) => { return h.Aliases.Contains(helpTopic); };
-            return this.HelpTopics.Find(finder);
+            return HelpTopics.Find(finder);
         }
 
         /// <summary>Registers the <see cref="HelpManager"/> system for export.</summary>

--- a/src/Core/ManagerSystems/ManagerSystem.cs
+++ b/src/Core/ManagerSystems/ManagerSystem.cs
@@ -22,7 +22,7 @@ namespace WheelMUD.Core
         /// <param name="systemHost">The system host to receive our updates.</param>
         public void SubscribeToSystemHost(ISystemHost systemHost)
         {
-            this.SystemHost = systemHost;
+            SystemHost = systemHost;
         }
 
         /// <summary>Start this manager system.</summary>
@@ -36,7 +36,7 @@ namespace WheelMUD.Core
         /// <param name="msg">The message to be sent.</param>
         public void UpdateSubSystemHost(ISubSystem sender, string msg)
         {
-            this.SystemHost.UpdateSystemHost(this, msg);
+            SystemHost.UpdateSystemHost(this, msg);
         }
     }
 }

--- a/src/Core/ManagerSystems/MobileManager.cs
+++ b/src/Core/ManagerSystems/MobileManager.cs
@@ -41,13 +41,13 @@ namespace WheelMUD.Core
         /// <param name="mobile">An instance of a mobile to be registered.</param>
         public void RegisterMobile(Thing mobile)
         {
-            this.mobiles.Add(mobile);
+            mobiles.Add(mobile);
         }
 
         /// <summary>Starts this system.</summary>
         public override void Start()
         {
-            this.SystemHost.UpdateSystemHost(this, "Starting...");
+            SystemHost.UpdateSystemHost(this, "Starting...");
 
             ////temp. Add a mobile explicitly here.
             ////TODO: replace with proper persistence mechanism
@@ -62,20 +62,20 @@ namespace WheelMUD.Core
             ////_mobiles.Add(mobile);
             ////mobile.Load();
 
-            this.SystemHost.UpdateSystemHost(this, "Started");
+            SystemHost.UpdateSystemHost(this, "Started");
         }
 
         /// <summary>Stops this system's individual components.</summary>
         public override void Stop()
         {
-            this.SystemHost.UpdateSystemHost(this, "Stopping...");
+            SystemHost.UpdateSystemHost(this, "Stopping...");
 
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                this.mobiles.Clear();
+                mobiles.Clear();
             }
 
-            this.SystemHost.UpdateSystemHost(this, "Stopped");
+            SystemHost.UpdateSystemHost(this, "Stopped");
         }
 
         /// <summary>Finds a mobile using the predicate passed.</summary>
@@ -83,9 +83,9 @@ namespace WheelMUD.Core
         /// <returns>The IMobile found.</returns>
         public Thing FindMobile(Predicate<Thing> predicate)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                return this.mobiles.Find(predicate);
+                return mobiles.Find(predicate);
             }
         }
 
@@ -96,13 +96,13 @@ namespace WheelMUD.Core
         public Thing FindMobileByName(string name, bool partialMatch)
         {
             name = name.ToLower();
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                Thing mobile = this.mobiles.Find(m => m.Name.ToLower().Equals(name));
+                Thing mobile = mobiles.Find(m => m.Name.ToLower().Equals(name));
 
                 if (mobile == null && partialMatch)
                 {
-                    mobile = this.mobiles.Find(m => m.Name.ToLower().StartsWith(name));
+                    mobile = mobiles.Find(m => m.Name.ToLower().StartsWith(name));
                 }
 
                 return mobile;
@@ -114,9 +114,9 @@ namespace WheelMUD.Core
         /// <returns>returns a mobile object.</returns>
         public Thing FindMobileById(string id)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                Thing mobile = this.mobiles.Find(m => m.Id.Equals(id));
+                Thing mobile = mobiles.Find(m => m.Id.Equals(id));
                 return mobile;
             }
         }

--- a/src/Core/ManagerSystems/PlacesManager.cs
+++ b/src/Core/ManagerSystems/PlacesManager.cs
@@ -18,8 +18,8 @@ namespace WheelMUD.Core
         private PlacesManager()
         {
             // TODO: Assign to ItemManager instance? is it needed? currently disabled...
-            this.WorldBehavior = new WorldBehavior();
-            this.World = new Thing(this.WorldBehavior)
+            WorldBehavior = new WorldBehavior();
+            World = new Thing(WorldBehavior)
             {
                 Name = GameConfiguration.Name
             };
@@ -37,17 +37,17 @@ namespace WheelMUD.Core
         /// <summary>Starts this system's individual components.</summary>
         public override void Start()
         {
-            this.SystemHost.UpdateSystemHost(this, "Starting...");
-            this.WorldBehavior.Load();
-            this.SystemHost.UpdateSystemHost(this, "Started");
+            SystemHost.UpdateSystemHost(this, "Starting...");
+            WorldBehavior.Load();
+            SystemHost.UpdateSystemHost(this, "Started");
         }
 
         /// <summary>Stops this system's individual components.</summary>
         public override void Stop()
         {
-            this.SystemHost.UpdateSystemHost(this, "Stopping...");
-            //// TODO: this.WorldBehavior.Areas.Clear();
-            this.SystemHost.UpdateSystemHost(this, "Stopped");
+            SystemHost.UpdateSystemHost(this, "Stopping...");
+            //// TODO: WorldBehavior.Areas.Clear();
+            SystemHost.UpdateSystemHost(this, "Stopped");
         }
 
         /// <summary>Registers the <see cref="PlacesManager"/> system for export.</summary>

--- a/src/Core/ManagerSystems/SessionManager.cs
+++ b/src/Core/ManagerSystems/SessionManager.cs
@@ -17,7 +17,7 @@ namespace WheelMUD.Core
         /// <summary>Prevents a default instance of the <see cref="SessionManager"/> class from being created.</summary>
         private SessionManager()
         {
-            this.Sessions = new Dictionary<string, Session>();
+            Sessions = new Dictionary<string, Session>();
         }
 
         /// <summary>Gets the singleton instance of the <see cref="SessionManager"/> system.</summary>
@@ -30,7 +30,7 @@ namespace WheelMUD.Core
         /// <param name="connection">The connected session.</param>
         public void OnSessionConnected(IConnection connection)
         {
-            this.CreateSession(connection);
+            CreateSession(connection);
         }
 
         /// <summary>Called upon session disconnection.</summary>
@@ -38,15 +38,15 @@ namespace WheelMUD.Core
         public void OnSessionDisconnected(IConnection connection)
         {
             ////if (SessionDisconnected != null)
-            ////    SessionDisconnected(this.Sessions[connection.ID]);#
-            lock (this.Sessions)
+            ////    SessionDisconnected(Sessions[connection.ID]);#
+            lock (Sessions)
             {
-                if (this.Sessions.ContainsKey(connection.ID))
+                if (Sessions.ContainsKey(connection.ID))
                 {
-                    PlayerManager.Instance.OnSessionDisconnected(this.Sessions[connection.ID]);
+                    PlayerManager.Instance.OnSessionDisconnected(Sessions[connection.ID]);
                 }
 
-                this.RemoveSession(connection.ID);
+                RemoveSession(connection.ID);
             }
         }
 
@@ -54,9 +54,9 @@ namespace WheelMUD.Core
         /// <param name="session">The authenticated session.</param>
         public void OnSessionAuthenticated(Session session)
         {
-            session.ActionReceived += this.Controller_ActionReceived;
+            session.ActionReceived += Controller_ActionReceived;
 
-            this.SystemHost.UpdateSystemHost(this, session.ID + " - Session Authenticated");
+            SystemHost.UpdateSystemHost(this, session.ID + " - Session Authenticated");
 
             // Tell the player manager about the new authenticated session.
             PlayerManager.Instance.OnSessionAuthenticated(session);
@@ -71,11 +71,11 @@ namespace WheelMUD.Core
             // established.  For now, ignore any such early input and avoid locking 
             // the sessions collection for the duration of the command processing.
             Session session = null;
-            lock (this.Sessions)
+            lock (Sessions)
             {
-                if (this.Sessions.ContainsKey(connection.ID))
+                if (Sessions.ContainsKey(connection.ID))
                 {
-                    session = this.Sessions[connection.ID];
+                    session = Sessions[connection.ID];
                 }
             }
 
@@ -85,22 +85,22 @@ namespace WheelMUD.Core
         /// <summary>Starts this system's individual components.</summary>
         public override void Start()
         {
-            this.SystemHost.UpdateSystemHost(this, "Starting...");
+            SystemHost.UpdateSystemHost(this, "Starting...");
 
-            this.SystemHost.UpdateSystemHost(this, "Started");
+            SystemHost.UpdateSystemHost(this, "Started");
         }
 
         /// <summary>Stops this system's individual components.</summary>
         public override void Stop()
         {
-            this.SystemHost.UpdateSystemHost(this, "Stopping...");
+            SystemHost.UpdateSystemHost(this, "Stopping...");
 
-            lock (this.Sessions)
+            lock (Sessions)
             {
-                this.Sessions.Clear();
+                Sessions.Clear();
             }
 
-            this.SystemHost.UpdateSystemHost(this, "Stopped");
+            SystemHost.UpdateSystemHost(this, "Stopped");
         }
 
         /// <summary>Creates a new session for the specified connection.</summary>
@@ -118,14 +118,14 @@ namespace WheelMUD.Core
             var session = new Session(connection);
 
             // Handle our session authenticated event.
-            session.SessionAuthenticated += this.OnSessionAuthenticated;
+            session.SessionAuthenticated += OnSessionAuthenticated;
 
             session.SubscribeToSystem(this);
 
             // Add the new session to our collection.
-            lock (this.Sessions)
+            lock (Sessions)
             {
-                this.Sessions.Add(connection.ID, session);
+                Sessions.Add(connection.ID, session);
             }
 
             return session;
@@ -138,19 +138,19 @@ namespace WheelMUD.Core
             // We remove the session from the collection, but we also
             // have to trigger the player unloaded event as the session
             // object is not aware of being unloaded.
-            lock (this.Sessions)
+            lock (Sessions)
             {
-                if (this.Sessions.ContainsKey(sessionID))
+                if (Sessions.ContainsKey(sessionID))
                 {
                     //// Fire our player unloaded event so that it can be handled by
                     //// the player manager
-                    ////if (this.PlayerUnloaded != null)
+                    ////if (PlayerUnloaded != null)
                     ////    PlayerUnloaded(session.Player);
-                    Session session = this.Sessions[sessionID];
-                    session.SessionAuthenticated -= this.OnSessionAuthenticated;
+                    Session session = Sessions[sessionID];
+                    session.SessionAuthenticated -= OnSessionAuthenticated;
                     session.UnsubscribeToSystem();
 
-                    this.Sessions.Remove(sessionID);
+                    Sessions.Remove(sessionID);
                 }
             }
         }

--- a/src/Core/ManagerSystems/ThingManager.cs
+++ b/src/Core/ManagerSystems/ThingManager.cs
@@ -36,14 +36,14 @@ namespace WheelMUD.Core
         public static ThingManager Instance => SingletonInstance.Value;
 
         /// <summary>Gets the collection of things.</summary>
-        public ICollection<Thing> Things => this.things.Values.ToList().AsReadOnly();
+        public ICollection<Thing> Things => things.Values.ToList().AsReadOnly();
 
         /// <summary>Determines whether a Thing is currently spawned in the world given the item id.</summary>
         /// <param name="thingID">The Thing ID to search for.</param>
         /// <returns><c>true</c> if Thing is in the world; otherwise, <c>false</c>.</returns>
         public bool IsThingInWorld(string thingID)
         {
-            return this.things.ContainsKey(thingID);
+            return things.ContainsKey(thingID);
         }
 
         /// <summary>Determines whether any Things match the specified condition.</summary>
@@ -51,7 +51,7 @@ namespace WheelMUD.Core
         /// <returns>True if at least one Thing matches the condition; otherwise, false.</returns>
         public bool Any(Func<Thing, bool> condition)
         {
-            return this.things.Values.Any(condition);
+            return things.Values.Any(condition);
         }
 
         /// <summary>Counts the number of Things matching the specified condition.</summary>
@@ -59,7 +59,7 @@ namespace WheelMUD.Core
         /// <returns>The number of Things matching the specified condition.</returns>
         public int Count(Func<Thing, bool> condition)
         {
-            return this.things.Values.Count(condition);
+            return things.Values.Count(condition);
         }
 
         /// <summary>Gets a Thing given a Thing ID.</summary>
@@ -68,7 +68,7 @@ namespace WheelMUD.Core
         public Thing FindThing(string thingID)
         {
             Thing thing;
-            this.things.TryGetValue(thingID, out thing);
+            things.TryGetValue(thingID, out thing);
             return thing;
         }
 
@@ -84,8 +84,8 @@ namespace WheelMUD.Core
                                               : StringComparison.CurrentCulture;
 
             return partialMatch
-                       ? this.things.Values.FirstOrDefault(thing => thing.Name.StartsWith(name, ignoreCase, null))
-                       : this.things.Values.FirstOrDefault(thing => string.Equals(thing.Name, name, comparison));
+                       ? things.Values.FirstOrDefault(thing => thing.Name.StartsWith(name, ignoreCase, null))
+                       : things.Values.FirstOrDefault(thing => string.Equals(thing.Name, name, comparison));
         }
 
         /// <summary>Retrieves a collection of things matching the specified condition.</summary>
@@ -93,7 +93,7 @@ namespace WheelMUD.Core
         /// <returns>A collection of things matching the condition.</returns>
         public IList<Thing> Find(Func<Thing, bool> condition)
         {
-            return this.things.Values.Where(condition).ToList().AsReadOnly();
+            return things.Values.Where(condition).ToList().AsReadOnly();
         }
 
         /// <summary>Tries to retrieve a Thing matching the specified condition.</summary>
@@ -101,7 +101,7 @@ namespace WheelMUD.Core
         /// <returns>The first Thing matching the condition, or null if none was found.</returns>
         public Thing FirstOrDefault(Func<Thing, bool> condition)
         {
-            return this.things.Values.FirstOrDefault(condition);
+            return things.Values.FirstOrDefault(condition);
         }
 
         /// <summary>Tries to move a Thing from its current location into the specified location, if that thing is movable.</summary>
@@ -130,7 +130,7 @@ namespace WheelMUD.Core
             }
 
             Thing removedThing;
-            return this.things.TryRemove(thing.Id, out removedThing);
+            return things.TryRemove(thing.Id, out removedThing);
         }
 
         /// <summary>Calls <see cref="DestroyThing"/> on all things matching the specified condition.</summary>
@@ -138,9 +138,9 @@ namespace WheelMUD.Core
         /// <returns>The number of things that were successfully destroyed.</returns>
         public int Destroy(Func<Thing, bool> condition)
         {
-            var thingsToRemove = this.things.Values.Where(condition);
+            var thingsToRemove = things.Values.Where(condition);
 
-            return thingsToRemove.Count(thing => this.DestroyThing(thing));
+            return thingsToRemove.Count(thing => DestroyThing(thing));
         }
 
         /// <summary>Starts this system's individual components.</summary>
@@ -151,7 +151,7 @@ namespace WheelMUD.Core
         /// <summary>Stops this system's individual components.</summary>
         public override void Stop()
         {
-            this.things.Clear();
+            things.Clear();
         }
 
         /// <summary>Add or update the ThingManager's cache of Things; should be called when the Id of a Thing is established or changes.</summary>
@@ -166,18 +166,18 @@ namespace WheelMUD.Core
         {
             Debug.Assert(oldId != newId, "UpdateThingRegistration should not be called when not changing the Thing ID.");
             Debug.Assert(!string.IsNullOrEmpty(newId), "After initialization, a Thing's Id should never become null or empty!");
-            ////Debug.Assert(!this.things.ContainsKey(newId), "A Thing has been assigned an Id which is not unique!");
+            ////Debug.Assert(!things.ContainsKey(newId), "A Thing has been assigned an Id which is not unique!");
 
             if (!string.IsNullOrEmpty(oldId))
             {
                 Thing removedThingOldId;
-                this.things.TryRemove(oldId, out removedThingOldId);
+                things.TryRemove(oldId, out removedThingOldId);
             }
 
             Thing removedThingNewId;
-            this.things.TryRemove(newId, out removedThingNewId);
+            things.TryRemove(newId, out removedThingNewId);
 
-            return this.things.TryAdd(newId, updatedThing);
+            return things.TryAdd(newId, updatedThing);
         }
 
         /// <summary>Exporter for MEF.</summary>

--- a/src/Core/ManagerSystems/TimeSystem.cs
+++ b/src/Core/ManagerSystems/TimeSystem.cs
@@ -53,25 +53,25 @@ namespace WheelMUD.Core
         /// <summary>Start the time system.</summary>
         public override void Start()
         {
-            this.SystemHost.UpdateSystemHost(this, "Starting...");
+            SystemHost.UpdateSystemHost(this, "Starting...");
 
-            if (this.timer == null)
+            if (timer == null)
             {
-                this.timer = new Timer(this.DoCallbacks, null, this.interval, this.interval);
+                timer = new Timer(DoCallbacks, null, interval, interval);
             }
 
-            this.SystemHost.UpdateSystemHost(this, "Started");
+            SystemHost.UpdateSystemHost(this, "Started");
         }
 
         /// <summary>Stops the time system.</summary>
         public override void Stop()
         {
-            this.SystemHost.UpdateSystemHost(this, "Stopping...");
+            SystemHost.UpdateSystemHost(this, "Stopping...");
 
-            this.timer.Change(Timeout.Infinite, Timeout.Infinite);
-            this.timer.Dispose();
+            timer.Change(Timeout.Infinite, Timeout.Infinite);
+            timer.Dispose();
 
-            this.SystemHost.UpdateSystemHost(this, "Stopped");
+            SystemHost.UpdateSystemHost(this, "Stopped");
         }
 
         /// <summary>Schedules an action according to the supplied <see cref="WheelMUD.Core.TimeEvent"/>.</summary>
@@ -83,9 +83,9 @@ namespace WheelMUD.Core
                 throw new ArgumentException("Cannot schedule a null event.", "args");
             }
 
-            lock (this.callbackQueue)
+            lock (callbackQueue)
             {
-                this.callbackQueue.Enqueue(timeEventArgs);
+                callbackQueue.Enqueue(timeEventArgs);
             }
         }
 
@@ -93,14 +93,14 @@ namespace WheelMUD.Core
         /// <param name="state">Currently unused.</param>
         private void DoCallbacks(object state)
         {
-            lock (this.callbackQueue)
+            lock (callbackQueue)
             {
                 // Loop over all events that have expired.
                 DateTime currentTime = DateTime.Now;
-                TimeEvent timeEvent = this.callbackQueue.Peek();
+                TimeEvent timeEvent = callbackQueue.Peek();
                 while (timeEvent != null && timeEvent.EndTime <= currentTime)
                 {
-                    var callback = this.callbackQueue.Dequeue().Callback;
+                    var callback = callbackQueue.Dequeue().Callback;
 
                     if (!timeEvent.IsCancelled)
                     {
@@ -110,7 +110,7 @@ namespace WheelMUD.Core
                         }
                     }
 
-                    timeEvent = this.callbackQueue.Peek();
+                    timeEvent = callbackQueue.Peek();
                 }
             }
         }
@@ -142,10 +142,10 @@ namespace WheelMUD.Core
             /// <param name="timeEventArgs">The <see cref="WheelMUD.Core.TimeEvent"/> instance containing the event data.</param>
             public void Enqueue(TimeEvent timeEventArgs)
             {
-                lock (this.heap)
+                lock (heap)
                 {
-                    this.heap.Add(timeEventArgs);
-                    this.UpHeap();
+                    heap.Add(timeEventArgs);
+                    UpHeap();
                 }
             }
 
@@ -153,9 +153,9 @@ namespace WheelMUD.Core
             /// <returns>The highest-priority <see cref="WheelMUD.Core.TimeEvent"/> item.</returns>
             public TimeEvent Peek()
             {
-                lock (this.heap)
+                lock (heap)
                 {
-                    return (this.heap.Count > 0) ? this.heap[0] : null;
+                    return (heap.Count > 0) ? heap[0] : null;
                 }
             }
 
@@ -163,14 +163,14 @@ namespace WheelMUD.Core
             /// <returns>The highest-priority <see cref="WheelMUD.Core.TimeEvent"/> item.</returns>
             public TimeEvent Dequeue()
             {
-                lock (this.heap)
+                lock (heap)
                 {
-                    if (this.heap.Count > 0)
+                    if (heap.Count > 0)
                     {
-                        var result = this.heap[0];
-                        this.heap[0] = this.heap.Last();
-                        this.heap.RemoveAt(this.heap.Count - 1);
-                        this.DownHeap();
+                        var result = heap[0];
+                        heap[0] = heap.Last();
+                        heap.RemoveAt(heap.Count - 1);
+                        DownHeap();
                         return result;
                     }
 
@@ -181,18 +181,18 @@ namespace WheelMUD.Core
             /// <summary>Adjusts the heap for the case where a new item was added.</summary>
             private void UpHeap()
             {
-                if (this.heap.Count < 2)
+                if (heap.Count < 2)
                 {
                     return;
                 }
 
-                int child = this.heap.Count - 1;
+                int child = heap.Count - 1;
                 int parent = (child - 1) / 2;
-                var newest = this.heap[child];
+                var newest = heap[child];
 
-                while (newest.EndTime < this.heap[parent].EndTime)
+                while (newest.EndTime < heap[parent].EndTime)
                 {
-                    this.heap[child] = this.heap[parent];
+                    heap[child] = heap[parent];
                     child = parent;
                     if (parent == 0)
                     {
@@ -202,13 +202,13 @@ namespace WheelMUD.Core
                     parent = (parent - 1) / 2;
                 }
 
-                this.heap[child] = newest;
+                heap[child] = newest;
             }
 
             /// <summary>Adjusts the heap for the case where the highest-priority item was removed.</summary>
             private void DownHeap()
             {
-                if (this.heap.Count < 2)
+                if (heap.Count < 2)
                 {
                     return;
                 }
@@ -216,27 +216,27 @@ namespace WheelMUD.Core
                 int parent = 0;
                 int leftChild = 1;
                 int rightChild = leftChild + 1;
-                var item = this.heap[parent];
+                var item = heap[parent];
 
-                if (rightChild < this.heap.Count - 1 && this.heap[rightChild].EndTime < this.heap[leftChild].EndTime)
+                if (rightChild < heap.Count - 1 && heap[rightChild].EndTime < heap[leftChild].EndTime)
                 {
                     leftChild = rightChild;
                 }
 
-                while (leftChild < this.heap.Count - 1 && this.heap[leftChild].EndTime < item.EndTime)
+                while (leftChild < heap.Count - 1 && heap[leftChild].EndTime < item.EndTime)
                 {
-                    this.heap[parent] = this.heap[leftChild];
+                    heap[parent] = heap[leftChild];
                     parent = leftChild;
                     leftChild = (parent * 2) + 1;
                     rightChild = leftChild + 1;
 
-                    if (rightChild < this.heap.Count - 1 && this.heap[rightChild].EndTime < this.heap[leftChild].EndTime)
+                    if (rightChild < heap.Count - 1 && heap[rightChild].EndTime < heap[leftChild].EndTime)
                     {
                         leftChild = rightChild;
                     }
                 }
 
-                this.heap[parent] = item;
+                heap[parent] = item;
             }
         }
     }

--- a/src/Core/Output/OutputBuffer.cs
+++ b/src/Core/Output/OutputBuffer.cs
@@ -26,7 +26,7 @@ namespace WheelMUD.Core.Output
         /// <summary>Gets the total length of the output buffer.</summary>
         public int Length
         {
-            get { return this.outputBuffer.Count; }
+            get { return outputBuffer.Count; }
         }
 
         /// <summary>Gets the current location in the output buffer.</summary>
@@ -37,11 +37,11 @@ namespace WheelMUD.Core.Output
         {
             get
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    int length = this.outputBuffer.Count;
+                    int length = outputBuffer.Count;
 
-                    if (length > 0 && this.CurrentLocation < length)
+                    if (length > 0 && CurrentLocation < length)
                     {
                         return true;
                     }
@@ -55,9 +55,9 @@ namespace WheelMUD.Core.Output
         /// <param name="outputRow">Single row to add to the buffer.</param>
         public void Append(string outputRow)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                this.outputBuffer.Add(outputRow);
+                outputBuffer.Add(outputRow);
             }
         }
 
@@ -65,11 +65,11 @@ namespace WheelMUD.Core.Output
         /// <param name="outputRows">Rows to add to the buffer.</param>
         public void Append(string[] outputRows)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
                 foreach (string outputRow in outputRows)
                 {
-                    this.outputBuffer.Add(outputRow);
+                    outputBuffer.Add(outputRow);
                 }
             }
         }
@@ -77,10 +77,10 @@ namespace WheelMUD.Core.Output
         /// <summary>Clears out the output buffer.</summary>
         public void Clear()
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                this.outputBuffer.Clear();
-                this.CurrentLocation = 0;
+                outputBuffer.Clear();
+                CurrentLocation = 0;
             }
         }
 
@@ -90,9 +90,9 @@ namespace WheelMUD.Core.Output
         /// <returns>Rows from the output buffer.</returns>
         public string[] GetRows(BufferDirection bufferDirection, int maxRows)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                int start = this.CurrentLocation;
+                int start = CurrentLocation;
                 int end = 0;
 
                 switch (bufferDirection)
@@ -119,23 +119,23 @@ namespace WheelMUD.Core.Output
                         end = start + maxRows;
                         break;
                     case BufferDirection.ForwardAllData:
-                        end = this.outputBuffer.Count;
+                        end = outputBuffer.Count;
                         break;
                 }
 
-                if (end > this.outputBuffer.Count)
+                if (end > outputBuffer.Count)
                 {
-                    end = this.outputBuffer.Count;
+                    end = outputBuffer.Count;
                 }
 
                 string[] output = new string[end - start];
 
                 for (int i = start; i < end; i++)
                 {
-                    output[i - start] = this.outputBuffer[i];
+                    output[i - start] = outputBuffer[i];
                 }
 
-                this.CurrentLocation = end;
+                CurrentLocation = end;
                 return output;
             }
         }

--- a/src/Core/Renderer/DefaultWhoRenderer.cs
+++ b/src/Core/Renderer/DefaultWhoRenderer.cs
@@ -48,7 +48,7 @@ namespace WheelMUD.Core
             {
                 // TODO: "tell {0}" is not a good menu command; possibly friend add/remove, invite to group, hailing, and so on.
                 var playerName = player.Parent.Name;
-                var playerState = this.GetPlayerState(player);
+                var playerState = GetPlayerState(player);
                 sb.AppendLine($"<%mxpsecureline%><send \"finger {playerName}|tell {playerName}\" \"|finger|tell\">{playerName}</send> - {player.Parent.FullName} {playerState}");
             }
 

--- a/src/Core/Renderer/Renderer.cs
+++ b/src/Core/Renderer/Renderer.cs
@@ -20,7 +20,7 @@ namespace WheelMUD.Core
         /// <summary>Prevents a default instance of the Renderer class from being created.</summary>
         private Renderer()
         {
-            this.Recompose();
+            Recompose();
         }
 
         /// <summary>The current CommandsCategories renderer.</summary>
@@ -102,57 +102,57 @@ namespace WheelMUD.Core
 
         public string RenderCommandsCategories(ITerminal terminal, IEnumerable<Command> commands)
         {
-            return this.currentCommandsCategoriesRenderer.Render(terminal, commands);
+            return currentCommandsCategoriesRenderer.Render(terminal, commands);
         }
 
         public string RenderCommandsList(ITerminal terminal, IEnumerable<Command> commands, string categoryName)
         {
-            return this.currentCommandsListRenderer.Render(terminal, commands, categoryName);
+            return currentCommandsListRenderer.Render(terminal, commands, categoryName);
         }
 
         public string RenderHelpCommand(ITerminal terminal, Command command)
         {
-            return this.currentHelpCommandRenderer.Render(terminal, command);
+            return currentHelpCommandRenderer.Render(terminal, command);
         }
 
         public string RenderHelpTopic(ITerminal terminal, HelpTopic helpTopic)
         {
-            return this.currentHelpTopicRenderer.Render(terminal, helpTopic);
+            return currentHelpTopicRenderer.Render(terminal, helpTopic);
         }
 
         public string RenderHelpTopics(ITerminal terminal)
         {
-            return this.currentHelpTopicsRenderer.Render(terminal);
+            return currentHelpTopicsRenderer.Render(terminal);
         }
 
         public string RenderInventory(Thing player)
         {
-            return this.currentInventoryRenderer.Render(player);
+            return currentInventoryRenderer.Render(player);
         }
 
         public string RenderPerceivedRoom(Thing viewer, Thing viewedRoom)
         {
-            return this.currentPerceivedRoomRenderer.Render(viewer, viewedRoom);
+            return currentPerceivedRoomRenderer.Render(viewer, viewedRoom);
         }
 
         public string RenderPerceivedThing(Thing viewer, Thing viewedThing)
         {
-            return this.currentPerceivedThingRenderer.Render(viewer, viewedThing);
+            return currentPerceivedThingRenderer.Render(viewer, viewedThing);
         }
 
         public string RenderScore(Thing player)
         {
-            return this.currentScoreRenderer.Render(player);
+            return currentScoreRenderer.Render(player);
         }
 
         public string RenderSplashScreen()
         {
-            return this.currentSplashScreenRenderer.Render();
+            return currentSplashScreenRenderer.Render();
         }
 
         public string RenderWho(Thing player)
         {
-            return this.currentWhoRenderer.Render(player);
+            return currentWhoRenderer.Render(player);
         }
 
         /// <summary>Recompose the subcomponents of this Renderer.</summary>
@@ -161,17 +161,17 @@ namespace WheelMUD.Core
             DefaultComposer.Container.ComposeParts(this);
 
             // Search each of the renderers for the one which has the highest priority.
-            this.currentCommandsCategoriesRenderer = DefaultComposer.GetInstance(this.CommandsCategoriesRenderers);
-            this.currentCommandsListRenderer = DefaultComposer.GetInstance(this.CommandsListRenderers);
-            this.currentHelpCommandRenderer = DefaultComposer.GetInstance(this.HelpCommandRenderers);
-            this.currentHelpTopicRenderer = DefaultComposer.GetInstance(this.HelpTopicRenderers);
-            this.currentHelpTopicsRenderer = DefaultComposer.GetInstance(this.HelpTopicsRenderers);
-            this.currentInventoryRenderer = DefaultComposer.GetInstance(this.InventoryRenderers);
-            this.currentPerceivedRoomRenderer = DefaultComposer.GetInstance(this.PerceivedRoomRenderers);
-            this.currentPerceivedThingRenderer = DefaultComposer.GetInstance(this.PerceivedThingRenderers);
-            this.currentScoreRenderer = DefaultComposer.GetInstance(this.ScoreRenderers);
-            this.currentSplashScreenRenderer = DefaultComposer.GetInstance(this.SplashScreenRenderers);
-            this.currentWhoRenderer = DefaultComposer.GetInstance(this.WhoRenderers);
+            currentCommandsCategoriesRenderer = DefaultComposer.GetInstance(CommandsCategoriesRenderers);
+            currentCommandsListRenderer = DefaultComposer.GetInstance(CommandsListRenderers);
+            currentHelpCommandRenderer = DefaultComposer.GetInstance(HelpCommandRenderers);
+            currentHelpTopicRenderer = DefaultComposer.GetInstance(HelpTopicRenderers);
+            currentHelpTopicsRenderer = DefaultComposer.GetInstance(HelpTopicsRenderers);
+            currentInventoryRenderer = DefaultComposer.GetInstance(InventoryRenderers);
+            currentPerceivedRoomRenderer = DefaultComposer.GetInstance(PerceivedRoomRenderers);
+            currentPerceivedThingRenderer = DefaultComposer.GetInstance(PerceivedThingRenderers);
+            currentScoreRenderer = DefaultComposer.GetInstance(ScoreRenderers);
+            currentSplashScreenRenderer = DefaultComposer.GetInstance(SplashScreenRenderers);
+            currentWhoRenderer = DefaultComposer.GetInstance(WhoRenderers);
         }
     }
 }

--- a/src/Core/Renderer/RendererExports.cs
+++ b/src/Core/Renderer/RendererExports.cs
@@ -23,7 +23,7 @@ namespace WheelMUD.Core
             /// <remarks>Unfortunately C# won't let us use generics to define ExportAttributes, or this file would be a lot less verbose.</remarks>
             public BaseExportAttribute(int rendererPriority, Type rendererDefinitionType) : base(rendererDefinitionType)
             {
-                this.Priority = rendererPriority;
+                Priority = rendererPriority;
             }
 
             /// <summary>Gets or sets the priority of the exported renderer; the renderer with the highest priority will be used.</summary>

--- a/src/Core/ScriptingCommand.cs
+++ b/src/Core/ScriptingCommand.cs
@@ -26,11 +26,11 @@ namespace WheelMUD.Core
             SecurityRole securityRole,
             ActionInput actionInput)
         {
-            this.Name = name;
-            this.ExecuteDelegate = executeDelegate;
-            this.GuardsDelegate = guardsDelegate;
-            this.SecurityRole = securityRole;
-            this.ActionInput = actionInput;
+            Name = name;
+            ExecuteDelegate = executeDelegate;
+            GuardsDelegate = guardsDelegate;
+            SecurityRole = securityRole;
+            ActionInput = actionInput;
         }
 
         /// <summary>Gets the name of the scripting command.</summary>

--- a/src/Core/Senses/SenseManager.cs
+++ b/src/Core/Senses/SenseManager.cs
@@ -26,12 +26,12 @@ namespace WheelMUD.Core
         {
             get
             {
-                return this.SenseDictionary[index];
+                return SenseDictionary[index];
             }
 
             set
             {
-                this.SenseDictionary[index] = value;
+                SenseDictionary[index] = value;
             }
         }
 
@@ -39,9 +39,9 @@ namespace WheelMUD.Core
         /// <param name="sense">The sense to add.</param>
         public void AddSense(Sense sense)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                this.SenseDictionary.Add(sense.SensoryType, sense);
+                SenseDictionary.Add(sense.SensoryType, sense);
             }
         }
 
@@ -49,9 +49,9 @@ namespace WheelMUD.Core
         /// <param name="sense">The sense to remove.</param>
         public void RemoveSense(Sense sense)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                this.SenseDictionary.Remove(sense.SensoryType);
+                SenseDictionary.Remove(sense.SensoryType);
             }
         }
 
@@ -60,7 +60,7 @@ namespace WheelMUD.Core
         /// <returns>True if the collection of senses contains this sense, else false.</returns>
         public bool Contains(Sense sense)
         {
-            return this.SenseDictionary.ContainsKey(sense.SensoryType);
+            return SenseDictionary.ContainsKey(sense.SensoryType);
         }
 
         /// <summary>Determines if the collection of senses contain the specified sense.</summary>
@@ -68,9 +68,9 @@ namespace WheelMUD.Core
         /// <returns>True if the collection of senses contains this sense, else false.</returns>
         public bool Contains(SensoryType senseType)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                return this.SenseDictionary.ContainsKey(senseType);
+                return SenseDictionary.ContainsKey(senseType);
             }
         }
 
@@ -78,21 +78,21 @@ namespace WheelMUD.Core
         /// <returns>The total count of all senses.</returns>
         public int Count()
         {
-            return this.SenseDictionary.Count;
+            return SenseDictionary.Count;
         }
 
         /// <summary>Gets an enumerator for the senses.</summary>
         /// <returns>An enumerator for the senses.</returns>
         public IEnumerator<Sense> GetEnumerator()
         {
-            return this.SenseDictionary.Values.GetEnumerator();
+            return SenseDictionary.Values.GetEnumerator();
         }
 
         /// <summary>Gets the dictionary of senses.</summary>
         /// <returns>A dictionary of senses.</returns>
         public Dictionary<SensoryType, Sense> GetSenses()
         {
-            return this.SenseDictionary;
+            return SenseDictionary;
         }
 
         /// <summary>Determine if the specified sensory message can be processed.</summary>
@@ -100,10 +100,10 @@ namespace WheelMUD.Core
         /// <returns>True if it can be processed, else false.</returns>
         public bool CanProcessSensoryMessage(SensoryMessage message)
         {
-            if (this.SenseDictionary.ContainsKey(message.TargetedSense) &&
-                this.SenseDictionary[message.TargetedSense].LowThreshold <= message.MessageStrength &&
-                this.SenseDictionary[message.TargetedSense].HighThreshold >= message.MessageStrength &&
-                this.SenseDictionary[message.TargetedSense].Enabled)
+            if (SenseDictionary.ContainsKey(message.TargetedSense) &&
+                SenseDictionary[message.TargetedSense].LowThreshold <= message.MessageStrength &&
+                SenseDictionary[message.TargetedSense].HighThreshold >= message.MessageStrength &&
+                SenseDictionary[message.TargetedSense].Enabled)
             {
                 return true;
             }

--- a/src/Core/Senses/SensesBehavior.cs
+++ b/src/Core/Senses/SensesBehavior.cs
@@ -25,7 +25,7 @@ namespace WheelMUD.Core
         public SensesBehavior(long instanceId, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceId;
+            ID = instanceId;
         }
 
         /// <summary>Gets or sets the senses this thing has access to.</summary>
@@ -35,13 +35,13 @@ namespace WheelMUD.Core
         /// <returns>A list of perceived exits.</returns>
         public List<string> PerceiveExits()
         {
-            if (this.Parent != null)
+            if (Parent != null)
             {
                 var exits = new List<string>();
 
                 // If the thing we are in now is exitable, then add the exit command.
-                var location = this.Parent.Parent;
-                var enterableExitableBehavior = this.Parent.Behaviors.FindFirst<EnterableExitableBehavior>();
+                var location = Parent.Parent;
+                var enterableExitableBehavior = Parent.Behaviors.FindFirst<EnterableExitableBehavior>();
                 if (enterableExitableBehavior != null)
                 {
                     exits.Add(enterableExitableBehavior.ExitCommand);
@@ -55,7 +55,7 @@ namespace WheelMUD.Core
                         var exitBehavior = thing.Behaviors.FindFirst<ExitBehavior>();
                         if (exitBehavior != null)
                         {
-                            if (thing.IsDetectableBySense(this.Senses))
+                            if (thing.IsDetectableBySense(Senses))
                             {
                                 exits.Add(exitBehavior.GetExitCommandFrom(location));
                             }
@@ -65,7 +65,7 @@ namespace WheelMUD.Core
                             enterableExitableBehavior = thing.Behaviors.FindFirst<EnterableExitableBehavior>();
                             if (enterableExitableBehavior != null)
                             {
-                                if (thing.IsDetectableBySense(this.Senses))
+                                if (thing.IsDetectableBySense(Senses))
                                 {
                                     exits.Add(enterableExitableBehavior.EnterCommand);
                                 }
@@ -85,17 +85,17 @@ namespace WheelMUD.Core
         public IList<Thing> PerceiveEntities()
         {
             // TODO: Refactor the perceive categories... players, mobs, items, exits, etc.
-            if (this.Parent != null)
+            if (Parent != null)
             {
                 var outEntities = new List<Thing>();
 
                 // TODO: Change Parent.Parent to a predicate that will find RoomBehaviors. This is a an ugly hack that needs to go away.
-                var entities = this.Parent.Parent.FindAllChildren(t => t.HasBehavior<PlayerBehavior>() || t.HasBehavior<MobileBehavior>());
+                var entities = Parent.Parent.FindAllChildren(t => t.HasBehavior<PlayerBehavior>() || t.HasBehavior<MobileBehavior>());
 
                 foreach (Thing thing in entities)
                 {
                     // TODO: Add '&& thing has EntityBehavior' or whatnot...
-                    if (thing != this.Parent && thing.IsDetectableBySense(this.Senses))
+                    if (thing != Parent && thing.IsDetectableBySense(Senses))
                     {
                         outEntities.Add(thing);
                     }
@@ -111,7 +111,7 @@ namespace WheelMUD.Core
         /// <returns>A list of perceived items.</returns>
         public IList<Thing> PerceiveItems()
         {
-            var self = this.Parent;
+            var self = Parent;
             if (self != null)
             {
                 var room = self.Parent;
@@ -121,7 +121,7 @@ namespace WheelMUD.Core
                     foreach (Thing item in room.Children)
                     {
                         // TODO: Use something like 'has ItemBehavior' instead?
-                        if (item.IsDetectableBySense(this.Senses) &&
+                        if (item.IsDetectableBySense(Senses) &&
                             !item.HasBehavior<ExitBehavior>() &&
                             !item.HasBehavior<PlayerBehavior>() &&
                             !item.HasBehavior<MobileBehavior>())
@@ -145,24 +145,24 @@ namespace WheelMUD.Core
         {
             // Distance-size, the perceiving thing should be able to perceive the place it is in (e.g. room), other
             // things in the same place, and its own things (e.g. inventory items).
-            bool isLocal = this.Parent.Parent == thing ||
-                (this.Parent.Parent != null && this.Parent.Parent.FindChild(t => t == thing) != null) ||
-                this.Parent.FindChild(t => t == thing) != null;
-            return isLocal && thing.IsDetectableBySense(this.Senses);
+            bool isLocal = Parent.Parent == thing ||
+                (Parent.Parent != null && Parent.Parent.FindChild(t => t == thing) != null) ||
+                Parent.FindChild(t => t == thing) != null;
+            return isLocal && thing.IsDetectableBySense(Senses);
         }
 
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.Senses = new SenseManager();
-            this.LoadDefaultSenses();
+            Senses = new SenseManager();
+            LoadDefaultSenses();
         }
 
         /// <summary>Load the senses of the entity.</summary>
         private void LoadDefaultSenses()
         {
             // TODO: Each sense's details should be persistable/designable per race, etc.
-            this.Senses.AddSense(new Sense()
+            Senses.AddSense(new Sense()
             {
                 SensoryType = SensoryType.Hearing,
                 MessagePrefix = "[HEARING]",
@@ -172,7 +172,7 @@ namespace WheelMUD.Core
                 HighThreshold = 100,
             });
 
-            this.Senses.AddSense(new Sense()
+            Senses.AddSense(new Sense()
             {
                 SensoryType = SensoryType.Sight,
                 MessagePrefix = "[SIGHT]",
@@ -182,7 +182,7 @@ namespace WheelMUD.Core
                 HighThreshold = 100,
             });
 
-            this.Senses.AddSense(new Sense()
+            Senses.AddSense(new Sense()
             {
                 SensoryType = SensoryType.Smell,
                 MessagePrefix = "[SMELL]",
@@ -192,7 +192,7 @@ namespace WheelMUD.Core
                 HighThreshold = 100,
             });
 
-            this.Senses.AddSense(new Sense()
+            Senses.AddSense(new Sense()
             {
                 SensoryType = SensoryType.Touch,
                 MessagePrefix = "[TOUCH]",
@@ -202,7 +202,7 @@ namespace WheelMUD.Core
                 HighThreshold = 100,
             });
 
-            this.Senses.AddSense(new Sense()
+            Senses.AddSense(new Sense()
             {
                 SensoryType = SensoryType.Taste,
                 MessagePrefix = "[TASTE]",
@@ -212,7 +212,7 @@ namespace WheelMUD.Core
                 HighThreshold = 100,
             });
 
-            this.Senses.AddSense(new Sense()
+            Senses.AddSense(new Sense()
             {
                 SensoryType = SensoryType.Debug,
                 MessagePrefix = "[DEBUG]",

--- a/src/Core/Senses/SensoryMessage.cs
+++ b/src/Core/Senses/SensoryMessage.cs
@@ -19,10 +19,10 @@ namespace WheelMUD.Core
         /// <param name="context">The context for the view processor to use to render the message.</param>
         public SensoryMessage(SensoryType targetedSense, int messageStrength, ContextualStringBuilder message, Hashtable context)
         {
-            this.TargetedSense = targetedSense;
-            this.MessageStrength = messageStrength;
-            this.Message = message;
-            this.Context = context;
+            TargetedSense = targetedSense;
+            MessageStrength = messageStrength;
+            Message = message;
+            Context = context;
         }
 
         /// <summary>Initializes a new instance of the SensoryMessage class.</summary>

--- a/src/Core/Session/DefaultState.cs
+++ b/src/Core/Session/DefaultState.cs
@@ -15,7 +15,7 @@ namespace WheelMUD.Core
         public DefaultState(Session session)
             : base(session)
         {
-            this.Prompt = string.Empty;
+            Prompt = string.Empty;
         }
 
         /// <summary>Gets or sets the prompt string to be shown by BuildPrompt.</summary>
@@ -26,7 +26,7 @@ namespace WheelMUD.Core
         /// <returns>The prompt.</returns>
         public override string BuildPrompt()
         {
-            return this.Prompt;
+            return Prompt;
         }
 
         /// <summary>Process the specified input.</summary>

--- a/src/Core/Session/ExportSessionStateAttribute.cs
+++ b/src/Core/Session/ExportSessionStateAttribute.cs
@@ -21,7 +21,7 @@ namespace WheelMUD.Core
         public ExportSessionStateAttribute(int statePriority)
             : base(typeof(SessionState))
         {
-            this.StatePriority = statePriority;
+            StatePriority = statePriority;
         }
 
         public ExportSessionStateAttribute(IDictionary<string, object> metadata)
@@ -34,7 +34,7 @@ namespace WheelMUD.Core
                 switch (key.ToLower())
                 {
                     case "statepriority":
-                        this.StatePriority = (int)metadata[key];
+                        StatePriority = (int)metadata[key];
                         break;
                     case "exporttypeidentity":
                         break;

--- a/src/Core/Session/Session.cs
+++ b/src/Core/Session/Session.cs
@@ -28,14 +28,14 @@ namespace WheelMUD.Core
         {
             if (connection != null)
             {
-                this.Connection = connection;
-                this.State = SessionStateManager.Instance.CreateDefaultState(this);
+                Connection = connection;
+                State = SessionStateManager.Instance.CreateDefaultState(this);
 
-                // The very first time we create a session, it couldn't write the prompt due to this.State
+                // The very first time we create a session, it couldn't write the prompt due to State
                 // not being set during that SessionState's construction, so force a prompt print here.
-                this.Write(string.Empty, true);
+                Write(string.Empty, true);
 
-                this.AtPrompt = false;
+                AtPrompt = false;
             }
         }
 
@@ -48,13 +48,13 @@ namespace WheelMUD.Core
         /// <summary>Gets the ID of the session.</summary>
         public string ID
         {
-            get { return this.Connection.ID; }
+            get { return Connection.ID; }
         }
 
         /// <summary>Gets the terminal this session is using.</summary>
         public ITerminal Terminal
         {
-            get { return this.Connection.Terminal; }
+            get { return Connection.Terminal; }
         }
 
         /// <summary>Gets or sets the player Thing attached to this session.</summary>
@@ -63,7 +63,7 @@ namespace WheelMUD.Core
         /// <summary>Gets the living behavior of the player attached to this session.</summary>
         public LivingBehavior LivingBehavior
         {
-            get { return this.Thing != null ? this.Thing.Behaviors.FindFirst<LivingBehavior>() : null; }
+            get { return Thing != null ? Thing.Behaviors.FindFirst<LivingBehavior>() : null; }
         }
 
         /// <summary>Gets the connection for this session.</summary>
@@ -84,35 +84,35 @@ namespace WheelMUD.Core
         /// <summary>Provides authentication services for this session.</summary>
         public void AuthenticateSession()
         {
-            this.SessionAuthenticated?.Invoke(this);
+            SessionAuthenticated?.Invoke(this);
         }
 
         /// <summary>Passes the input up the chain for processing.</summary>
         /// <param name="input">The input to pass up the chain</param>
         public void ProcessCommand(string input)
         {
-            this.State.ProcessInput(input);
+            State.ProcessInput(input);
         }
 
         /// <summary>Sends the prompt to the connection.</summary>
         public void SendPrompt()
         {
-            if (!this.AtPrompt)
+            if (!AtPrompt)
             {
-                this.Connection.Send(Environment.NewLine + this.State.BuildPrompt());
+                Connection.Send(Environment.NewLine + State.BuildPrompt());
             }
             else
             {
-                this.Connection.Send(this.State.BuildPrompt());
+                Connection.Send(State.BuildPrompt());
             }
 
-            this.AtPrompt = true;
+            AtPrompt = true;
         }
 
         /// <summary>Writes an empty string followed by a prompt.</summary>
         public void WritePrompt()
         {
-            this.Write(string.Empty, true);
+            Write(string.Empty, true);
         }
 
         /// <summary>Write data to the users screen.</summary>
@@ -120,15 +120,15 @@ namespace WheelMUD.Core
         /// <param name="sendPrompt">true to send the prompt after, false otherwise.</param>
         public void Write(string data, bool sendPrompt = true)
         {
-            if (this.AtPrompt)
+            if (AtPrompt)
             {
                 data = Environment.NewLine + data;
             }
 
-            this.AtPrompt = false;
+            AtPrompt = false;
             if (sendPrompt)
             {
-                string prompt = this.State != null ? this.State.BuildPrompt() : string.Empty;
+                string prompt = State != null ? State.BuildPrompt() : string.Empty;
 
                 // Protection against double prompt.
                 if (!data.EndsWith(Environment.NewLine + prompt))
@@ -136,38 +136,38 @@ namespace WheelMUD.Core
                     data = data + Environment.NewLine + prompt;
                 }
 
-                this.AtPrompt = true;
+                AtPrompt = true;
             }
 
-            this.Connection.Send(data);
+            Connection.Send(data);
         }
 
         /// <summary>Place an action on the command queue for execution.</summary>
         /// <param name="actionInput">The action input to attempt to execute.</param>
         public void ExecuteAction(ActionInput actionInput)
         {
-            this.LastActionInput = actionInput;
-            this.ActionReceived?.Invoke((IController)this, actionInput);
+            LastActionInput = actionInput;
+            ActionReceived?.Invoke((IController)this, actionInput);
         }
 
         /// <summary>Subscribe to receive system updates from this system.</summary>
         /// <param name="sender">The subscribing system; generally use 'this'.</param>
         public void SubscribeToSystem(ISubSystemHost sender)
         {
-            this.host = sender;
+            host = sender;
         }
 
         /// <summary>Removes subscriptions from the system.</summary>
         public void UnsubscribeToSystem()
         {
-            this.host = null;
+            host = null;
         }
 
         /// <summary>Inform subscribed system(s) of the specified update.</summary>
         /// <param name="msg">The message to be sent to subscribed system(s).</param>
         public void InformSubscribedSystem(string msg)
         {
-            this.host.UpdateSubSystemHost(this, msg);
+            host.UpdateSubSystemHost(this, msg);
         }
 
         /// <summary>Starts this session.</summary>

--- a/src/Core/Session/SessionState.cs
+++ b/src/Core/Session/SessionState.cs
@@ -19,7 +19,7 @@ namespace WheelMUD.Core
         /// <param name="session">The session entering this state.</param>
         public SessionState(Session session)
         {
-            this.Session = session;
+            Session = session;
         }
 
         /// <summary>Gets or sets the session this state applies to.</summary>

--- a/src/Core/Session/SessionStateManager.cs
+++ b/src/Core/Session/SessionStateManager.cs
@@ -24,7 +24,7 @@ namespace WheelMUD.Core
 
         private SessionStateManager()
         {
-            this.Recompose();
+            Recompose();
         }
 
         /// <summary>Gets the SessionStateManager singleton instance.</summary>
@@ -39,7 +39,7 @@ namespace WheelMUD.Core
             lock (LockObject)
             {
                 var parameters = new object[] { session };
-                return (SessionState)this.defaultSessionStateConstructor.Invoke(parameters);
+                return (SessionState)defaultSessionStateConstructor.Invoke(parameters);
             }
         }
 
@@ -53,9 +53,9 @@ namespace WheelMUD.Core
                 // TODO: assembly version number could be used as orderby tiebreaker to help ensure
                 //       "latest" is always prioritized over an equal StatePriority of an older version.
                 Type defaultSessionStateType;
-                if (this.SessionStates.Length > 0)
+                if (SessionStates.Length > 0)
                 {
-                    defaultSessionStateType = (from s in this.SessionStates
+                    defaultSessionStateType = (from s in SessionStates
                                                orderby s.Metadata.StatePriority descending
                                                select s.Value.GetType()).First();
                 }
@@ -67,7 +67,7 @@ namespace WheelMUD.Core
                 // Find the constructor of that type which takes a Session.  We'll use this info to 
                 // quickly create the default SessionStates for newly connected sessions.
                 var constructorTypes = new Type[] { typeof(Session) };
-                this.defaultSessionStateConstructor = defaultSessionStateType.GetConstructor(constructorTypes);
+                defaultSessionStateConstructor = defaultSessionStateType.GetConstructor(constructorTypes);
             }
         }
     }

--- a/src/Core/Stat.cs
+++ b/src/Core/Stat.cs
@@ -39,14 +39,14 @@ namespace WheelMUD.Core
         public BaseStat(IController controller, string name, string abbreviation, string formula, int value, int minValue, int maxValue, bool visible)
         {
             this.minValue = 0;
-            this.Host = controller;
-            this.Name = name;
-            this.Abbreviation = abbreviation;
-            this.Formula = formula;
-            this.currentValue = value;
+            Host = controller;
+            Name = name;
+            Abbreviation = abbreviation;
+            Formula = formula;
+            currentValue = value;
             this.minValue = minValue;
             this.maxValue = maxValue;
-            this.Visible = visible;
+            Visible = visible;
         }
 
         /// <summary>Initializes a new instance of the <see cref="BaseStat"/> class.</summary>
@@ -67,9 +67,9 @@ namespace WheelMUD.Core
         {
             get
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    return this.currentValue;
+                    return currentValue;
                 }
             }
         }
@@ -85,17 +85,17 @@ namespace WheelMUD.Core
         {
             get
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    return this.maxValue;
+                    return maxValue;
                 }
             }
 
             set
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    this.maxValue = value;
+                    maxValue = value;
                 }
             }
         }
@@ -105,17 +105,17 @@ namespace WheelMUD.Core
         {
             get
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    return this.minValue;
+                    return minValue;
                 }
             }
 
             set
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    this.minValue = value;
+                    minValue = value;
                 }
             }
         }
@@ -148,14 +148,14 @@ namespace WheelMUD.Core
         /// <param name="message">The contextual message to broadcast with the change.</param>
         public virtual void SetValue(int value, Thing sender, ContextualStringBuilder message)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                int oldValue = this.currentValue;
+                int oldValue = currentValue;
 
-                if (this.Host != null)
+                if (Host != null)
                 {
                     // Check if the player is in the character creation state.
-                    Thing hostThing = this.Host.Thing;
+                    Thing hostThing = Host.Thing;
                     if (hostThing != null)
                     {
                         var e = new StatChangeEvent(
@@ -169,17 +169,17 @@ namespace WheelMUD.Core
 
                         if (!e.IsCancelled)
                         {
-                            if (value >= this.maxValue)
+                            if (value >= maxValue)
                             {
-                                this.currentValue = this.maxValue;
+                                currentValue = maxValue;
                             }
-                            else if (value <= this.minValue)
+                            else if (value <= minValue)
                             {
-                                this.currentValue = this.minValue;
+                                currentValue = minValue;
                             }
                             else
                             {
-                                this.currentValue = value;
+                                currentValue = value;
                             }
 
                             hostThing.Eventing.OnCombatEvent(e, EventScope.ParentsDown);
@@ -187,12 +187,12 @@ namespace WheelMUD.Core
                     }
                     else
                     {
-                        this.currentValue = value;
+                        currentValue = value;
                     }
                 }
                 else
                 {
-                    this.currentValue = value;
+                    currentValue = value;
                 }
             }
         }
@@ -202,7 +202,7 @@ namespace WheelMUD.Core
         /// <param name="sender">The sender of the stat change.</param>
         public void SetValue(int value, Thing sender)
         {
-            this.SetValue(value, sender, null);
+            SetValue(value, sender, null);
         }
 
         /// <summary>Increases the value of the stat.</summary>
@@ -211,7 +211,7 @@ namespace WheelMUD.Core
         /// <param name="message">The contextual message to broadcast with the change.</param>
         public void Increase(int value, Thing sender, ContextualStringBuilder message)
         {
-            this.SetValue(this.Value + value, sender, message);
+            SetValue(Value + value, sender, message);
         }
 
         /// <summary>Increases the value of the stat.</summary>
@@ -219,7 +219,7 @@ namespace WheelMUD.Core
         /// <param name="sender">The sender of the stat change.</param>
         public void Increase(int value, Thing sender)
         {
-            this.SetValue(this.Value + value, sender);
+            SetValue(Value + value, sender);
         }
 
         /// <summary>Decreases the value of the stat.</summary>
@@ -228,7 +228,7 @@ namespace WheelMUD.Core
         /// <param name="message">The contextual message to broadcast with the change.</param>
         public void Decrease(int value, Thing sender, ContextualStringBuilder message)
         {
-            this.SetValue(this.Value - value, sender, message);
+            SetValue(Value - value, sender, message);
         }
 
         /// <summary>Decreases the value of the stat.</summary>
@@ -236,7 +236,7 @@ namespace WheelMUD.Core
         /// <param name="sender">The sender of the stat change.</param>
         public void Decrease(int value, Thing sender)
         {
-            this.SetValue(this.Value - value, sender);
+            SetValue(Value - value, sender);
         }
     }
 }

--- a/src/Core/Thing.cs
+++ b/src/Core/Thing.cs
@@ -51,27 +51,27 @@ namespace WheelMUD.Core
         /// <param name="behaviors">The behaviors.</param>
         public Thing(params Behavior[] behaviors)
         {
-            this.Eventing = new ThingEventing(this);
-            this.KeyWords = new List<string>();
-            this.Children = new List<Thing>();
-            this.Behaviors = new BehaviorManager(this);
+            Eventing = new ThingEventing(this);
+            KeyWords = new List<string>();
+            Children = new List<Thing>();
+            Behaviors = new BehaviorManager(this);
 
-            this.Parent = null;
-            this.Name = string.Empty;
-            this.Title = string.Empty;
-            this.Description = string.Empty;
+            Parent = null;
+            Name = string.Empty;
+            Title = string.Empty;
+            Description = string.Empty;
 
-            this.stats = new Dictionary<string, GameStat>();
-            this.attributes = new Dictionary<string, GameAttribute>();
-            this.skills = new Dictionary<string, GameSkill>();
-            this.contextCommands = new Dictionary<string, ContextCommand>();
+            stats = new Dictionary<string, GameStat>();
+            attributes = new Dictionary<string, GameAttribute>();
+            skills = new Dictionary<string, GameSkill>();
+            contextCommands = new Dictionary<string, ContextCommand>();
 
             if (behaviors != null)
             {
                 foreach (var behavior in behaviors)
                 {
                     behavior.SetParent(this);
-                    this.Behaviors.Add(behavior);
+                    Behaviors.Add(behavior);
                 }
             }
         }
@@ -79,7 +79,7 @@ namespace WheelMUD.Core
         /// <summary>Finalizes an instance of the <see cref="Thing"/> class.</summary>
         ~Thing()
         {
-            this.Dispose();
+            Dispose();
         }
 
         public ThingEventing Eventing { get; private set; }
@@ -92,20 +92,20 @@ namespace WheelMUD.Core
             get
             {
                 // Avoid races with retrieving ID while it is in the process of changing.
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    return this.id;
+                    return id;
                 }
             }
 
             set
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    if (value != this.id)
+                    if (value != id)
                     {
-                        ThingManager.Instance.UpdateThingRegistration(this.id, value, this);
-                        this.id = value;
+                        ThingManager.Instance.UpdateThingRegistration(id, value, this);
+                        id = value;
                     }
                 }
             }
@@ -120,7 +120,7 @@ namespace WheelMUD.Core
         /// <summary>Gets the full name of this thing.</summary>
         public string FullName
         {
-            get { return this.Name; }
+            get { return Name; }
         }
 
         /// <summary>Gets or sets the title of this thing.</summary>
@@ -151,17 +151,17 @@ namespace WheelMUD.Core
         {
             get
             {
-                return this.Parent?.Id;
+                return Parent?.Id;
             }
             set
             {
                 if (value == null)
                 {
-                    this.Parent = null;
+                    Parent = null;
                 }
-                else if (this.Parent?.Id != value)
+                else if (Parent?.Id != value)
                 {
-                    this.Parent = ThingManager.Instance.FindThing(value);
+                    Parent = ThingManager.Instance.FindThing(value);
                 }
             }
         }
@@ -174,13 +174,13 @@ namespace WheelMUD.Core
             {
                 var parents = new List<Thing>();
 
-                var mainParent = this.Parent;
+                var mainParent = Parent;
                 if (mainParent != null)
                 {
                     parents.Add(mainParent);
                 }
 
-                var multipleParentsBehavior = this.Behaviors.FindFirst<MultipleParentsBehavior>();
+                var multipleParentsBehavior = Behaviors.FindFirst<MultipleParentsBehavior>();
                 if (multipleParentsBehavior != null)
                 {
                     parents.AddRange(multipleParentsBehavior.SecondaryParents);
@@ -195,17 +195,17 @@ namespace WheelMUD.Core
         {
             get
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    return this.stats;
+                    return stats;
                 }
             }
 
             set
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    this.stats = value;
+                    stats = value;
                 }
             }
         }
@@ -215,17 +215,17 @@ namespace WheelMUD.Core
         {
             get
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    return this.attributes;
+                    return attributes;
                 }
             }
 
             set
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    this.attributes = value;
+                    attributes = value;
                 }
             }
         }
@@ -235,17 +235,17 @@ namespace WheelMUD.Core
         {
             get
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    return this.skills;
+                    return skills;
                 }
             }
 
             set
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    this.skills = value;
+                    skills = value;
                 }
             }
         }
@@ -255,9 +255,9 @@ namespace WheelMUD.Core
         {
             get
             {
-                lock (this.lockObject)
+                lock (lockObject)
                 {
-                    return this.contextCommands;
+                    return contextCommands;
                 }
             }
         }
@@ -287,7 +287,7 @@ namespace WheelMUD.Core
         /// <returns>A string representation of this Thing instance.</returns>
         public override string ToString()
         {
-            return string.Format("{0} (ID: {1})", this.FullName, this.Id);
+            return string.Format("{0} (ID: {1})", FullName, Id);
         }
 
         /// <summary>Performs tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
@@ -302,7 +302,7 @@ namespace WheelMUD.Core
         {
             // If this thing is a player, use the player saving code instead of the generic
             // saving code, since players currently have their own DB/persistence concerns.
-            var playerBehavior = this.Behaviors.FindFirst<PlayerBehavior>();
+            var playerBehavior = Behaviors.FindFirst<PlayerBehavior>();
             if (playerBehavior != null)
             {
                 playerBehavior.SaveWholePlayer();
@@ -311,9 +311,9 @@ namespace WheelMUD.Core
             {
                 // TODO: If a thing is asked to save, see if it is a child/subchild of a player, and if so, save the player instead?
                 // TODO: Implement saving of core thing -> saving of housed Behaviors too.
-                if (this.Parent.HasBehavior<PlayerBehavior>())
+                if (Parent.HasBehavior<PlayerBehavior>())
                 {
-                    this.Parent.Behaviors.FindFirst<PlayerBehavior>().SaveWholePlayer();
+                    Parent.Behaviors.FindFirst<PlayerBehavior>().SaveWholePlayer();
                 }
                 else
                 {
@@ -335,10 +335,10 @@ namespace WheelMUD.Core
         /// <returns>True if the Things can become a single stack, else false.</returns>
         public bool CanStack(Thing thing)
         {
-            if (this.TemplateId == thing.TemplateId && this.Name == thing.Name && this.FullName == thing.FullName)
+            if (TemplateId == thing.TemplateId && Name == thing.Name && FullName == thing.FullName)
             {
                 // TODO: Better logic to see differing properties on housed behaviors, etc...
-                if (this.Behaviors.CanStack(thing.Behaviors))
+                if (Behaviors.CanStack(thing.Behaviors))
                 {
                     // throw new NotImplementedException();
                 }
@@ -370,7 +370,7 @@ namespace WheelMUD.Core
             try
             {
                 var s = new XmlSerializer(typeof(Thing));
-                s.Serialize(w, this.Clone());
+                s.Serialize(w, Clone());
                 s = null;
             }
             catch
@@ -391,7 +391,7 @@ namespace WheelMUD.Core
             {
                 var s = new XmlSerializer(typeof(Thing));
                 var i = (Thing)s.Deserialize(r);
-                this.CloneProperties(i);
+                CloneProperties(i);
             }
             catch
             {
@@ -405,7 +405,7 @@ namespace WheelMUD.Core
         /// <param name="existingThing">The existing thing.</param>
         public void CloneProperties(Thing existingThing)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
                 lock (existingThing.lockObject)
                 {
@@ -413,15 +413,15 @@ namespace WheelMUD.Core
                     // to allow this base Item.Clone to take care of all the cloning.
                     // TODO: Test this.  Especially if any properties have indexers.
                     // TODO: Make sure this deep-copies things like behaviors.
-                    var properties = this.GetType().GetProperties();
+                    var properties = GetType().GetProperties();
 
                     foreach (var property in properties)
                     {
                         property.SetValue(this, property.GetValue(existingThing, null), null);
                     }
 
-                    this.Id = null;
-                    this.Behaviors = (BehaviorManager)existingThing.Behaviors.Clone();
+                    Id = null;
+                    Behaviors = (BehaviorManager)existingThing.Behaviors.Clone();
                 }
             }
         }
@@ -431,9 +431,9 @@ namespace WheelMUD.Core
         /// <returns>The Item found.</returns>
         public Thing FindChild(Predicate<Thing> predicate)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                return this.Children.Find(predicate);
+                return Children.Find(predicate);
             }
         }
 
@@ -449,15 +449,15 @@ namespace WheelMUD.Core
 
             string s = searchString.ToLower();
 
-            lock (this.lockObject)
+            lock (lockObject)
             {
                 // Try to find the item in this collection by seeing if any item ID matches 
                 // the string exactly, else if that find call returns null, find any item ID 
                 // that starts with the specified string, else if that is null...
-                Thing foundThing = this.Children.Find(i => i.Id != null && i.Id.Equals(s)) ??
-                                   this.Children.Find(i => i.Name.ToLower().Equals(s)) ??
-                                   this.Children.Find(i => i.Name.ToLower().StartsWith(s)) ??
-                                   this.Children.Find(i => i.KeyWords.Contains(s));
+                Thing foundThing = Children.Find(i => i.Id != null && i.Id.Equals(s)) ??
+                                   Children.Find(i => i.Name.ToLower().Equals(s)) ??
+                                   Children.Find(i => i.Name.ToLower().StartsWith(s)) ??
+                                   Children.Find(i => i.KeyWords.Contains(s));
 
                 return foundThing;
             }
@@ -477,10 +477,10 @@ namespace WheelMUD.Core
                 return null;
             }
 
-            Thing foundThing = this.FindChild(searchString);
+            Thing foundThing = FindChild(searchString);
             if (foundThing == null)
             {
-                foundThing = this.Parent.FindChild(searchString);
+                foundThing = Parent.FindChild(searchString);
             }
 
             return foundThing;
@@ -493,12 +493,12 @@ namespace WheelMUD.Core
         {
             // TODO: Why are these locking?  If this is to avoid iteration of Children while it may 
             //       also be modified by another thread, it fails to do so, as the user can access/change
-            //       the public this.Children list directly.  We may need a private this.children member 
+            //       the public Children list directly.  We may need a private children member 
             //       and only allow specific access to children via our public methods which would return
             //       new lists with the appropriate members (instead of sharing the actual list).
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                return this.Children.FindAll(predicate);
+                return Children.FindAll(predicate);
             }
         }
 
@@ -507,11 +507,11 @@ namespace WheelMUD.Core
         /// <returns>List of behaviors.</returns>
         public List<T> FindAllChildrenBehaviors<T>() where T : Behavior
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
                 var found = new List<T>();
 
-                foreach (Thing thing in this.Children)
+                foreach (Thing thing in Children)
                 {
                     T behavior = thing.Behaviors.FindFirst<T>();
 
@@ -530,7 +530,7 @@ namespace WheelMUD.Core
         /// <returns>A behavior if one is found, otherwise null.</returns>
         public T FindBehavior<T>() where T : Behavior
         {
-            T behavior = this.Behaviors.FindFirst<T>();
+            T behavior = Behaviors.FindFirst<T>();
 
             return behavior;
         }
@@ -540,7 +540,7 @@ namespace WheelMUD.Core
         /// <returns>True if the behavior was found, otherwise false.</returns>
         public bool HasBehavior<T>() where T : Behavior
         {
-            T behavior = this.Behaviors.FindFirst<T>();
+            T behavior = Behaviors.FindFirst<T>();
             return behavior != null;
         }
 
@@ -549,7 +549,7 @@ namespace WheelMUD.Core
         /// <returns>The matching GameState, if found, else null.</returns>
         public GameStat FindStat<T>() where T : GameStat
         {
-            var statList = new List<GameStat>(this.Stats.Values);
+            var statList = new List<GameStat>(Stats.Values);
             T stat = statList.OfType<T>().FirstOrDefault();
             return stat;
         }
@@ -560,7 +560,7 @@ namespace WheelMUD.Core
         public GameStat FindGameStat(string name)
         {
             GameStat stat;
-            this.Stats.TryGetValue(name, out stat);
+            Stats.TryGetValue(name, out stat);
             return stat;
         }
 
@@ -570,7 +570,7 @@ namespace WheelMUD.Core
         public GameAttribute FindGameAttribute(string name)
         {
             GameAttribute attribute;
-            this.Attributes.TryGetValue(name, out attribute);
+            Attributes.TryGetValue(name, out attribute);
             return attribute;
         }
 
@@ -579,7 +579,7 @@ namespace WheelMUD.Core
         /// <returns>The matching attribute, if found, else null.</returns>
         public T FindGameAttribute<T>() where T : GameAttribute
         {
-            var attribList = new List<GameAttribute>(this.Attributes.Values);
+            var attribList = new List<GameAttribute>(Attributes.Values);
             T attribute = attribList.OfType<T>().FirstOrDefault();
             return attribute;
         }
@@ -589,7 +589,7 @@ namespace WheelMUD.Core
         /// <returns>The GameSkill, if found, or null.</returns>
         public GameSkill FindGameSkill<T>() where T : GameSkill
         {
-            var skillList = new List<GameSkill>(this.Skills.Values);
+            var skillList = new List<GameSkill>(Skills.Values);
             T skill = skillList.OfType<T>().FirstOrDefault();
             return skill;
         }
@@ -600,7 +600,7 @@ namespace WheelMUD.Core
         public GameSkill FindGameSkill(string skillName)
         {
             GameSkill skill;
-            this.Skills.TryGetValue(skillName, out skill);
+            Skills.TryGetValue(skillName, out skill);
             return skill;
         }
 
@@ -617,7 +617,7 @@ namespace WheelMUD.Core
             // TODO: The whole MultipleParentsBehavior may be too complicated for our actual use cases,
             //       and we should consider a lighter approach that doesn't track multiple parents, but
             //       simply lets the thing be a child of multiple locations.
-            lock (this.lockObject)
+            lock (lockObject)
             {
                 lock (thing.lockObject)
                 {
@@ -637,7 +637,7 @@ namespace WheelMUD.Core
                         }
                     }
 
-                    var addRequest = this.RequestAdd(thing);
+                    var addRequest = RequestAdd(thing);
                     if (addRequest.IsCancelled)
                     {
                         return false;
@@ -651,7 +651,7 @@ namespace WheelMUD.Core
                         oldParent.PerformRemoval(thing, removalRequest, multipleParentsBehavior);
                     }
 
-                    this.PerformAdd(thing, addRequest, multipleParentsBehavior);
+                    PerformAdd(thing, addRequest, multipleParentsBehavior);
                 }
 
                 return true;
@@ -665,15 +665,15 @@ namespace WheelMUD.Core
         {
             // No two threads may add/remove any combination of the parent/sub-thing at the same time,
             // in order to prevent race conditions resulting in thing-disconnection/duplication/etc.
-            lock (this.lockObject)
+            lock (lockObject)
             {
                 lock (thing.lockObject)
                 {
-                    if (this.Children.Contains(thing))
+                    if (Children.Contains(thing))
                     {
                         var multipleParentsBehavior = thing.Behaviors.FindFirst<MultipleParentsBehavior>();
-                        var removalRequest = this.RequestRemoval(thing);
-                        return this.PerformRemoval(thing, removalRequest, multipleParentsBehavior);
+                        var removalRequest = RequestRemoval(thing);
+                        return PerformRemoval(thing, removalRequest, multipleParentsBehavior);
                     }
                 }
             }
@@ -691,7 +691,7 @@ namespace WheelMUD.Core
         /// <param name="newParent"></param>
         public void RigParentUnsafe(Thing newParent)
         {
-            this.Parent = newParent;
+            Parent = newParent;
         }
 
         /// <summary>Adds this Thing to a parent.</summary>
@@ -705,7 +705,7 @@ namespace WheelMUD.Core
         /// <summary>Removes a Thing from the applicable parent(s).</summary>
         public void RemoveFromParents()
         {
-            foreach (var parent in this.Parents)
+            foreach (var parent in Parents)
             {
                 parent.Remove(this);
             }
@@ -716,7 +716,7 @@ namespace WheelMUD.Core
         public void AddAttribute(GameAttribute gameAttribute)
         {
             gameAttribute.Parent = this;
-            this.Attributes.Add(gameAttribute.Name, gameAttribute);
+            Attributes.Add(gameAttribute.Name, gameAttribute);
             gameAttribute.OnAdd();
         }
 
@@ -725,9 +725,9 @@ namespace WheelMUD.Core
         public void RemoveAttribute(GameAttribute gameAttribute)
         {
             gameAttribute.Parent = null;
-            if (this.Attributes.ContainsKey(gameAttribute.Name))
+            if (Attributes.ContainsKey(gameAttribute.Name))
             {
-                this.Attributes.Remove(gameAttribute.Name);
+                Attributes.Remove(gameAttribute.Name);
             }
             gameAttribute.OnRemove();
         }
@@ -737,7 +737,7 @@ namespace WheelMUD.Core
         public void AddStat(GameStat gameStat)
         {
             gameStat.Parent = this;
-            this.Stats.Add(gameStat.Name, gameStat);
+            Stats.Add(gameStat.Name, gameStat);
             gameStat.OnAdd();
         }
 
@@ -746,9 +746,9 @@ namespace WheelMUD.Core
         public void RemoveStat(GameStat gameStat)
         {
             gameStat.Parent = null;
-            if (this.Stats.ContainsKey(gameStat.Name))
+            if (Stats.ContainsKey(gameStat.Name))
             {
-                this.Stats.Remove(gameStat.Name);
+                Stats.Remove(gameStat.Name);
             }
             gameStat.OnRemove();
         }
@@ -758,11 +758,11 @@ namespace WheelMUD.Core
         /// <returns>The remainder (stack of) Thing if this stack couldn't combine all of the other, else null.</returns>
         private Thing Combine(Thing thing)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
                 lock (thing.lockObject)
                 {
-                    if (!this.CanStack(thing))
+                    if (!CanStack(thing))
                     {
                         // Return the full original (stack of) thing as the unstacked remainder.
                         return thing;
@@ -771,7 +771,7 @@ namespace WheelMUD.Core
                     // TODO: Better stacking: produce a remainder thing and return it, in cases where a maximum stack count
                     //       would be exceeded.  Also, take into account potentially different Behaviors attached to the
                     //       objects in the CanStack method!
-                    this.Count += thing.Count;
+                    Count += thing.Count;
                     return null;
                 }
             }
@@ -781,7 +781,7 @@ namespace WheelMUD.Core
         {
             // Create and raise a removal event request.
             var removeChildEvent = new RemoveChildEvent(thingToRemove);
-            this.Eventing.OnMovementRequest(removeChildEvent, EventScope.SelfDown);
+            Eventing.OnMovementRequest(removeChildEvent, EventScope.SelfDown);
             return removeChildEvent;
         }
 
@@ -790,7 +790,7 @@ namespace WheelMUD.Core
             // Prepare an add event request, and ensure both the new parent (this) and the 
             // thing itself both get a chance to cancel this request before committing.
             var addChildEvent = new AddChildEvent(thingToAdd, this);
-            this.Eventing.OnMovementRequest(addChildEvent, EventScope.SelfDown);
+            Eventing.OnMovementRequest(addChildEvent, EventScope.SelfDown);
             thingToAdd.Eventing.OnMovementRequest(addChildEvent, EventScope.SelfDown);
             return addChildEvent;
         }
@@ -808,12 +808,12 @@ namespace WheelMUD.Core
             }
 
             // Send the removal event.
-            this.Eventing.OnMovementEvent(removalEvent, EventScope.SelfDown);
+            Eventing.OnMovementEvent(removalEvent, EventScope.SelfDown);
 
             // If the thing to remove was in our Children collection, remove it.
-            if (this.Children.Contains(thingToRemove))
+            if (Children.Contains(thingToRemove))
             {
-                this.Children.Remove(thingToRemove);
+                Children.Remove(thingToRemove);
             }
 
             // If we don't have a MultipleParentsBehavior, directly remove the one-allowed 
@@ -839,7 +839,7 @@ namespace WheelMUD.Core
 
             // If an existing thing is stackable with the added thing, combine the new
             // thing into the existing thing instead of simply adding it.
-            foreach (Thing currentThing in this.Children)
+            foreach (Thing currentThing in Children)
             {
                 if (thingToAdd.CanStack(currentThing))
                 {
@@ -849,9 +849,9 @@ namespace WheelMUD.Core
             }
 
             // The item cannot be stacked so add the item to the specified parent.
-            if (!this.Children.Contains(thingToAdd))
+            if (!Children.Contains(thingToAdd))
             {
-                this.Children.Add(thingToAdd);
+                Children.Add(thingToAdd);
             }
 
             // If we don't have a MultipleParentsBehavior, directly set the one-allowed 
@@ -865,7 +865,7 @@ namespace WheelMUD.Core
                 multipleParentsBehavior.AddParent(this);
             }
 
-            this.Eventing.OnMovementEvent(addEvent, EventScope.SelfDown);
+            Eventing.OnMovementEvent(addEvent, EventScope.SelfDown);
             return true;
         }
     }

--- a/src/Data.RavenDb/RavenDocumentSessionBridge.cs
+++ b/src/Data.RavenDb/RavenDocumentSessionBridge.cs
@@ -26,38 +26,38 @@ namespace WheelMUD.Data
 
         public void Delete<T>(T entity)
         {
-            this.documentSession.Delete<T>(entity);
+            documentSession.Delete<T>(entity);
         }
 
         public void Delete(string id)
         {
-            this.documentSession.Delete(id);
+            documentSession.Delete(id);
         }
 
         public void Dispose()
         {
-            this.documentSession.Dispose();
-            this.documentSession = null;
+            documentSession.Dispose();
+            documentSession = null;
         }
 
         public T Load<T>(string id)
         {
-            return this.documentSession.Load<T>(id);
+            return documentSession.Load<T>(id);
         }
 
         public IOrderedQueryable<T> Query<T>()
         {
-            return this.documentSession.Query<T>();
+            return documentSession.Query<T>();
         }
 
         public void SaveChanges()
         {
-            this.documentSession.SaveChanges();
+            documentSession.SaveChanges();
         }
 
         public void Store<T>(T entity)
         {
-            this.documentSession.Store(entity);
+            documentSession.Store(entity);
         }
     }
 }

--- a/src/Data.SqlServer/WheelMudSqlServerProvider.cs
+++ b/src/Data.SqlServer/WheelMudSqlServerProvider.cs
@@ -22,7 +22,7 @@ namespace WheelMUD.Data.SqlServer
 
         public WheelMudSqlServerProvider(string connectionString)
         {
-            this.ConnectionString = connectionString;
+            ConnectionString = connectionString;
         }
 
         public string ConnectionString { get; set; }
@@ -31,7 +31,7 @@ namespace WheelMUD.Data.SqlServer
 
         public IDbConnection CreateDatabaseSession()
         {
-            var connectionFactory = new OrmLiteConnectionFactory(this.ConnectionString, false, SqlServerOrmLiteDialectProvider.Instance);
+            var connectionFactory = new OrmLiteConnectionFactory(ConnectionString, false, SqlServerOrmLiteDialectProvider.Instance);
             IDbConnection connection = connectionFactory.OpenDbConnection();
             return connection;
         }

--- a/src/Data.Sqlite/WheelMudSqliteProvider.cs
+++ b/src/Data.Sqlite/WheelMudSqliteProvider.cs
@@ -24,7 +24,7 @@ namespace WheelMUD.Data.Sqlite
 
         public WheelMudSqliteProvider(string connectionString)
         {
-            this.ConnectionString = connectionString;
+            ConnectionString = connectionString;
         }
 
         public string ConnectionString { get; set; }
@@ -33,8 +33,8 @@ namespace WheelMUD.Data.Sqlite
 
         public IDbConnection CreateDatabaseSession()
         {
-            VerifyValidSqLiteFile(this.ConnectionString);
-            var connectionFactory = new OrmLiteConnectionFactory(this.ConnectionString, SqliteOrmLiteDialectProvider.Instance, true);
+            VerifyValidSqLiteFile(ConnectionString);
+            var connectionFactory = new OrmLiteConnectionFactory(ConnectionString, SqliteOrmLiteDialectProvider.Instance, true);
             return connectionFactory.OpenDbConnection();
         }
 

--- a/src/Data/Entities/AreaRecord.cs
+++ b/src/Data/Entities/AreaRecord.cs
@@ -17,7 +17,7 @@ namespace WheelMUD.Data.Entities
         /// <summary>Initializes a new instance of the AreaRecord class.</summary>
         public AreaRecord()
         {
-            this.Rooms = new Dictionary<long, RoomRecord>();
+            Rooms = new Dictionary<long, RoomRecord>();
         }
 
         public virtual string Name { get; set; }

--- a/src/Data/HelperConfigInfo.cs
+++ b/src/Data/HelperConfigInfo.cs
@@ -17,7 +17,7 @@ namespace WheelMUD.Data
         /// <summary>Prevents a default instance of the <see cref="AppConfigInfo"/> class from being created.</summary>
         private AppConfigInfo()
         {
-            this.GetConfigSettings();
+            GetConfigSettings();
         }
 
         /// <summary>Gets the singleton instance of the <see cref="AppConfigInfo"/> class.</summary>
@@ -56,21 +56,21 @@ namespace WheelMUD.Data
         /// <summary>Gets the configuration settings.</summary>
         private void GetConfigSettings()
         {
-            this.UserAccountIsPlayerCharacter = GameConfiguration.GetAppConfigBool("UserAccountIsPlayerCharacter");
-            this.PlayerCharacterNamesMustUseSingleCapital = GameConfiguration.GetAppConfigBool("PlayerCharacterNamesMustUseSingleCapital");
+            UserAccountIsPlayerCharacter = GameConfiguration.GetAppConfigBool("UserAccountIsPlayerCharacter");
+            PlayerCharacterNamesMustUseSingleCapital = GameConfiguration.GetAppConfigBool("PlayerCharacterNamesMustUseSingleCapital");
 
-            var relationalSettings = this.GetConnectionStringSettings("RelationalDataProviderName", "WheelMUDSQLite");
-            var documentSettings = this.GetConnectionStringSettings("DocumentDataProviderName", "RavenDB");
-            this.RelationalDataProviderName = relationalSettings.Name;
-            this.RelationalConnectionString = relationalSettings.ConnectionString;
-            this.DocumentDataProviderName = documentSettings.Name;
-            this.DocumentConnectionString = documentSettings.ConnectionString;
+            var relationalSettings = GetConnectionStringSettings("RelationalDataProviderName", "WheelMUDSQLite");
+            var documentSettings = GetConnectionStringSettings("DocumentDataProviderName", "RavenDB");
+            RelationalDataProviderName = relationalSettings.Name;
+            RelationalConnectionString = relationalSettings.ConnectionString;
+            DocumentDataProviderName = documentSettings.Name;
+            DocumentConnectionString = documentSettings.ConnectionString;
 
             // Replace any tokens like {DataDir} in the connection strings with evaluated values.
             // This prevents new administrators from having to adjust App.config for user-specific paths.
             var dataDir = GameConfiguration.DataStoragePath + Path.DirectorySeparatorChar;
-            this.RelationalConnectionString = this.RelationalConnectionString.Replace("{DataDir}", dataDir);
-            this.DocumentConnectionString = this.DocumentConnectionString.Replace("{DataDir}", dataDir);
+            RelationalConnectionString = RelationalConnectionString.Replace("{DataDir}", dataDir);
+            DocumentConnectionString = DocumentConnectionString.Replace("{DataDir}", dataDir);
         }
     }
 }

--- a/src/Data/ProviderCache.cs
+++ b/src/Data/ProviderCache.cs
@@ -17,7 +17,7 @@ namespace WheelMUD.Data
     {
         public ProviderCache()
         {
-            this.PopulateProvierCache();
+            PopulateProvierCache();
         }
 
         [ImportMany(typeof(IWheelMudRelationalDbProvider))]

--- a/src/Data/User.cs
+++ b/src/Data/User.cs
@@ -48,14 +48,14 @@ namespace WheelMUD.Data
         {
             var salt = new Byte[24];
             CryptoProvider.GetBytes(salt);
-            this.Salt = Encoding.UTF8.GetString(salt);
-            this.HashedPassword = Hash(this.Salt, newPassword);
+            Salt = Encoding.UTF8.GetString(salt);
+            HashedPassword = Hash(Salt, newPassword);
         }
 
         public bool PasswordMatches(string password)
         {
-            var hash = Hash(this.Salt, password);
-            return StructuralComparisons.StructuralEqualityComparer.Equals(hash, this.HashedPassword);
+            var hash = Hash(Salt, password);
+            return StructuralComparisons.StructuralEqualityComparer.Equals(hash, HashedPassword);
         }
 
         public static string Hash(string salt, string password)
@@ -66,11 +66,11 @@ namespace WheelMUD.Data
 
         public void AddPlayerCharacter(string playerCharacterId)
         {
-            lock (this.PlayerCharacterIds)
+            lock (PlayerCharacterIds)
             {
-                if (!this.PlayerCharacterIds.Contains(playerCharacterId))
+                if (!PlayerCharacterIds.Contains(playerCharacterId))
                 {
-                    this.PlayerCharacterIds.Add(playerCharacterId);
+                    PlayerCharacterIds.Add(playerCharacterId);
                 }
             }
         }

--- a/src/Effects/AlterSenseEffect.cs
+++ b/src/Effects/AlterSenseEffect.cs
@@ -31,7 +31,7 @@ namespace WheelMUD.Effects
         public AlterSenseEffect(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets or sets the type of sense which is to be altered.</summary>
@@ -43,9 +43,9 @@ namespace WheelMUD.Effects
         /// <summary>Sets the default properties of this effect instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.SensoryType = SensoryType.None;
-            this.AlterAmount = 0;
-            this.Duration = new TimeSpan(0, 0, 30);
+            SensoryType = SensoryType.None;
+            AlterAmount = 0;
+            Duration = new TimeSpan(0, 0, 30);
         }
     }
 }

--- a/src/Effects/FaintEffect.cs
+++ b/src/Effects/FaintEffect.cs
@@ -25,7 +25,7 @@ namespace WheelMUD.Effects
         public FaintEffect(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /* 
@@ -39,10 +39,10 @@ namespace WheelMUD.Effects
         /// <param name="duration">duration of the effect</param>
         public override void Apply(TimeSpan duration)
         {
-            this.entity = (Entity)this.Host;
+            entity = (Entity)Host;
             
-            this.previousConsciousness = this.entity.Consciousness;
-            this.entity.Consciousness = Consciousness.Unconscious;
+            previousConsciousness = entity.Consciousness;
+            entity.Consciousness = Consciousness.Unconscious;
 
             base.Apply(duration);
         }
@@ -50,11 +50,11 @@ namespace WheelMUD.Effects
         /// <summary>This undoes the effect, returning entity to its previous state of consciousness.</summary>
         private void Restore()
         {
-            if (this.entity != null)
+            if (entity != null)
             {
-                if (this.entity.Consciousness == Consciousness.Unconscious)
+                if (entity.Consciousness == Consciousness.Unconscious)
                 {
-                    this.entity.Consciousness = this.previousConsciousness;
+                    entity.Consciousness = previousConsciousness;
                 }
             }
         }

--- a/src/Effects/ImmobileEffect.cs
+++ b/src/Effects/ImmobileEffect.cs
@@ -25,7 +25,7 @@ namespace WheelMUD.Effects
         public ImmobileEffect(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Sets the default properties of this effect instance.</summary>

--- a/src/Effects/MutedEffect.cs
+++ b/src/Effects/MutedEffect.cs
@@ -24,11 +24,11 @@ namespace WheelMUD.Effects
         public MutedEffect(Thing activeThing, TimeSpan duration, SensoryMessage sensoryMessage, SensoryMessage expirationMessage)
             : base(duration)
         {
-            this.Name = "Mute";
-            this.ActiveThing = activeThing;
-            this.SensoryMessage = sensoryMessage;
-            this.ExpirationMessage = expirationMessage;
-            this.Duration = duration;
+            Name = "Mute";
+            ActiveThing = activeThing;
+            SensoryMessage = sensoryMessage;
+            ExpirationMessage = expirationMessage;
+            Duration = duration;
         }
 
         /// <summary>Initializes a new instance of the <see cref="MutedEffect" /> class.</summary>
@@ -37,8 +37,8 @@ namespace WheelMUD.Effects
         public MutedEffect(long instanceId, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.Name = "Mute";
-            this.ID = instanceId;
+            Name = "Mute";
+            ID = instanceId;
         }
 
         /// <summary>Gets or sets the name.</summary>
@@ -71,44 +71,44 @@ namespace WheelMUD.Effects
         protected override void OnAddBehavior()
         {
             // While this effect is attached to its parent, it denies all verbal communications from it.
-            this.Interceptor = new CancellableGameEventHandler(this.DenyCommunicationRequest);
-            this.Parent.Eventing.CommunicationRequest += this.Interceptor;
+            Interceptor = new CancellableGameEventHandler(DenyCommunicationRequest);
+            Parent.Eventing.CommunicationRequest += Interceptor;
 
             // Create event and broadcast it to let the affected parties know the effect was applied.
-            var muteEvent = new EffectEvent(this.ActiveThing, this.Parent, this.SensoryMessage);
-            this.ActiveThing.Eventing.OnCommunicationRequest(muteEvent, EventScope.ParentsDown);
+            var muteEvent = new EffectEvent(ActiveThing, Parent, SensoryMessage);
+            ActiveThing.Eventing.OnCommunicationRequest(muteEvent, EventScope.ParentsDown);
             if (!muteEvent.IsCancelled)
             {
-                this.ActiveThing.Eventing.OnCommunicationEvent(muteEvent, EventScope.ParentsDown);
+                ActiveThing.Eventing.OnCommunicationEvent(muteEvent, EventScope.ParentsDown);
             }
 
             // Create an event to be broadcast when the mute effect expires,
             // and schedule it with the TimeSystem.
-            this.UnmuteEvent = new TimeEvent(this.ActiveThing, this.Unmute, this.EndTime, this.ExpirationMessage);
-            TimeSystem.Instance.ScheduleEvent(this.UnmuteEvent);
+            UnmuteEvent = new TimeEvent(ActiveThing, Unmute, EndTime, ExpirationMessage);
+            TimeSystem.Instance.ScheduleEvent(UnmuteEvent);
 
             base.OnAddBehavior();
         }
 
-        /// <summary>Called when the current parent of this behavior is about to be removed. (Refer to this.Parent.)</summary>
+        /// <summary>Called when the current parent of this behavior is about to be removed. (Refer to Parent.)</summary>
         protected override void OnRemoveBehavior()
         {
             // Stop intercepting communication events.
-            this.Parent.Eventing.CommunicationRequest -= this.Interceptor;
-            this.Interceptor = null;
+            Parent.Eventing.CommunicationRequest -= Interceptor;
+            Interceptor = null;
 
             // Broadcast the event that was created earlier in OnAddBehavior.
-            this.ActiveThing.Eventing.OnCommunicationRequest(this.UnmuteEvent, EventScope.ParentsDown);
-            if (!this.UnmuteEvent.IsCancelled)
+            ActiveThing.Eventing.OnCommunicationRequest(UnmuteEvent, EventScope.ParentsDown);
+            if (!UnmuteEvent.IsCancelled)
             {
-                this.ActiveThing.Eventing.OnCommunicationEvent(this.UnmuteEvent, EventScope.ParentsDown);
+                ActiveThing.Eventing.OnCommunicationEvent(UnmuteEvent, EventScope.ParentsDown);
             }
 
             // In case the effect was removed manually (i.e. not by TimeSystem), we should cancel the event so
             // TimeSystem will know to ignore it when the EndTime is reached.
-            if (this.UnmuteEvent != null && !this.UnmuteEvent.IsCancelled)
+            if (UnmuteEvent != null && !UnmuteEvent.IsCancelled)
             {
-                this.UnmuteEvent.Cancel(string.Empty);
+                UnmuteEvent.Cancel(string.Empty);
             }
 
             base.OnRemoveBehavior();
@@ -117,14 +117,14 @@ namespace WheelMUD.Effects
         /// <summary>Removes this effect from its parent Thing.</summary>
         public void Unmute()
         {
-            this.Parent.Eventing.OnCommunicationEvent(this.UnmuteEvent, EventScope.ParentsDown);
-            this.Parent.Behaviors.Remove(this);
+            Parent.Eventing.OnCommunicationEvent(UnmuteEvent, EventScope.ParentsDown);
+            Parent.Behaviors.Remove(this);
         }
 
         /// <summary>Sets the default properties of this effect instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.Duration = TimeSpan.FromMinutes(60);
+            Duration = TimeSpan.FromMinutes(60);
         }
 
         /// <summary>Deny communication requests by the host Thing.</summary>
@@ -133,7 +133,7 @@ namespace WheelMUD.Effects
         private void DenyCommunicationRequest(IThing root, CancellableGameEvent e)
         {
             var communicationRequest = e as VerbalCommunicationEvent;
-            if (communicationRequest != null && communicationRequest.ActiveThing == this.Parent)
+            if (communicationRequest != null && communicationRequest.ActiveThing == Parent)
             {
                 e.Cancel("You are currently muted.");
             }

--- a/src/Effects/PoisonEffect.cs
+++ b/src/Effects/PoisonEffect.cs
@@ -25,7 +25,7 @@ namespace WheelMUD.Effects
         public PoisonEffect(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /* TODO: Rework against new Effect class and time/tick events.
@@ -45,23 +45,23 @@ namespace WheelMUD.Effects
         /// <param name="duration">duration 12</param>
         public override void Apply(TimeSpan duration)
         {
-            if (this.totalTime == new TimeSpan(0, 0, 0))
+            if (totalTime == new TimeSpan(0, 0, 0))
             {
-                this.totalTime = duration;
+                totalTime = duration;
             }
 
-            this.totalTime = this.totalTime - this.timeBetweenTicks;
-            this.health = this.Host.Stats["health"];
+            totalTime = totalTime - timeBetweenTicks;
+            health = Host.Stats["health"];
 
-            if (this.numOfTicks != 0)
+            if (numOfTicks != 0)
             {
-                this.health.Decrease(10, this.Host);
-                this.numOfTicks -= 1;
-                base.Apply(this.timeBetweenTicks);
+                health.Decrease(10, Host);
+                numOfTicks -= 1;
+                base.Apply(timeBetweenTicks);
             }
             else
             {
-                this.Remove();
+                Remove();
             }
         }
         */

--- a/src/Effects/StatEffect.cs
+++ b/src/Effects/StatEffect.cs
@@ -33,15 +33,15 @@ namespace WheelMUD.Effects
         public StatEffect(Thing activeThing, GameStat stat, int valueMod, int minimumMod, int maximumMod, TimeSpan duration, SensoryMessage sensoryMessage, SensoryMessage expirationMessage)
             : base(duration)
         {
-            this.Name = stat.Name;
-            this.Stat = stat;
-            this.ValueMod = valueMod;
-            this.MinimumMod = minimumMod;
-            this.MaximumMod = maximumMod;
-            this.ActiveThing = activeThing;
-            this.SensoryMessage = sensoryMessage;
-            this.ExpirationMessage = expirationMessage;
-            this.Duration = duration;
+            Name = stat.Name;
+            Stat = stat;
+            ValueMod = valueMod;
+            MinimumMod = minimumMod;
+            MaximumMod = maximumMod;
+            ActiveThing = activeThing;
+            SensoryMessage = sensoryMessage;
+            ExpirationMessage = expirationMessage;
+            Duration = duration;
         }
 
         /// <summary>Initializes a new instance of the StatEffect class.</summary>
@@ -50,7 +50,7 @@ namespace WheelMUD.Effects
         public StatEffect(long instanceId, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceId;
+            ID = instanceId;
         }
 
         /// <summary>Gets or sets the name.</summary>
@@ -84,58 +84,58 @@ namespace WheelMUD.Effects
         /// <summary>Expires this instance.</summary>
         public void Expire()
         {
-            this.Parent.Behaviors.Remove(this);
+            Parent.Behaviors.Remove(this);
 
-            this.RemoveStatEvent.Cancel(string.Empty);
-            this.RemoveStatEvent = null;
+            RemoveStatEvent.Cancel(string.Empty);
+            RemoveStatEvent = null;
         }
 
         /// <summary>Applies the effect to its host.</summary>
-        /// <remarks>Preconditions: this.Parent.Attributes must not be null if this.Parent is not null.</remarks>
+        /// <remarks>Preconditions: Parent.Attributes must not be null if Parent is not null.</remarks>
         protected override void OnAddBehavior()
         {
             // Create and broadcast the event notifying players that the effect was applied.
-            var addEvent = new EffectEvent(this.ActiveThing, this.Parent, this.SensoryMessage);
-            this.ActiveThing.Eventing.OnCommunicationRequest(addEvent, EventScope.ParentsDown);
+            var addEvent = new EffectEvent(ActiveThing, Parent, SensoryMessage);
+            ActiveThing.Eventing.OnCommunicationRequest(addEvent, EventScope.ParentsDown);
             if (!addEvent.IsCancelled)
             {
-                this.ActiveThing.Eventing.OnCommunicationEvent(addEvent, EventScope.ParentsDown);
+                ActiveThing.Eventing.OnCommunicationEvent(addEvent, EventScope.ParentsDown);
             }
 
             // Create and schedule an event that tells TimeSystem to call Expire()
             // after EndTime is reached.
-            this.RemoveStatEvent = new TimeEvent(this.ActiveThing, this.Expire, this.EndTime, this.ExpirationMessage);
-            TimeSystem.Instance.ScheduleEvent(this.RemoveStatEvent);
+            RemoveStatEvent = new TimeEvent(ActiveThing, Expire, EndTime, ExpirationMessage);
+            TimeSystem.Instance.ScheduleEvent(RemoveStatEvent);
         }
 
         /// <summary>The method that is called when an effect is to be removed.</summary>
         /// <remarks>
         /// It is effectively the cleanup operation, i.e. reduce stats to normal level.
-        /// Preconditions: this.Parent.Attributes must not be null if this.Parent is not null.
-        /// this.Stat must not be null - provide defaults in this.SetDefaultProperties().
+        /// Preconditions: Parent.Attributes must not be null if Parent is not null.
+        /// Stat must not be null - provide defaults in SetDefaultProperties().
         /// </remarks>
         protected override void OnRemoveBehavior()
         {
             // Broadcast the removal event that we previously created in OnAddBehavior.
-            this.ActiveThing.Eventing.OnCommunicationRequest(this.RemoveStatEvent, EventScope.ParentsDown);
-            if (!this.RemoveStatEvent.IsCancelled)
+            ActiveThing.Eventing.OnCommunicationRequest(RemoveStatEvent, EventScope.ParentsDown);
+            if (!RemoveStatEvent.IsCancelled)
             {
-                this.ActiveThing.Eventing.OnCommunicationEvent(this.RemoveStatEvent, EventScope.ParentsDown);
+                ActiveThing.Eventing.OnCommunicationEvent(RemoveStatEvent, EventScope.ParentsDown);
             }
 
             // Normally the TimeSystem will remove this event when it expires.
             // If it is removed by some other means, we should cancel the RemoveStatEvent so
             // TimeSystem will know to ignore it when the EndTime is reached.
-            if (this.RemoveStatEvent != null && !this.RemoveStatEvent.IsCancelled)
+            if (RemoveStatEvent != null && !RemoveStatEvent.IsCancelled)
             {
-                this.RemoveStatEvent.Cancel(string.Empty);
+                RemoveStatEvent.Cancel(string.Empty);
             }
         }
 
         /// <summary>Sets the default properties of this effect instance. Duration is given a default TimeSpan.</summary>
         protected override void SetDefaultProperties()
         {
-            this.Duration = TimeSpan.FromMinutes(1);
+            Duration = TimeSpan.FromMinutes(1);
         }
     }
 }

--- a/src/Effects/UnbalanceEffect.cs
+++ b/src/Effects/UnbalanceEffect.cs
@@ -24,7 +24,7 @@ namespace WheelMUD.Effects
         public UnbalanceEffect(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Sets the default properties of this effect instance.</summary>

--- a/src/FTPServer/Ftp/CommandHandlers/AlloCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/AlloCommandHandler.cs
@@ -16,7 +16,7 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            return this.GetMessage(202, "Allo processed successfully (depreciated).");
+            return GetMessage(202, "Allo processed successfully (depreciated).");
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/AppendCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/AppendCommandHandler.cs
@@ -20,24 +20,24 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            string filePath = this.GetPath(message);
+            string filePath = GetPath(message);
 
-            var file = this.ConnectionObject.FileSystemObject.OpenFile(filePath, true);
+            var file = ConnectionObject.FileSystemObject.OpenFile(filePath, true);
             if (file == null)
             {
-                return this.GetMessage(425, "Couldn't open file");
+                return GetMessage(425, "Couldn't open file");
             }
 
-            var socketReply = new FtpReplySocket(this.ConnectionObject);
+            var socketReply = new FtpReplySocket(ConnectionObject);
 
             if (!socketReply.Loaded)
             {
-                return this.GetMessage(425, "Error in establishing data connection.");
+                return GetMessage(425, "Error in establishing data connection.");
             }
 
             var data = new byte[BufferSize];
 
-            SocketHelpers.Send(this.ConnectionObject.Socket, this.GetMessage(150, "Opening connection for data transfer."));
+            SocketHelpers.Send(ConnectionObject.Socket, GetMessage(150, "Opening connection for data transfer."));
 
             int received = socketReply.Receive(data);
 
@@ -50,7 +50,7 @@ namespace WheelMUD.Ftp.FtpCommands
             file.Close();
             socketReply.Close();
 
-            return this.GetMessage(226, string.Format("Appended file successfully. ({0})", filePath));
+            return GetMessage(226, string.Format("Appended file successfully. ({0})", filePath));
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/CdUpCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/CdUpCommandHandler.cs
@@ -18,9 +18,9 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            string workingDirectory = this.GetPath(message);
+            string workingDirectory = GetPath(message);
 
-            if (this.ConnectionObject.FileSystemObject.DirectoryExists(workingDirectory))
+            if (ConnectionObject.FileSystemObject.DirectoryExists(workingDirectory))
             {
                 if (workingDirectory != "\\")
                 {
@@ -32,13 +32,13 @@ namespace WheelMUD.Ftp.FtpCommands
                         path = path.Replace('/', '\\');
                     }
 
-                    this.ConnectionObject.CurrentDirectory = path;
+                    ConnectionObject.CurrentDirectory = path;
 
-                    return this.GetMessage(250, "CDUP command successful.");
+                    return GetMessage(250, "CDUP command successful.");
                 }
             }
 
-            return this.GetMessage(550, "CDUP could not change directory.");
+            return GetMessage(550, "CDUP could not change directory.");
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/CwdCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/CwdCommandHandler.cs
@@ -23,17 +23,17 @@ namespace WheelMUD.Ftp.FtpCommands
 
             if (!FileNameHelpers.IsValid(message))
             {
-                return this.GetMessage(550, "Not a valid directory string.");
+                return GetMessage(550, "Not a valid directory string.");
             }
 
-            var dir = this.GetPath(message);
-            if (!this.ConnectionObject.FileSystemObject.DirectoryExists(dir))
+            var dir = GetPath(message);
+            if (!ConnectionObject.FileSystemObject.DirectoryExists(dir))
             {
-                return this.GetMessage(550, "Not a valid directory.");
+                return GetMessage(550, "Not a valid directory.");
             }
 
-            this.ConnectionObject.CurrentDirectory = Path.Combine(this.ConnectionObject.CurrentDirectory, message);
-            return this.GetMessage(250, string.Format("CWD Successful ({0})", this.ConnectionObject.CurrentDirectory.Replace("\\", "/")));
+            ConnectionObject.CurrentDirectory = Path.Combine(ConnectionObject.CurrentDirectory, message);
+            return GetMessage(250, string.Format("CWD Successful ({0})", ConnectionObject.CurrentDirectory.Replace("\\", "/")));
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/DeleCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/DeleCommandHandler.cs
@@ -17,18 +17,18 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            var filePath = this.GetPath(message);
-            if (!this.ConnectionObject.FileSystemObject.FileExists(filePath))
+            var filePath = GetPath(message);
+            if (!ConnectionObject.FileSystemObject.FileExists(filePath))
             {
-                return this.GetMessage(550, "File does not exist.");
+                return GetMessage(550, "File does not exist.");
             }
 
-            if (!this.ConnectionObject.FileSystemObject.Delete(filePath))
+            if (!ConnectionObject.FileSystemObject.Delete(filePath))
             {
-                return this.GetMessage(550, "Couldn't delete file.");
+                return GetMessage(550, "Couldn't delete file.");
             }
 
-            return this.GetMessage(250, "File deleted successfully");
+            return GetMessage(250, "File deleted successfully");
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/FtpCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/FtpCommandHandler.cs
@@ -16,8 +16,8 @@ namespace WheelMUD.Ftp.FtpCommands
     {
         public FtpCommandHandler(string command, FtpConnectionObject connectionObject)
         {
-            this.Command = command;
-            this.ConnectionObject = connectionObject;
+            Command = command;
+            ConnectionObject = connectionObject;
         }
 
         public string Command { get; private set; }
@@ -26,7 +26,7 @@ namespace WheelMUD.Ftp.FtpCommands
 
         public void Process(string message)
         {
-            this.SendMessage(OnProcess(message));
+            SendMessage(OnProcess(message));
         }
 
         protected virtual string OnProcess(string message)
@@ -44,11 +44,11 @@ namespace WheelMUD.Ftp.FtpCommands
         {
             if (path.Length == 0)
             {
-                return this.ConnectionObject.CurrentDirectory;
+                return ConnectionObject.CurrentDirectory;
             }
 
             path = path.Replace('/', '\\');
-            return Path.Combine(this.ConnectionObject.CurrentDirectory, path);
+            return Path.Combine(ConnectionObject.CurrentDirectory, path);
         }
 
         private void SendMessage(string message)
@@ -61,14 +61,14 @@ namespace WheelMUD.Ftp.FtpCommands
             int endIndex = message.IndexOf('\r');
             if (endIndex < 0)
             {
-                FtpServerMessageHandler.SendMessage(this.ConnectionObject.Id, message);
+                FtpServerMessageHandler.SendMessage(ConnectionObject.Id, message);
             }
             else
             {
-                FtpServerMessageHandler.SendMessage(this.ConnectionObject.Id, message.Substring(0, endIndex));
+                FtpServerMessageHandler.SendMessage(ConnectionObject.Id, message.Substring(0, endIndex));
             }
 
-            SocketHelpers.Send(this.ConnectionObject.Socket, message);
+            SocketHelpers.Send(ConnectionObject.Socket, message);
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/ListCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/ListCommandHandler.cs
@@ -16,7 +16,7 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string BuildReply(string message, string[] files)
         {
-            return this.BuildLongReply(files);
+            return BuildLongReply(files);
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/ListCommandHandlerBase.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/ListCommandHandlerBase.cs
@@ -22,40 +22,40 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            SocketHelpers.Send(this.ConnectionObject.Socket, "150 Opening data connection for LIST\r\n");
+            SocketHelpers.Send(ConnectionObject.Socket, "150 Opening data connection for LIST\r\n");
 
             string[] asFiles = null;
             string[] asDirectories = null;
 
             message = message.Trim();
 
-            string path = this.GetPath(string.Empty);
+            string path = GetPath(string.Empty);
 
             if (message.Length == 0 || message[0] == '-')
             {
-                asFiles = this.ConnectionObject.FileSystemObject.GetFiles(path);
-                asDirectories = this.ConnectionObject.FileSystemObject.GetDirectories(path);
+                asFiles = ConnectionObject.FileSystemObject.GetFiles(path);
+                asDirectories = ConnectionObject.FileSystemObject.GetDirectories(path);
             }
             else
             {
-                asFiles = this.ConnectionObject.FileSystemObject.GetFiles(path, message);
-                asDirectories = this.ConnectionObject.FileSystemObject.GetDirectories(path, message);
+                asFiles = ConnectionObject.FileSystemObject.GetFiles(path, message);
+                asDirectories = ConnectionObject.FileSystemObject.GetDirectories(path, message);
             }
 
             var asAll = ArrayHelpers.Add(asDirectories, asFiles) as string[];
-            string fileList = this.BuildReply(message, asAll);
+            string fileList = BuildReply(message, asAll);
 
-            var socketReply = new FtpReplySocket(this.ConnectionObject);
+            var socketReply = new FtpReplySocket(ConnectionObject);
 
             if (!socketReply.Loaded)
             {
-                return this.GetMessage(550, "LIST unable to establish return connection.");
+                return GetMessage(550, "LIST unable to establish return connection.");
             }
 
             socketReply.Send(fileList);
             socketReply.Close();
 
-            return this.GetMessage(226, "LIST successful.");
+            return GetMessage(226, "LIST successful.");
         }
 
         protected abstract string BuildReply(string message, string[] asFiles);
@@ -69,7 +69,7 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected string BuildLongReply(string[] asFiles)
         {
-            string dir = this.GetPath(string.Empty);
+            string dir = GetPath(string.Empty);
 
             var stringBuilder = new StringBuilder();
 
@@ -78,7 +78,7 @@ namespace WheelMUD.Ftp.FtpCommands
                 string file = asFiles[index];
                 file = Path.Combine(dir, file);
 
-                var info = this.ConnectionObject.FileSystemObject.GetFileInfo(file);
+                var info = ConnectionObject.FileSystemObject.GetFileInfo(file);
                 if (info != null)
                 {
                     string attributes = info.GetAttributeString();

--- a/src/FTPServer/Ftp/CommandHandlers/MakeDirectoryCommandHandlerBase.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/MakeDirectoryCommandHandlerBase.cs
@@ -16,13 +16,13 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            string filePath = this.GetPath(message);
-            if (!this.ConnectionObject.FileSystemObject.CreateDirectory(filePath))
+            string filePath = GetPath(message);
+            if (!ConnectionObject.FileSystemObject.CreateDirectory(filePath))
             {
-                return this.GetMessage(550, string.Format("Couldn't create directory. ({0})", filePath));
+                return GetMessage(550, string.Format("Couldn't create directory. ({0})", filePath));
             }
 
-            return this.GetMessage(257, filePath);
+            return GetMessage(257, filePath);
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/NlstCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/NlstCommandHandler.cs
@@ -18,10 +18,10 @@ namespace WheelMUD.Ftp.FtpCommands
         {
             if (message == "-L" || message == "-l")
             {
-                return this.BuildLongReply(asFiles);
+                return BuildLongReply(asFiles);
             }
 
-            return this.BuildShortReply(asFiles);
+            return BuildShortReply(asFiles);
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/NoopCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/NoopCommandHandler.cs
@@ -16,7 +16,7 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            return this.GetMessage(200, string.Empty);
+            return GetMessage(200, string.Empty);
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/PasswordCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/PasswordCommandHandler.cs
@@ -20,23 +20,23 @@ namespace WheelMUD.Ftp.FtpCommands
         {
             string retval;
 
-            var user = PlayerRepositoryExtensions.Authenticate(this.ConnectionObject.User, message);
+            var user = PlayerRepositoryExtensions.Authenticate(ConnectionObject.User, message);
             if (user != null)
             {
-                this.ConnectionObject.CreateFileSystem();
-                retval = this.GetMessage(220, "Password ok, FTP server ready");
+                ConnectionObject.CreateFileSystem();
+                retval = GetMessage(220, "Password ok, FTP server ready");
             }
             else
             {
-                retval = this.GetMessage(530, "Username or password incorrect");
+                retval = GetMessage(530, "Username or password incorrect");
             }
 
-            ////if (this.ConnectionObject.Login(sMessage))
+            ////if (ConnectionObject.Login(sMessage))
             ////{
-            ////    return this.GetMessage(220, "Password ok, FTP server ready");
+            ////    return GetMessage(220, "Password ok, FTP server ready");
             ////}
             ////
-            ////return this.GetMessage(530, "Username or password incorrect");
+            ////return GetMessage(530, "Username or password incorrect");
 
             return retval;
         }

--- a/src/FTPServer/Ftp/CommandHandlers/PasvCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/PasvCommandHandler.cs
@@ -20,25 +20,25 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            if (this.ConnectionObject.PasvSocket == null)
+            if (ConnectionObject.PasvSocket == null)
             {
                 var listener = SocketHelpers.CreateTcpListener(Port);
                 if (listener == null)
                 {
-                    return this.GetMessage(550, string.Format("Couldn't start listener on port {0}", Port));
+                    return GetMessage(550, string.Format("Couldn't start listener on port {0}", Port));
                 }
 
-                this.SendPasvReply();
+                SendPasvReply();
 
                 listener.Start();
 
-                this.ConnectionObject.PasvSocket = listener.AcceptTcpClient();
+                ConnectionObject.PasvSocket = listener.AcceptTcpClient();
 
                 listener.Stop();
                 return string.Empty;
             }
 
-            this.SendPasvReply();
+            SendPasvReply();
             return string.Empty;
         }
 
@@ -50,7 +50,7 @@ namespace WheelMUD.Ftp.FtpCommands
             addr += "0";
             addr += ',';
             addr += Port.ToString();
-            SocketHelpers.Send(this.ConnectionObject.Socket, string.Format("227 ={0}\r\n", addr));
+            SocketHelpers.Send(ConnectionObject.Socket, string.Format("227 ={0}\r\n", addr));
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/PortCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/PortCommandHandler.cs
@@ -19,15 +19,15 @@ namespace WheelMUD.Ftp.FtpCommands
             string[] data = message.Split(new char[] { ',' });
             if (data.Length != 6)
             {
-                return this.GetMessage(550, "Error in setting up data connection");
+                return GetMessage(550, "Error in setting up data connection");
             }
 
             int socketPort = (int.Parse(data[4]) * 256) + int.Parse(data[5]);
 
-            this.ConnectionObject.PortCommandSocketPort = socketPort;
-            this.ConnectionObject.PortCommandSocketAddress = string.Join(".", data, 0, 4);
+            ConnectionObject.PortCommandSocketPort = socketPort;
+            ConnectionObject.PortCommandSocketAddress = string.Join(".", data, 0, 4);
 
-            return this.GetMessage(200, string.Format("{0} command succeeded", this.Command));
+            return GetMessage(200, string.Format("{0} command succeeded", Command));
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/PwdCommandHandlerBase.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/PwdCommandHandlerBase.cs
@@ -17,9 +17,9 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            string dir = this.ConnectionObject.CurrentDirectory;
+            string dir = ConnectionObject.CurrentDirectory;
             dir = dir.Replace('\\', '/');
-            return this.GetMessage(257, string.Format("\"{0}\" PWD Successful.", dir));
+            return GetMessage(257, string.Format("\"{0}\" PWD Successful.", dir));
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/QuitCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/QuitCommandHandler.cs
@@ -16,7 +16,7 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            return this.GetMessage(220, "Goodbye");
+            return GetMessage(220, "Goodbye");
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/RemoveDirectoryCommandHandlerBase.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/RemoveDirectoryCommandHandlerBase.cs
@@ -16,18 +16,18 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            string file = this.GetPath(message);
-            if (!this.ConnectionObject.FileSystemObject.DirectoryExists(file))
+            string file = GetPath(message);
+            if (!ConnectionObject.FileSystemObject.DirectoryExists(file))
             {
-                return this.GetMessage(550, string.Format("Directory does not exist"));
+                return GetMessage(550, string.Format("Directory does not exist"));
             }
 
-            if (this.ConnectionObject.FileSystemObject.Delete(file))
+            if (ConnectionObject.FileSystemObject.Delete(file))
             {
-                return this.GetMessage(250, "Directory removed.");
+                return GetMessage(250, "Directory removed.");
             }
 
-            return this.GetMessage(550, string.Format("Couldn't remove directory ({0}).", file));
+            return GetMessage(550, string.Format("Couldn't remove directory ({0}).", file));
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/RenameCompleteCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/RenameCompleteCommandHandler.cs
@@ -16,28 +16,28 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            if (this.ConnectionObject.FileToRename.Length == 0)
+            if (ConnectionObject.FileToRename.Length == 0)
             {
-                return this.GetMessage(503, "RNTO must be preceded by a RNFR.");
+                return GetMessage(503, "RNTO must be preceded by a RNFR.");
             }
 
-            string newFileName = this.GetPath(message);
-            string oldFileName = this.ConnectionObject.FileToRename;
+            string newFileName = GetPath(message);
+            string oldFileName = ConnectionObject.FileToRename;
 
-            this.ConnectionObject.FileToRename = string.Empty;
+            ConnectionObject.FileToRename = string.Empty;
 
-            if (this.ConnectionObject.FileSystemObject.FileExists(newFileName) ||
-                this.ConnectionObject.FileSystemObject.DirectoryExists(newFileName))
+            if (ConnectionObject.FileSystemObject.FileExists(newFileName) ||
+                ConnectionObject.FileSystemObject.DirectoryExists(newFileName))
             {
-                return this.GetMessage(553, string.Format("File already exists ({0}).", newFileName));
+                return GetMessage(553, string.Format("File already exists ({0}).", newFileName));
             }
 
-            if (!this.ConnectionObject.FileSystemObject.Move(oldFileName, newFileName))
+            if (!ConnectionObject.FileSystemObject.Move(oldFileName, newFileName))
             {
-                return this.GetMessage(553, "Move failed");
+                return GetMessage(553, "Move failed");
             }
 
-            return this.GetMessage(250, "Renamed file successfully.");
+            return GetMessage(250, "Renamed file successfully.");
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/RenameStartCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/RenameStartCommandHandler.cs
@@ -17,17 +17,17 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            string file = this.GetPath(message);
-            this.ConnectionObject.FileToRename = file;
+            string file = GetPath(message);
+            ConnectionObject.FileToRename = file;
 
-            var info = this.ConnectionObject.FileSystemObject.GetFileInfo(file);
+            var info = ConnectionObject.FileSystemObject.GetFileInfo(file);
             if (info == null)
             {
-                return this.GetMessage(550, string.Format("File does not exist ({0}).", file));
+                return GetMessage(550, string.Format("File does not exist ({0}).", file));
             }
 
-            this.ConnectionObject.RenameDirectory = info.IsDirectory();
-            return this.GetMessage(350, string.Format("Rename file started ({0}).", file));
+            ConnectionObject.RenameDirectory = info.IsDirectory();
+            return GetMessage(350, string.Format("Rename file started ({0}).", file));
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/RetrCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/RetrCommandHandler.cs
@@ -19,24 +19,24 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            string filePath = this.GetPath(message);
-            if (!this.ConnectionObject.FileSystemObject.FileExists(filePath))
+            string filePath = GetPath(message);
+            if (!ConnectionObject.FileSystemObject.FileExists(filePath))
             {
-                return this.GetMessage(550, "File doesn't exist");
+                return GetMessage(550, "File doesn't exist");
             }
 
-            var replySocket = new FtpReplySocket(this.ConnectionObject);
+            var replySocket = new FtpReplySocket(ConnectionObject);
             if (!replySocket.Loaded)
             {
-                return this.GetMessage(550, "Unable to establish data connection");
+                return GetMessage(550, "Unable to establish data connection");
             }
 
-            SocketHelpers.Send(this.ConnectionObject.Socket, "150 Starting data transfer, please wait...\r\n");
+            SocketHelpers.Send(ConnectionObject.Socket, "150 Starting data transfer, please wait...\r\n");
 
-            var file = this.ConnectionObject.FileSystemObject.OpenFile(filePath, false);
+            var file = ConnectionObject.FileSystemObject.OpenFile(filePath, false);
             if (file == null)
             {
-                return this.GetMessage(550, "Couldn't open file");
+                return GetMessage(550, "Couldn't open file");
             }
 
             const int BufferSize = 65536;
@@ -50,7 +50,7 @@ namespace WheelMUD.Ftp.FtpCommands
             file.Close();
             replySocket.Close();
 
-            return this.GetMessage(226, "File download succeeded.");
+            return GetMessage(226, "File download succeeded.");
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/SizeCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/SizeCommandHandler.cs
@@ -16,19 +16,19 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            string path = this.GetPath(message);
-            if (!this.ConnectionObject.FileSystemObject.FileExists(path))
+            string path = GetPath(message);
+            if (!ConnectionObject.FileSystemObject.FileExists(path))
             {
-                return this.GetMessage(550, string.Format("File doesn't exist ({0})", path));
+                return GetMessage(550, string.Format("File doesn't exist ({0})", path));
             }
 
-            var info = this.ConnectionObject.FileSystemObject.GetFileInfo(path);
+            var info = ConnectionObject.FileSystemObject.GetFileInfo(path);
             if (info == null)
             {
-                return this.GetMessage(550, "Error in getting file information");
+                return GetMessage(550, "Error in getting file information");
             }
 
-            return this.GetMessage(220, info.GetSize().ToString());
+            return GetMessage(220, info.GetSize().ToString());
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/StoreCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/StoreCommandHandler.cs
@@ -20,21 +20,21 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            var filePath = this.GetPath(message);
-            if (this.ConnectionObject.FileSystemObject.FileExists(filePath))
+            var filePath = GetPath(message);
+            if (ConnectionObject.FileSystemObject.FileExists(filePath))
             {
-                return this.GetMessage(553, "File already exists.");
+                return GetMessage(553, "File already exists.");
             }
 
-            var file = this.ConnectionObject.FileSystemObject.OpenFile(filePath, true);
-            var socketReply = new FtpReplySocket(this.ConnectionObject);
+            var file = ConnectionObject.FileSystemObject.OpenFile(filePath, true);
+            var socketReply = new FtpReplySocket(ConnectionObject);
 
             if (!socketReply.Loaded)
             {
-                return this.GetMessage(425, "Error in establishing data connection.");
+                return GetMessage(425, "Error in establishing data connection.");
             }
 
-            SocketHelpers.Send(this.ConnectionObject.Socket, this.GetMessage(150, "Opening connection for data transfer."));
+            SocketHelpers.Send(ConnectionObject.Socket, GetMessage(150, "Opening connection for data transfer."));
 
             byte[] data = new byte[BufferSize];
             int received = socketReply.Receive(data);
@@ -47,7 +47,7 @@ namespace WheelMUD.Ftp.FtpCommands
             file.Close();
             socketReply.Close();
 
-            return this.GetMessage(226, "Uploaded file successfully.");
+            return GetMessage(226, "Uploaded file successfully.");
         }
     }
 }

--- a/src/FTPServer/Ftp/CommandHandlers/TypeCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/TypeCommandHandler.cs
@@ -20,17 +20,17 @@ namespace WheelMUD.Ftp.FtpCommands
             message = message.ToUpper();
             if (message == "A")
             {
-                this.ConnectionObject.BinaryMode = false;
-                return this.GetMessage(200, "ASCII transfer mode active.");
+                ConnectionObject.BinaryMode = false;
+                return GetMessage(200, "ASCII transfer mode active.");
             }
             else if (message == "I")
             {
-                this.ConnectionObject.BinaryMode = true;
-                return this.GetMessage(200, "Binary transfer mode active.");
+                ConnectionObject.BinaryMode = true;
+                return GetMessage(200, "Binary transfer mode active.");
             }
             else
             {
-                return this.GetMessage(550, string.Format("Error - unknown binary mode \"{0}\"", message));
+                return GetMessage(550, string.Format("Error - unknown binary mode \"{0}\"", message));
             }
         }
     }

--- a/src/FTPServer/Ftp/CommandHandlers/UserCommandHandler.cs
+++ b/src/FTPServer/Ftp/CommandHandlers/UserCommandHandler.cs
@@ -16,8 +16,8 @@ namespace WheelMUD.Ftp.FtpCommands
 
         protected override string OnProcess(string message)
         {
-            this.ConnectionObject.User = message;
-            return this.GetMessage(331, string.Format("User {0} logged in, needs password", message));
+            ConnectionObject.User = message;
+            return GetMessage(331, string.Format("User {0} logged in, needs password", message));
         }
     }
 }

--- a/src/FTPServer/Ftp/FileSystem/StandardFileInfoObject.cs
+++ b/src/FTPServer/Ftp/FileSystem/StandardFileInfoObject.cs
@@ -20,34 +20,34 @@ namespace WheelMUD.Ftp.FileSystem
         {
             try
             {
-                this.fileInfo = new FileInfo(path);
-                this.isLoaded = true;
+                fileInfo = new FileInfo(path);
+                isLoaded = true;
             }
             catch (IOException)
             {
-                this.fileInfo = null;
+                fileInfo = null;
             }
         }
 
         public bool IsDirectory()
         {
-            return (this.fileInfo.Attributes & FileAttributes.Directory) != 0;
+            return (fileInfo.Attributes & FileAttributes.Directory) != 0;
         }
 
         public DateTime GetModifiedTime()
         {
-            return this.fileInfo.LastWriteTime;
+            return fileInfo.LastWriteTime;
         }
 
         public long GetSize()
         {
-            return this.fileInfo.Length;
+            return fileInfo.Length;
         }
 
         public string GetAttributeString()
         {
-            bool isDir = (this.fileInfo.Attributes & FileAttributes.Directory) != 0;
-            bool isReadOnly = (this.fileInfo.Attributes & FileAttributes.ReadOnly) != 0;
+            bool isDir = (fileInfo.Attributes & FileAttributes.Directory) != 0;
+            bool isReadOnly = (fileInfo.Attributes & FileAttributes.ReadOnly) != 0;
 
             var builder = new StringBuilder();
 

--- a/src/FTPServer/Ftp/FileSystem/StandardFileObject.cs
+++ b/src/FTPServer/Ftp/FileSystem/StandardFileObject.cs
@@ -20,31 +20,31 @@ namespace WheelMUD.Ftp.FileSystem
             {
                 var mode = write ? FileMode.OpenOrCreate : FileMode.Open;
                 var access = write ? FileAccess.Write : FileAccess.Read;
-                this.fileStream = new FileStream(path, mode, access);
+                fileStream = new FileStream(path, mode, access);
 
                 if (write)
                 {
-                    this.fileStream.Seek(0, System.IO.SeekOrigin.End);
+                    fileStream.Seek(0, System.IO.SeekOrigin.End);
                 }
 
-                this.isLoaded = true;
+                isLoaded = true;
             }
             catch (IOException)
             {
-                this.fileStream = null;
+                fileStream = null;
             }
         }
 
         public int Read(byte[] data, int dataSize)
         {
-            if (this.fileStream == null)
+            if (fileStream == null)
             {
                 return 0;
             }
 
             try
             {
-                return this.fileStream.Read(data, 0, dataSize);
+                return fileStream.Read(data, 0, dataSize);
             }
             catch (IOException)
             {
@@ -54,14 +54,14 @@ namespace WheelMUD.Ftp.FileSystem
 
         public int Write(byte[] data, int dataSize)
         {
-            if (this.fileStream == null)
+            if (fileStream == null)
             {
                 return 0;
             }
 
             try
             {
-                this.fileStream.Write(data, 0, dataSize);
+                fileStream.Write(data, 0, dataSize);
             }
             catch (IOException)
             {
@@ -73,17 +73,17 @@ namespace WheelMUD.Ftp.FileSystem
 
         public void Close()
         {
-            if (this.fileStream != null)
+            if (fileStream != null)
             {
                 try
                 {
-                    this.fileStream.Close();
+                    fileStream.Close();
                 }
                 catch (IOException)
                 {
                 }
 
-                this.fileStream = null;
+                fileStream = null;
             }
         }
     }

--- a/src/FTPServer/Ftp/FileSystem/StandardFileSystemObject.cs
+++ b/src/FTPServer/Ftp/FileSystem/StandardFileSystemObject.cs
@@ -20,62 +20,62 @@ namespace WheelMUD.Ftp.FileSystem
 
         public IFile OpenFile(string path, bool write)
         {
-            var file = new StandardFileObject(this.GetPath(path), write);
+            var file = new StandardFileObject(GetPath(path), write);
             return file.Loaded ? file : null;
         }
 
         public IFileInfo GetFileInfo(string path)
         {
-            var info = new StandardFileInfoObject(this.GetPath(path));
+            var info = new StandardFileInfoObject(GetPath(path));
             return info.Loaded ? info : null;
         }
 
         public string[] GetFiles(string path)
         {
-            string currentPath = this.GetPath(path);
+            string currentPath = GetPath(path);
             string[] files = Directory.GetFiles(currentPath);
-            this.RemovePath(files, currentPath);
+            RemovePath(files, currentPath);
             return files;
         }
 
         public string[] GetFiles(string path, string wildcard)
         {
-            string currentPath = this.GetPath(path);
+            string currentPath = GetPath(path);
             string[] asFiles = Directory.GetFiles(currentPath, wildcard);
-            this.RemovePath(asFiles, currentPath);
+            RemovePath(asFiles, currentPath);
             return asFiles;
         }
 
         public string[] GetDirectories(string path)
         {
-            string currentPath = this.GetPath(path);
+            string currentPath = GetPath(path);
             string[] files = Directory.GetDirectories(currentPath);
-            this.RemovePath(files, currentPath);
+            RemovePath(files, currentPath);
             return files;
         }
 
         public string[] GetDirectories(string path, string wildcard)
         {
-            string currentPath = this.GetPath(path);
+            string currentPath = GetPath(path);
             string[] files = Directory.GetDirectories(currentPath, wildcard);
-            this.RemovePath(files, currentPath);
+            RemovePath(files, currentPath);
             return files;
         }
 
         public bool DirectoryExists(string path)
         {
-            return Directory.Exists(this.GetPath(path));
+            return Directory.Exists(GetPath(path));
         }
 
         public bool FileExists(string path)
         {
-            return File.Exists(this.GetPath(path));
+            return File.Exists(GetPath(path));
         }
 
         public bool Move(string oldPath, string newPath)
         {
-            string fullPathOld = this.GetPath(oldPath);
-            string fullPathNew = this.GetPath(newPath);
+            string fullPathOld = GetPath(oldPath);
+            string fullPathNew = GetPath(newPath);
 
             try
             {
@@ -106,7 +106,7 @@ namespace WheelMUD.Ftp.FileSystem
         {
             try
             {
-                var fullPath = this.GetPath(path);
+                var fullPath = GetPath(path);
                 var info = new FileInfo(fullPath);
                 if (info == null)
                 {
@@ -132,7 +132,7 @@ namespace WheelMUD.Ftp.FileSystem
 
         public bool CreateDirectory(string path)
         {
-            string fullPath = this.GetPath(path);
+            string fullPath = GetPath(path);
 
             try
             {

--- a/src/FTPServer/Ftp/FtpConnectionData.cs
+++ b/src/FTPServer/Ftp/FtpConnectionData.cs
@@ -15,14 +15,14 @@ namespace WheelMUD.Ftp
     {
         public FtpConnectionData(int id, TcpClient socket)
         {
-            this.BinaryMode = false;
-            this.RenameDirectory = false;
-            this.PasvSocket = null;
-            this.Id = id;
-            this.Socket = socket;
-            this.CurrentDirectory = "\\";
-            this.PortCommandSocketAddress = string.Empty;
-            this.PortCommandSocketPort = 20;
+            BinaryMode = false;
+            RenameDirectory = false;
+            PasvSocket = null;
+            Id = id;
+            Socket = socket;
+            CurrentDirectory = "\\";
+            PortCommandSocketAddress = string.Empty;
+            PortCommandSocketPort = 20;
         }
 
         /// <summary>Gets the main connection socket.</summary>
@@ -63,7 +63,7 @@ namespace WheelMUD.Ftp
 
         protected void SetFileSystemObject(IFileSystem fileSystem)
         {
-            this.FileSystemObject = fileSystem;
+            FileSystemObject = fileSystem;
         }
     }
 }

--- a/src/FTPServer/Ftp/FtpConnectionObject.cs
+++ b/src/FTPServer/Ftp/FtpConnectionObject.cs
@@ -23,33 +23,33 @@ namespace WheelMUD.Ftp
         public FtpConnectionObject(IFileSystemClassFactory fileSystemClassFactory, int nId, TcpClient socket)
             : base(nId, socket)
         {
-            this.commandHashTable = new Hashtable();
+            commandHashTable = new Hashtable();
             this.fileSystemClassFactory = fileSystemClassFactory;
 
-            this.LoadCommands();
+            LoadCommands();
         }
 
         public bool Login(string password)
         {
-            var fileSystem = this.fileSystemClassFactory.Create(this.User, password);
+            var fileSystem = fileSystemClassFactory.Create(User, password);
             if (fileSystem == null)
             {
                 return false;
             }
 
-            this.SetFileSystemObject(fileSystem);
+            SetFileSystemObject(fileSystem);
             return true;
         }
 
         public bool CreateFileSystem()
         {
-            var fileSystem = this.fileSystemClassFactory.Create(this.User, string.Empty);
+            var fileSystem = fileSystemClassFactory.Create(User, string.Empty);
             if (fileSystem == null)
             {
                 return false;
             }
 
-            this.SetFileSystemObject(fileSystem);
+            SetFileSystemObject(fileSystem);
             return true;
         }
 
@@ -58,7 +58,7 @@ namespace WheelMUD.Ftp
             var message = Encoding.ASCII.GetString(data);
             message = message.Substring(0, message.IndexOf('\r'));
 
-            FtpServerMessageHandler.SendMessage(this.Id, message);
+            FtpServerMessageHandler.SendMessage(Id, message);
 
             string command;
             string value;
@@ -76,11 +76,11 @@ namespace WheelMUD.Ftp
                 value = message.Substring(command.Length + 1);
             }
 
-            var handler = this.commandHashTable[command] as FtpCommandHandler;
+            var handler = commandHashTable[command] as FtpCommandHandler;
             if (handler == null)
             {
-                FtpServerMessageHandler.SendMessage(this.Id, string.Format("\"{0}\" : Unknown command", command));
-                SocketHelpers.Send(this.Socket, "550 Unknown command\r\n");
+                FtpServerMessageHandler.SendMessage(Id, string.Format("\"{0}\" : Unknown command", command));
+                SocketHelpers.Send(Socket, "550 Unknown command\r\n");
             }
             else
             {
@@ -90,36 +90,36 @@ namespace WheelMUD.Ftp
 
         private void LoadCommands()
         {
-            this.AddCommand(new UserCommandHandler(this));
-            this.AddCommand(new PasswordCommandHandler(this));
-            this.AddCommand(new QuitCommandHandler(this));
-            this.AddCommand(new CwdCommandHandler(this));
-            this.AddCommand(new PortCommandHandler(this));
-            this.AddCommand(new PasvCommandHandler(this));
-            this.AddCommand(new ListCommandHandler(this));
-            this.AddCommand(new NlstCommandHandler(this));
-            this.AddCommand(new PwdCommandHandler(this));
-            this.AddCommand(new XPwdCommandHandler(this));
-            this.AddCommand(new TypeCommandHandler(this));
-            this.AddCommand(new RetrCommandHandler(this));
-            this.AddCommand(new NoopCommandHandler(this));
-            this.AddCommand(new SizeCommandHandler(this));
-            this.AddCommand(new DeleCommandHandler(this));
-            this.AddCommand(new AlloCommandHandler(this));
-            this.AddCommand(new StoreCommandHandler(this));
-            this.AddCommand(new MakeDirectoryCommandHandler(this));
-            this.AddCommand(new RemoveDirectoryCommandHandler(this));
-            this.AddCommand(new AppendCommandHandler(this));
-            this.AddCommand(new RenameStartCommandHandler(this));
-            this.AddCommand(new RenameCompleteCommandHandler(this));
-            this.AddCommand(new XMkdCommandHandler(this));
-            this.AddCommand(new XRmdCommandHandler(this));
-            this.AddCommand(new CdUpCommandHandler(this));
+            AddCommand(new UserCommandHandler(this));
+            AddCommand(new PasswordCommandHandler(this));
+            AddCommand(new QuitCommandHandler(this));
+            AddCommand(new CwdCommandHandler(this));
+            AddCommand(new PortCommandHandler(this));
+            AddCommand(new PasvCommandHandler(this));
+            AddCommand(new ListCommandHandler(this));
+            AddCommand(new NlstCommandHandler(this));
+            AddCommand(new PwdCommandHandler(this));
+            AddCommand(new XPwdCommandHandler(this));
+            AddCommand(new TypeCommandHandler(this));
+            AddCommand(new RetrCommandHandler(this));
+            AddCommand(new NoopCommandHandler(this));
+            AddCommand(new SizeCommandHandler(this));
+            AddCommand(new DeleCommandHandler(this));
+            AddCommand(new AlloCommandHandler(this));
+            AddCommand(new StoreCommandHandler(this));
+            AddCommand(new MakeDirectoryCommandHandler(this));
+            AddCommand(new RemoveDirectoryCommandHandler(this));
+            AddCommand(new AppendCommandHandler(this));
+            AddCommand(new RenameStartCommandHandler(this));
+            AddCommand(new RenameCompleteCommandHandler(this));
+            AddCommand(new XMkdCommandHandler(this));
+            AddCommand(new XRmdCommandHandler(this));
+            AddCommand(new CdUpCommandHandler(this));
         }
 
         private void AddCommand(FtpCommandHandler handler)
         {
-            this.commandHashTable.Add(handler.Command, handler);
+            commandHashTable.Add(handler.Command, handler);
         }
     }
 }

--- a/src/FTPServer/Ftp/FtpReplySocket.cs
+++ b/src/FTPServer/Ftp/FtpReplySocket.cs
@@ -18,21 +18,21 @@ namespace WheelMUD.Ftp
 
         public FtpReplySocket(FtpConnectionObject connectionObject)
         {
-            this.socket = OpenSocket(connectionObject);
+            socket = OpenSocket(connectionObject);
         }
 
         public bool Loaded
         {
             get
             {
-                return this.socket != null;
+                return socket != null;
             }
         }
 
         public void Close()
         {
             SocketHelpers.Close(socket);
-            this.socket = null;
+            socket = null;
         }
 
         public bool Send(byte[] data, int size)
@@ -48,12 +48,12 @@ namespace WheelMUD.Ftp
         public bool Send(string message)
         {
             byte[] data = Encoding.ASCII.GetBytes(message);
-            return this.Send(data, data.Length);
+            return Send(data, data.Length);
         }
 
         public int Receive(byte[] data)
         {
-            return this.socket.GetStream().Read(data, 0, data.Length);
+            return socket.GetStream().Read(data, 0, data.Length);
         }
 
         private static TcpClient OpenSocket(FtpConnectionObject connectionObject)

--- a/src/FTPServer/Ftp/FtpServer.cs
+++ b/src/FTPServer/Ftp/FtpServer.cs
@@ -34,7 +34,7 @@ namespace WheelMUD.Ftp
 
         public FtpServer(IFileSystemClassFactory fileSystemClassFactory)
         {
-            this.connections = new ArrayList();
+            connections = new ArrayList();
             this.fileSystemClassFactory = fileSystemClassFactory;
         }
 
@@ -44,9 +44,9 @@ namespace WheelMUD.Ftp
 
         ~FtpServer()
         {
-            if (this.serverSocketListener != null)
+            if (serverSocketListener != null)
             {
-                this.serverSocketListener.Stop();
+                serverSocketListener.Stop();
             }
         }
 
@@ -59,8 +59,8 @@ namespace WheelMUD.Ftp
         public void Start(int port)
         {
             this.port = port;
-            this.serverThread = new Thread(this.ThreadRun);
-            this.serverThread.Start();
+            serverThread = new Thread(ThreadRun);
+            serverThread.Start();
         }
 
         public void Start()
@@ -68,22 +68,22 @@ namespace WheelMUD.Ftp
             int port = GameConfiguration.TryGetAppConfigInt("FtpPort", 0);
             if (port > 0)
             {
-                this.host.UpdateSystemHost(this, "Starting...");
-                this.Start();
-                this.host.UpdateSystemHost(this, "Started");
+                host.UpdateSystemHost(this, "Starting...");
+                Start();
+                host.UpdateSystemHost(this, "Started");
             }
             else
             {
-                this.host.UpdateSystemHost(this, "Omitting FTP support.");
+                host.UpdateSystemHost(this, "Omitting FTP support.");
             }
         }
 
         public void Stop()
         {
-            this.host.UpdateSystemHost(this, "Stopping");
-            this.shuttingDown = true;
+            host.UpdateSystemHost(this, "Stopping");
+            shuttingDown = true;
 
-            foreach (object t in this.connections)
+            foreach (object t in connections)
             {
                 var handler = t as FtpSocketHandler;
                 if (handler != null)
@@ -92,16 +92,16 @@ namespace WheelMUD.Ftp
                 }
             }
 
-            if (this.serverSocketListener != null)
+            if (serverSocketListener != null)
             {
-                this.serverSocketListener.Stop();
+                serverSocketListener.Stop();
             }
-            if (this.serverThread != null)
+            if (serverThread != null)
             {
-                this.serverThread.Join();
+                serverThread.Join();
             }
 
-            this.host.UpdateSystemHost(this, "Stopped");
+            host.UpdateSystemHost(this, "Stopped");
         }
 
         /// <summary>Allows the sub system host to receive an update when subscribed to this system.</summary>
@@ -109,14 +109,14 @@ namespace WheelMUD.Ftp
         /// <param name="msg">The message to be sent.</param>
         public void UpdateSubSystemHost(ISubSystem sender, string msg)
         {
-            this.host.UpdateSystemHost(this, msg);
+            host.UpdateSystemHost(this, msg);
         }
 
         /// <summary>Subscribes this system to the specified system host, so that host can receive updates.</summary>
         /// <param name="sender">The system host to receive our updates.</param>
         public void SubscribeToSystemHost(ISystemHost sender)
         {
-            this.host = sender;
+            host = sender;
         }
 
         /// <summary>Subscribe to receive system updates from this system.</summary>
@@ -138,42 +138,42 @@ namespace WheelMUD.Ftp
 
         private void ThreadRun()
         {
-            this.serverSocketListener = SocketHelpers.CreateTcpListener(this.port);
+            serverSocketListener = SocketHelpers.CreateTcpListener(port);
 
-            if (this.serverSocketListener != null)
+            if (serverSocketListener != null)
             {
-                this.serverSocketListener.Start();
+                serverSocketListener.Start();
 
                 FtpServerMessageHandler.SendMessage(0, "FTP Server Started");
-                this.UpdateSubSystemHost(this, "FTP Server Multi-Threaded Core Started");
+                UpdateSubSystemHost(this, "FTP Server Multi-Threaded Core Started");
 
-                while (!this.shuttingDown)
+                while (!shuttingDown)
                 {
                     TcpClient socket = null;
                     try
                     {
-                        socket = this.serverSocketListener.AcceptTcpClient();
+                        socket = serverSocketListener.AcceptTcpClient();
                     }
                     catch (SocketException)
                     {
-                        this.shuttingDown = true;
+                        shuttingDown = true;
                     }
                     finally
                     {
                         if (socket == null)
                         {
-                            this.shuttingDown = true;
+                            shuttingDown = true;
                         }
                         else
                         {
                             socket.NoDelay = false;
-                            this.id++;
+                            id++;
 
-                            FtpServerMessageHandler.SendMessage(this.id, "New connection");
-                            this.UpdateSubSystemHost(this, "New connection id = " + this.id);
+                            FtpServerMessageHandler.SendMessage(id, "New connection");
+                            UpdateSubSystemHost(this, "New connection id = " + id);
 
                             SendAcceptMessage(socket);
-                            this.InitialiseSocketHandler(socket);
+                            InitialiseSocketHandler(socket);
                         }
                     }
                 }
@@ -181,29 +181,29 @@ namespace WheelMUD.Ftp
             else
             {
                 FtpServerMessageHandler.SendMessage(0, "Error in starting FTP server");
-                this.UpdateSubSystemHost(this, "Error in starting FTP server");
+                UpdateSubSystemHost(this, "Error in starting FTP server");
             }
         }
 
         private void InitialiseSocketHandler(TcpClient socket)
         {
-            var handler = new FtpSocketHandler(this.fileSystemClassFactory, this.id);
+            var handler = new FtpSocketHandler(fileSystemClassFactory, id);
             handler.Start(socket);
-            this.connections.Add(handler);
-            handler.Closed += this.HandleClosed;
-            if (this.NewConnection != null)
+            connections.Add(handler);
+            handler.Closed += HandleClosed;
+            if (NewConnection != null)
             {
-                this.NewConnection(this.id);
+                NewConnection(id);
             }
         }
 
         private void HandleClosed(FtpSocketHandler handler)
         {
-            this.UpdateSubSystemHost(this, string.Format("Client #{0} has disconnected", handler.Id));
-            this.connections.Remove(handler);
-            if (this.ConnectionClosed != null)
+            UpdateSubSystemHost(this, string.Format("Client #{0} has disconnected", handler.Id));
+            connections.Remove(handler);
+            if (ConnectionClosed != null)
             {
-                this.ConnectionClosed(handler.Id);
+                ConnectionClosed(handler.Id);
             }
         }
     }

--- a/src/FTPServer/Ftp/FtpSocketHandler.cs
+++ b/src/FTPServer/Ftp/FtpSocketHandler.cs
@@ -24,7 +24,7 @@ namespace WheelMUD.Ftp
 
         public FtpSocketHandler(IFileSystemClassFactory fileSystemClassFactory, int nId)
         {
-            this.Id = nId;
+            Id = nId;
             this.fileSystemClassFactory = fileSystemClassFactory;
         }
 
@@ -36,18 +36,18 @@ namespace WheelMUD.Ftp
 
         public void Start(TcpClient socket)
         {
-            this.clientSocket = socket;
+            clientSocket = socket;
 
-            this.connectionCommands = new FtpConnectionObject(this.fileSystemClassFactory, this.Id, socket);
+            connectionCommands = new FtpConnectionObject(fileSystemClassFactory, Id, socket);
 
-            this.mainThread = new Thread(this.ThreadRun);
-            this.mainThread.Name = "ThreadRun:" + this.Id;
-            this.mainThread.Start();
+            mainThread = new Thread(ThreadRun);
+            mainThread.Name = "ThreadRun:" + Id;
+            mainThread.Start();
         }
 
         public void Stop()
         {
-            SocketHelpers.Close(this.clientSocket);
+            SocketHelpers.Close(clientSocket);
             ////_mainThread.Join();
         }
 
@@ -58,12 +58,12 @@ namespace WheelMUD.Ftp
             {
                 //while (_clientSocket.Connected)
                 //{
-                int received = this.clientSocket.GetStream().Read(data, 0, InternalBufferSize);
+                int received = clientSocket.GetStream().Read(data, 0, InternalBufferSize);
                 while (received > 0)
                 {
-                    this.connectionCommands.Process(data);
+                    connectionCommands.Process(data);
 
-                    received = this.clientSocket.GetStream().Read(data, 0, InternalBufferSize);
+                    received = clientSocket.GetStream().Read(data, 0, InternalBufferSize);
                 }
                 //}
             }
@@ -91,24 +91,24 @@ namespace WheelMUD.Ftp
                 string msg = e.Message;
                 Console.WriteLine("FtpSocketHandler.ThreadRun() ::" + Environment.NewLine + msg);
 
-                this.CloseSocket();
+                CloseSocket();
             }
 
-            this.CloseSocket();
+            CloseSocket();
         }
 
         private void CloseSocket()
         {
-            FtpServerMessageHandler.SendMessage(this.Id, "Connection closed");
+            FtpServerMessageHandler.SendMessage(Id, "Connection closed");
 
-            if (this.clientSocket.Connected)
+            if (clientSocket.Connected)
             {
-                this.clientSocket.Close();
+                clientSocket.Close();
             }
 
-            if (this.Closed != null)
+            if (Closed != null)
             {
-                this.Closed(this);
+                Closed(this);
             }
         }
     }

--- a/src/FTPServer/Ftp/UserData.cs
+++ b/src/FTPServer/Ftp/UserData.cs
@@ -19,7 +19,7 @@ namespace WheelMUD.Ftp
         /// <summary>Initializes a new instance of the <see cref="UserData"/> class.</summary>
         protected UserData()
         {
-            this.mapUserToData = new Hashtable();
+            mapUserToData = new Hashtable();
         }
 
         public static UserData Instance { get; } = new UserData();
@@ -28,7 +28,7 @@ namespace WheelMUD.Ftp
         {
             get
             {
-                ICollection collectionUsers = this.mapUserToData.Keys;
+                ICollection collectionUsers = mapUserToData.Keys;
                 var asUsers = new string[collectionUsers.Count];
                 int index = 0;
                 foreach (string user in collectionUsers)
@@ -45,23 +45,23 @@ namespace WheelMUD.Ftp
         {
             get
             {
-                return this.mapUserToData.Count;
+                return mapUserToData.Count;
             }
         }
 
         public void AddUser(string user)
         {
-            this.mapUserToData.Add(user, new UserDataItem());
+            mapUserToData.Add(user, new UserDataItem());
         }
 
         public void RemoveUser(string user)
         {
-            this.mapUserToData.Remove(user);
+            mapUserToData.Remove(user);
         }
 
         public string GetUserPassword(string user)
         {
-            UserDataItem item = this.GetUserItem(user);
+            UserDataItem item = GetUserItem(user);
             if (item != null)
             {
                 return item.Password;
@@ -72,7 +72,7 @@ namespace WheelMUD.Ftp
 
         public void SetUserPassword(string user, string password)
         {
-            UserDataItem item = this.GetUserItem(user);
+            UserDataItem item = GetUserItem(user);
             if (item != null)
             {
                 item.Password = password;
@@ -81,7 +81,7 @@ namespace WheelMUD.Ftp
 
         public string GetUserStartingDirectory(string user)
         {
-            UserDataItem item = this.GetUserItem(user);
+            UserDataItem item = GetUserItem(user);
             if (item != null)
             {
                 return item.StartingDirectory;
@@ -92,7 +92,7 @@ namespace WheelMUD.Ftp
 
         public void SetUserStartingDirectory(string user, string directory)
         {
-            UserDataItem item = this.GetUserItem(user);
+            UserDataItem item = GetUserItem(user);
             if (item != null)
             {
                 item.StartingDirectory = directory;
@@ -101,7 +101,7 @@ namespace WheelMUD.Ftp
 
         public bool HasUser(string user)
         {
-            UserDataItem item = this.GetUserItem(user);
+            UserDataItem item = GetUserItem(user);
             return item != null;
         }
 
@@ -111,7 +111,7 @@ namespace WheelMUD.Ftp
             {
                 var formatter = new BinaryFormatter();
                 var fileStream = new FileStream(fileName, FileMode.Create);
-                formatter.Serialize(fileStream, this.mapUserToData);
+                formatter.Serialize(fileStream, mapUserToData);
                 fileStream.Close();
             }
             catch (IOException)
@@ -133,7 +133,7 @@ namespace WheelMUD.Ftp
             {
                 var formatter = new BinaryFormatter();
                 var fileStream = new FileStream(fileName, FileMode.Open);
-                this.mapUserToData = formatter.Deserialize(fileStream) as Hashtable;
+                mapUserToData = formatter.Deserialize(fileStream) as Hashtable;
             }
             catch (IOException)
             {
@@ -145,17 +145,17 @@ namespace WheelMUD.Ftp
 
         public bool Save()
         {
-            return this.Save(this.GetDefaultPath());
+            return Save(GetDefaultPath());
         }
 
         public bool Load()
         {
-            return this.Load(this.GetDefaultPath());
+            return Load(GetDefaultPath());
         }
 
         private UserDataItem GetUserItem(string user)
         {
-            return this.mapUserToData[user] as UserDataItem;
+            return mapUserToData[user] as UserDataItem;
         }
 
         private string GetDefaultPath()

--- a/src/Main/Application.cs
+++ b/src/Main/Application.cs
@@ -29,7 +29,7 @@ namespace WheelMUD.Main
         /// <summary>Prevents a default instance of the <see cref="Application"/> class from being created.</summary>
         private Application()
         {
-            UnhandledExceptionHandler.Register(this.Notify);
+            UnhandledExceptionHandler.Register(Notify);
         }
 
         /// <summary>Gets the singleton instance of this <see cref="Application"/>.</summary>
@@ -49,19 +49,19 @@ namespace WheelMUD.Main
         /// <param name="sender">The subscribing system; generally use 'this'.</param>
         public void SubscribeToSystem(ISuperSystemSubscriber sender)
         {
-            if (this.subscribers.Contains(sender))
+            if (subscribers.Contains(sender))
             {
                 throw new DuplicateNameException("The subscriber is already subscribed to Super System events.");
             }
 
-            this.subscribers.Add(sender);
+            subscribers.Add(sender);
         }
 
         /// <summary>Unsubscribe from the specified super system subscriber.</summary>
         /// <param name="sender">The unsubscribing system; generally use 'this'.</param>
         public void UnSubscribeFromSystem(ISuperSystemSubscriber sender)
         {
-            this.subscribers.Remove(sender);
+            subscribers.Remove(sender);
         }
 
         /// <summary>Start the application.</summary>
@@ -72,7 +72,7 @@ namespace WheelMUD.Main
             EnsureDataIsPresent();
 #endif
 
-            this.InitializeSystems();
+            InitializeSystems();
         }
 
         private static void EnsureFilesArePresent()
@@ -158,12 +158,12 @@ namespace WheelMUD.Main
         /// <summary>Stop the application.</summary>
         public void Stop()
         {
-            this.Notify("Shutting Down...");
-            this.Notify("Stopping Services...");
+            Notify("Shutting Down...");
+            Notify("Stopping Services...");
 
             CoreManager.Instance.Stop();
 
-            this.Notify("Server is now Stopped");
+            Notify("Server is now Stopped");
         }
 
         /// <summary>Send an update to the system host.</summary>
@@ -171,14 +171,14 @@ namespace WheelMUD.Main
         /// <param name="msg">The message to be sent.</param>
         public void UpdateSystemHost(ISystem sender, string msg)
         {
-            this.Notify(sender.GetType().Name + " - " + msg);
+            Notify(sender.GetType().Name + " - " + msg);
         }
 
         /// <summary>Notify subscribers of the specified message.</summary>
         /// <param name="message">The message to pass along.</param>
         public void Notify(string message)
         {
-            foreach (ISuperSystemSubscriber subscriber in this.subscribers)
+            foreach (ISuperSystemSubscriber subscriber in subscribers)
             {
                 subscriber.Notify(message);
             }
@@ -268,14 +268,14 @@ namespace WheelMUD.Main
         /// <summary>Initializes the systems of this application.</summary>
         private void InitializeSystems()
         {
-            this.Notify(this.DisplayStartup());
-            this.Notify("Starting Application.");
+            Notify(DisplayStartup());
+            Notify("Starting Application.");
 
             // Add environment variables needed by the program.
             VariableProcessor.Set("app.path", AppDomain.CurrentDomain.BaseDirectory);
 
             // Find and prepare all the application's most recent systems from those discovered by MEF.
-            var systemExporters = this.GetLatestSystems();
+            var systemExporters = GetLatestSystems();
             CoreManager.Instance.SubSystems = new List<ISystem>();
             foreach (var systemExporter in systemExporters)
             {
@@ -285,7 +285,7 @@ namespace WheelMUD.Main
             CoreManager.Instance.SubscribeToSystem(this);
             CoreManager.Instance.Start();
 
-            this.Notify("All services are started. Server is fully operational.");
+            Notify("All services are started. Server is fully operational.");
         }
 
         /// <summary>Gets the latest versions of each of our composed systems.</summary>
@@ -298,13 +298,13 @@ namespace WheelMUD.Main
 
             // Find the Type of each distinct available system.  ToList forces LINQ to process immediately.
             var systems = new List<SystemExporter>();
-            var systemTypes = from s in this.AvailableSystems select s.Value.SystemType;
+            var systemTypes = from s in AvailableSystems select s.Value.SystemType;
             var distinctTypeNames = (from t in systemTypes select t.Name).Distinct().ToList();
 
             foreach (string systemTypeName in distinctTypeNames)
             {
                 // Add only the single most-recent version of this type (if there were more than one found).
-                SystemExporter systemToAdd = (from s in this.AvailableSystems
+                SystemExporter systemToAdd = (from s in AvailableSystems
                                               let type = s.Value.SystemType
                                               where type.Name == systemTypeName
                                               orderby s.Metadata.Priority descending,
@@ -325,7 +325,7 @@ namespace WheelMUD.Main
         {
             var sb = new StringBuilder();
             sb.AppendLine("Starting up... " + DateTime.Now.ToString());
-            sb.AppendLine(this.BasicAdministrativeGameInfo);
+            sb.AppendLine(BasicAdministrativeGameInfo);
             return sb.ToString();
         }
     }

--- a/src/Server/Connection.cs
+++ b/src/Server/Connection.cs
@@ -44,19 +44,19 @@ namespace WheelMUD.Server
         /// <param name="connectionHost">The system hosting this connection.</param>
         public Connection(Socket socket, ISubSystem connectionHost)
         {
-            this.Buffer = new StringBuilder();
-            this.OutputBuffer = new OutputBuffer();
-            this.Data = new byte[1];
-            this.Terminal = new Terminal();
+            Buffer = new StringBuilder();
+            OutputBuffer = new OutputBuffer();
+            Data = new byte[1];
+            Terminal = new Terminal();
             this.socket = socket;
             var remoteEndPoint = (IPEndPoint)this.socket.RemoteEndPoint;
-            this.CurrentIPAddress = remoteEndPoint.Address;
-            this.ID = Guid.NewGuid().ToString();
-            this.TelnetCodeHandler = new TelnetCodeHandler(this);
+            CurrentIPAddress = remoteEndPoint.Address;
+            ID = Guid.NewGuid().ToString();
+            TelnetCodeHandler = new TelnetCodeHandler(this);
 
             // TODO: Paging row size should be dynamic from Telnet (NAWS?) or a player-chosen override.
             //       (This used to be called BufferLength in old discussions.)
-            this.PagingRowLimit = 40;
+            PagingRowLimit = 40;
             this.connectionHost = connectionHost;
         }
 
@@ -89,12 +89,12 @@ namespace WheelMUD.Server
         {
             get
             {
-                return this.pagingRowLimit;
+                return pagingRowLimit;
             }
 
             set
             {
-                this.pagingRowLimit = value == 0 ? 1000 : value;
+                pagingRowLimit = value == 0 ? 1000 : value;
             }
         }
 
@@ -113,7 +113,7 @@ namespace WheelMUD.Server
         /// <summary>Disconnects the connection.</summary>
         public void Disconnect()
         {
-            this.OnConnectionDisconnect();
+            OnConnectionDisconnect();
         }
 
         /// <summary>Sends raw bytes to the connection.</summary>
@@ -122,15 +122,15 @@ namespace WheelMUD.Server
         {
             try
             {
-                this.socket.BeginSend(data, 0, data.Length, 0, new AsyncCallback(this.OnSendComplete), null);
+                socket.BeginSend(data, 0, data.Length, 0, new AsyncCallback(OnSendComplete), null);
             }
             catch (SocketException)
             {
-                this.OnConnectionDisconnect();
+                OnConnectionDisconnect();
             }
             catch (ObjectDisposedException)
             {
-                this.OnConnectionDisconnect();
+                OnConnectionDisconnect();
             }
         }
 
@@ -139,7 +139,7 @@ namespace WheelMUD.Server
         /// <param name="data">The data to send</param>
         public void Send(string data)
         {
-            this.Send(data, false);
+            Send(data, false);
         }
 
         /// <summary>Sends string data to the connection.</summary>
@@ -147,7 +147,7 @@ namespace WheelMUD.Server
         /// <param name="bypassDataFormatter">Indicates whether the data formatter should be bypassed (for a quicker send).</param>
         public void Send(string data, bool bypassDataFormatter)
         {
-            this.Send(data, bypassDataFormatter, false);
+            Send(data, bypassDataFormatter, false);
         }
 
         /// <summary>Sends string data to the connection</summary>
@@ -164,14 +164,14 @@ namespace WheelMUD.Server
             byte[] bytes;
 
             // Check for MCCP (its not worth using for short strings as the overhead is quite high).
-            if (this.Terminal.UseMCCP && data.Length > MCCPThreshold)
+            if (Terminal.UseMCCP && data.Length > MCCPThreshold)
             {
                 // Compress the data
                 bytes = MCCPHandler.Compress(data);
 
                 // Send the sub request to say that the next load of data
                 // is compressed. The sub request is IAC SE COMPRESS2 IAC SB
-                this.Send(new byte[] { 255, 250, 86, 255, 240 });
+                Send(new byte[] { 255, 250, 86, 255, 240 });
             }
             else
             {
@@ -179,26 +179,26 @@ namespace WheelMUD.Server
             }
 
             // Send the data.
-            this.Send(bytes);
+            Send(bytes);
         }
 
         /// <summary>Sends data from the output buffer to the client.</summary>
         /// <param name="bufferDirection">Direction to move in the buffer.</param>
         public void ProcessBuffer(BufferDirection bufferDirection)
         {
-            if (this.OutputBuffer.HasMoreData)
+            if (OutputBuffer.HasMoreData)
             {
-                string[] output = this.OutputBuffer.GetRows(bufferDirection, this.PagingRowLimit);
+                string[] output = OutputBuffer.GetRows(bufferDirection, PagingRowLimit);
 
-                bool appendOverflow = this.OutputBuffer.HasMoreData;
+                bool appendOverflow = OutputBuffer.HasMoreData;
                 string data = BufferHandler.Format(
                     output,
                     false,
                     appendOverflow,
-                    this.OutputBuffer.CurrentLocation,
-                    this.OutputBuffer.Length);
+                    OutputBuffer.CurrentLocation,
+                    OutputBuffer.Length);
 
-                this.Send(data, false, true);
+                Send(data, false, true);
             }
         }
 
@@ -208,16 +208,16 @@ namespace WheelMUD.Server
             try
             {
                 // Start receiving any data written by the connected client asynchronously.
-                var callback = new AsyncCallback(this.OnDataReceived);
-                this.socket.BeginReceive(this.Data, 0, this.Data.Length, SocketFlags.None, callback, null);
+                var callback = new AsyncCallback(OnDataReceived);
+                socket.BeginReceive(Data, 0, Data.Length, SocketFlags.None, callback, null);
             }
             catch (ObjectDisposedException)
             {
-                this.OnConnectionDisconnect();
+                OnConnectionDisconnect();
             }
             catch (SocketException)
             {
-                this.OnConnectionDisconnect();
+                OnConnectionDisconnect();
             }
         }
 
@@ -227,14 +227,14 @@ namespace WheelMUD.Server
         {
             try
             {
-                this.socket.EndSend(asyncResult);
+                socket.EndSend(asyncResult);
 
                 // Raise our data sent event.
-                this.DataSent?.Invoke(this, new ConnectionArgs(this));
+                DataSent?.Invoke(this, new ConnectionArgs(this));
             }
             catch
             {
-                this.OnConnectionDisconnect();
+                OnConnectionDisconnect();
             }
         }
 
@@ -246,47 +246,47 @@ namespace WheelMUD.Server
             {
                 int iRx;
 
-                if (this.socket.Connected)
+                if (socket.Connected)
                 {
                     // Complete the BeginReceive() asynchronous call by EndReceive() method
                     // which will return the number of characters written to the stream 
                     // by the client
-                    iRx = this.socket.EndReceive(asyncResult);
+                    iRx = socket.EndReceive(asyncResult);
 
                     // If the number of bytes received is 0 then something fishy is going on, so
                     // we close the socket.
                     if (iRx == 0)
                     {
-                        this.OnConnectionDisconnect();
+                        OnConnectionDisconnect();
                     }
                     else
                     {
                         // Raise the Data Received Event. Signals that some data has arrived.
-                        this.DataReceived?.Invoke(this, new ConnectionArgs(this));
+                        DataReceived?.Invoke(this, new ConnectionArgs(this));
 
                         // Continue the waiting for data on the Socket
-                        this.ListenForData();
+                        ListenForData();
                     }
                 }
             }
             catch (ObjectDisposedException)
             {
                 // If we're shutting down, quietly ignore these exceptions and try to close the connection.
-                this.OnConnectionDisconnect();
+                OnConnectionDisconnect();
             }
             catch (ThreadAbortException)
             {
                 // If we're shutting down, quietly ignore these exceptions and try to close the connection.
-                this.OnConnectionDisconnect();
+                OnConnectionDisconnect();
             }
             catch (Exception ex)
             {
                 // In order to isolate connection-specific issues, we're going to trap the exception, log
                 // the details, and kill that connection.  (Other connections and the game itself should
                 // be able to continue through such situations.)
-                string ip = this.CurrentIPAddress == null ? "[null]" : this.CurrentIPAddress.ToString();
+                string ip = CurrentIPAddress == null ? "[null]" : CurrentIPAddress.ToString();
                 string message = $"Exception encountered for connection:{Environment.NewLine}IP: {ip}, ID {ID}:{Environment.NewLine}{ex.ToDeepString()}";
-                this.connectionHost.InformSubscribedSystem(message);
+                connectionHost.InformSubscribedSystem(message);
 
                 // If the debugger is attached, we probably want to break now in order to better debug 
                 // the issue closer to where it occurred; if your debugger broke here you may want to 
@@ -296,19 +296,19 @@ namespace WheelMUD.Server
                     Debugger.Break();
                 }
 
-                this.OnConnectionDisconnect();
+                OnConnectionDisconnect();
             }
         }
 
         /// <summary>Disconnects the sockets and raises the disconnected event.</summary>
         private void OnConnectionDisconnect()
         {
-            if (this.socket.Connected)
+            if (socket.Connected)
             {
-                this.socket.Shutdown(SocketShutdown.Both);
-                this.socket.Close();
+                socket.Shutdown(SocketShutdown.Both);
+                socket.Close();
 
-                this.ClientDisconnected?.Invoke(this, new ConnectionArgs(this));
+                ClientDisconnected?.Invoke(this, new ConnectionArgs(this));
             }
         }
     }

--- a/src/Server/InputParser.cs
+++ b/src/Server/InputParser.cs
@@ -68,7 +68,7 @@ namespace WheelMUD.Server
                 // We should pass that up as a valid command.
                 if (input == newLineMarker)
                 {
-                    this.RaiseInputReceived(new ConnectionArgs(sender), string.Empty);
+                    RaiseInputReceived(new ConnectionArgs(sender), string.Empty);
                 }
 
                 // Does our input "end" with \r if so then we have a series of full commands.
@@ -90,7 +90,7 @@ namespace WheelMUD.Server
                         sender.LastRawInput = currentInput;
 
                         // Raise the input received event.
-                        this.RaiseInputReceived(new ConnectionArgs(sender), currentInput.Trim());
+                        RaiseInputReceived(new ConnectionArgs(sender), currentInput.Trim());
                     }
                 }
 
@@ -154,7 +154,7 @@ namespace WheelMUD.Server
         /// <param name="action">The text that was received</param>
         private void RaiseInputReceived(ConnectionArgs connectionArgs, string action)
         {
-            this.InputReceived?.Invoke(this, connectionArgs, action);
+            InputReceived?.Invoke(this, connectionArgs, action);
         }
     }
 }

--- a/src/Server/ServerManager.cs
+++ b/src/Server/ServerManager.cs
@@ -28,16 +28,16 @@ namespace WheelMUD.Server
         private ServerManager()
         {
             // Set up our event handlers for the base server.
-            this.baseServer.ClientConnect += this.BaseServer_OnClientConnect;
-            this.baseServer.DataReceived += this.BaseServer_OnDataReceived;
-            this.baseServer.DataSent += BaseServer_OnDataSent;
-            this.baseServer.ClientDisconnected += this.BaseServer_OnClientDisconnected;
+            baseServer.ClientConnect += BaseServer_OnClientConnect;
+            baseServer.DataReceived += BaseServer_OnDataReceived;
+            baseServer.DataSent += BaseServer_OnDataSent;
+            baseServer.ClientDisconnected += BaseServer_OnClientDisconnected;
 
             // Set up our event handlers for the command server.
-            this.inputParser.InputReceived += this.CommandServer_OnInputReceived;
+            inputParser.InputReceived += CommandServer_OnInputReceived;
 
             // Set up to respond to player log out events by closing those connections.
-            PlayerManager.Instance.GlobalPlayerLogOutEvent += this.PlayerManager_GlobalPlayerLogOutEvent;
+            PlayerManager.Instance.GlobalPlayerLogOutEvent += PlayerManager_GlobalPlayerLogOutEvent;
         }
 
         /// <summary>Gets the singleton instance of this ServerManager.</summary>
@@ -49,37 +49,37 @@ namespace WheelMUD.Server
         /// <summary>Starts this system's individual components.</summary>
         public override void Start()
         {
-            this.SystemHost.UpdateSystemHost(this, "Starting...");
-            this.baseServer.SubscribeToSystem(this);
-            this.baseServer.Start();
-            this.telnetServer.Start();
-            this.SystemHost.UpdateSystemHost(this, "Started on port " + this.baseServer.Port);
-            this.StartTime = DateTime.Now;
+            SystemHost.UpdateSystemHost(this, "Starting...");
+            baseServer.SubscribeToSystem(this);
+            baseServer.Start();
+            telnetServer.Start();
+            SystemHost.UpdateSystemHost(this, "Started on port " + baseServer.Port);
+            StartTime = DateTime.Now;
         }
 
         /// <summary>Stops this system's individual components.</summary>
         public override void Stop()
         {
-            this.SystemHost.UpdateSystemHost(this, "Stopping...");
+            SystemHost.UpdateSystemHost(this, "Stopping...");
 
-            this.telnetServer.Stop();
-            this.baseServer.Stop();
+            telnetServer.Stop();
+            baseServer.Stop();
 
-            this.SystemHost.UpdateSystemHost(this, "Stopped");
+            SystemHost.UpdateSystemHost(this, "Stopped");
         }
 
         /// <summary>Closes the specified connection.</summary>
         /// <param name="connectionId">The connection ID to be closed.</param>
         public void CloseConnection(string connectionId)
         {
-            this.baseServer.CloseConnection(connectionId);
+            baseServer.CloseConnection(connectionId);
         }
 
         /// <summary>Closes the specified connection.</summary>
         /// <param name="connection">The connection to be closed.</param>
         public void CloseConnection(IConnection connection)
         {
-            this.baseServer.CloseConnection(connection);
+            baseServer.CloseConnection(connection);
         }
 
         /// <summary>Gets the specified connection.</summary>
@@ -87,7 +87,7 @@ namespace WheelMUD.Server
         /// <returns> The get connection.</returns>
         public IConnection GetConnection(string connectionId)
         {
-            return this.baseServer.GetConnection(connectionId);
+            return baseServer.GetConnection(connectionId);
         }
 
         /// <summary>This is called when the base server sent data.</summary>
@@ -102,12 +102,12 @@ namespace WheelMUD.Server
         /// <param name="data">The data being sent</param>
         private void ProcessIncomingData(IConnection sender, byte[] data)
         {
-            byte[] bytes = this.telnetServer.OnDataReceived(sender, data);
+            byte[] bytes = telnetServer.OnDataReceived(sender, data);
 
             // All bytes might have been stripped out so check for that.
             if (bytes.Length > 0)
             {
-                this.inputParser.OnDataReceived(sender, bytes);
+                inputParser.OnDataReceived(sender, bytes);
             }
         }
 
@@ -127,7 +127,7 @@ namespace WheelMUD.Server
         private void BaseServer_OnClientConnect(object sender, ConnectionArgs args)
         {
             // We send the connection to our session manager to deal with.
-            this.UpdateSubSystemHost((ISubSystem)sender, args.Connection.ID + " - Connected");
+            UpdateSubSystemHost((ISubSystem)sender, args.Connection.ID + " - Connected");
             SessionManager.Instance.OnSessionConnected(args.Connection);
         }
 
@@ -138,7 +138,7 @@ namespace WheelMUD.Server
         {
             SessionManager.Instance.OnSessionDisconnected(args.Connection);
 
-            this.UpdateSubSystemHost((ISubSystem)sender, args.Connection.ID + " - Disconnected");
+            UpdateSubSystemHost((ISubSystem)sender, args.Connection.ID + " - Disconnected");
         }
 
         /// <summary>This is called when the base server receives data.</summary>
@@ -146,7 +146,7 @@ namespace WheelMUD.Server
         /// <param name="args">The event arguments.</param>
         private void BaseServer_OnDataReceived(object sender, ConnectionArgs args)
         {
-            this.ProcessIncomingData(args.Connection, args.Connection.Data);
+            ProcessIncomingData(args.Connection, args.Connection.Data);
         }
 
         /// <summary>Processes the player log out events from the player manager; disconnects logged out characters.</summary>

--- a/src/Server/Telnet/ConnectionTelnetStateOptionCode.cs
+++ b/src/Server/Telnet/ConnectionTelnetStateOptionCode.cs
@@ -37,7 +37,7 @@ namespace WheelMUD.Server.Telnet
                 option = new TelnetOption("temp", data, false, Parent.Connection);
             }
 
-            switch (this.optionCode)
+            switch (optionCode)
             {
                 case (int)TelnetResponseCode.DO:
                     option.NegotiateDo();

--- a/src/Server/Telnet/TelnetCodeHandler.cs
+++ b/src/Server/Telnet/TelnetCodeHandler.cs
@@ -52,27 +52,27 @@ namespace WheelMUD.Server.Telnet
         /// <param name="connection">The connection upon which this telnet code handler is based.</param>
         public TelnetCodeHandler(Connection connection)
         {
-            this.connectionTelnetState = new ConnectionTelnetStateText(this);
+            connectionTelnetState = new ConnectionTelnetStateText(this);
             this.connection = connection;
-            this.SetupRequiredOptions();
+            SetupRequiredOptions();
         }
 
         /// <summary>Gets the telnet options this handler supports.</summary>
         public List<ITelnetOption> TelnetOptions
         {
-            get { return this.telnetOptions; }
+            get { return telnetOptions; }
         }
 
         /// <summary>Gets the connection this handler relates to.</summary>
         public Connection Connection
         {
-            get { return this.connection; }
+            get { return connection; }
         }
 
         /// <summary>Gets the sub request buffer.</summary>
         public List<byte> SubRequestBuffer
         {
-            get { return this.subRequestBuffer; }
+            get { return subRequestBuffer; }
         }
 
         /// <summary>We pass each byte that comes in to our state classes for processing.</summary>
@@ -82,38 +82,38 @@ namespace WheelMUD.Server.Telnet
         {
             foreach (byte bit in data)
             {
-                this.connectionTelnetState.ProcessInput(bit);
+                connectionTelnetState.ProcessInput(bit);
             }
 
-            byte[] rtnData = this.buffer.ToArray();
-            this.buffer.Clear();
+            byte[] rtnData = buffer.ToArray();
+            buffer.Clear();
             return rtnData;
         }
 
         /// <summary>Begin the negotiation of telnet options.</summary>
         public void BeginNegotiation()
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                ITelnetOption naws = this.telnetOptions.Find(delegate (ITelnetOption o) { return o.Name.Equals("naws"); });
+                ITelnetOption naws = telnetOptions.Find(delegate (ITelnetOption o) { return o.Name.Equals("naws"); });
                 if (naws != null)
                 {
                     naws.Enable();
                 }
 
-                ITelnetOption termType = this.telnetOptions.Find(delegate (ITelnetOption o) { return o.Name.Equals("termtype"); });
+                ITelnetOption termType = telnetOptions.Find(delegate (ITelnetOption o) { return o.Name.Equals("termtype"); });
                 if (termType != null)
                 {
                     termType.Enable();
                 }
 
-                ITelnetOption mxp = this.telnetOptions.Find(delegate (ITelnetOption o) { return o.Name.Equals("mxp"); });
+                ITelnetOption mxp = telnetOptions.Find(delegate (ITelnetOption o) { return o.Name.Equals("mxp"); });
                 if (mxp != null)
                 {
                     mxp.Enable();
                 }
 
-                ITelnetOption mccp = this.telnetOptions.Find(delegate (ITelnetOption o) { return o.Name.Equals("compress2"); });
+                ITelnetOption mccp = telnetOptions.Find(delegate (ITelnetOption o) { return o.Name.Equals("compress2"); });
                 if (mccp != null)
                 {
                     mccp.Enable();
@@ -125,29 +125,29 @@ namespace WheelMUD.Server.Telnet
         /// <param name="newState">The state to change to</param>
         internal void ChangeState(ConnectionTelnetState newState)
         {
-            this.connectionTelnetState = newState;
+            connectionTelnetState = newState;
         }
 
         /// <summary>Adds a byte to the data buffer.</summary>
         /// <param name="data">The data to be added to the buffer.</param>
         internal void AddToBuffer(byte data)
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                this.buffer.Add(data);
+                buffer.Add(data);
             }
         }
 
         /// <summary>Sets up the options we want to negotiate.</summary>
         private void SetupRequiredOptions()
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                this.telnetOptions.Add(new TelnetOptionEcho(false, Connection));
-                this.telnetOptions.Add(new TelnetOptionNaws(true, Connection));
-                this.telnetOptions.Add(new TelnetOptionTermType(true, Connection));
-                this.telnetOptions.Add(new TelnetOptionMXP(true, Connection));
-                this.telnetOptions.Add(new TelnetOptionMCCP(true, Connection));
+                telnetOptions.Add(new TelnetOptionEcho(false, Connection));
+                telnetOptions.Add(new TelnetOptionNaws(true, Connection));
+                telnetOptions.Add(new TelnetOptionTermType(true, Connection));
+                telnetOptions.Add(new TelnetOptionMXP(true, Connection));
+                telnetOptions.Add(new TelnetOptionMCCP(true, Connection));
             }
         }
     }

--- a/src/Server/Telnet/TelnetDataStates.cs
+++ b/src/Server/Telnet/TelnetDataStates.cs
@@ -27,7 +27,7 @@ namespace WheelMUD.Server.Telnet
         /// <param name="parent">The parent telnet code handler which this object is created by.</param>
         protected ConnectionTelnetState(TelnetCodeHandler parent)
         {
-            this.Parent = parent;
+            Parent = parent;
         }
 
         /// <summary>Gets or sets the parent telnet code handler.</summary>

--- a/src/Server/Telnet/TelnetOption.cs
+++ b/src/Server/Telnet/TelnetOption.cs
@@ -19,17 +19,17 @@ namespace WheelMUD.Server.Telnet
         /// <param name="connection">The connection upon which we are negotiating.</param>
         public TelnetOption(string name, int optionCode, bool wantOption, Connection connection)
         {
-            this.Name = name;
-            this.OptionCode = optionCode;
-            this.WantOption = wantOption;
-            this.Connection = connection;
+            Name = name;
+            OptionCode = optionCode;
+            WantOption = wantOption;
+            Connection = connection;
 
             // Initialize the default values for all automatic properties of this class
             // that need to be something other than zero or null.
-            this.UsState = TelnetOptionState.NO;
-            this.UsSubState = TelnetQueueState.EMPTY;
-            this.HimState = TelnetOptionState.NO;
-            this.HimSubState = TelnetQueueState.EMPTY;
+            UsState = TelnetOptionState.NO;
+            UsSubState = TelnetQueueState.EMPTY;
+            HimState = TelnetOptionState.NO;
+            HimSubState = TelnetQueueState.EMPTY;
         }
 
         /// <summary>The available telnet option states.</summary>
@@ -105,21 +105,21 @@ namespace WheelMUD.Server.Telnet
             //         OPPOSITE Error: Already queued an enable request.
             // WANTYES EMPTY Error: Already negotiating for enable.
             //         OPPOSITE himq=EMPTY.
-            this.WantOption = true;
-            this.UsState = TelnetOptionState.WANTYES;
+            WantOption = true;
+            UsState = TelnetOptionState.WANTYES;
 
-            switch (this.HimState)
+            switch (HimState)
             {
                 case TelnetOptionState.NO:
-                    this.HimState = TelnetOptionState.WANTYES;
-                    this.Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DO, (byte)this.OptionCode });
+                    HimState = TelnetOptionState.WANTYES;
+                    Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DO, (byte)OptionCode });
                     break;
                 case TelnetOptionState.YES:
                     break;
                 case TelnetOptionState.WANTNO:
-                    if (this.HimSubState == TelnetQueueState.EMPTY)
+                    if (HimSubState == TelnetQueueState.EMPTY)
                     {
-                        this.HimSubState = TelnetQueueState.OPPOSITE;
+                        HimSubState = TelnetQueueState.OPPOSITE;
                     }
                     else
                     {
@@ -127,12 +127,12 @@ namespace WheelMUD.Server.Telnet
 
                     break;
                 case TelnetOptionState.WANTYES:
-                    if (this.HimSubState == TelnetQueueState.EMPTY)
+                    if (HimSubState == TelnetQueueState.EMPTY)
                     {
                     }
                     else
                     {
-                        this.HimSubState = TelnetQueueState.EMPTY;
+                        HimSubState = TelnetQueueState.EMPTY;
                     }
 
                     break;
@@ -151,30 +151,30 @@ namespace WheelMUD.Server.Telnet
             // WANTYES EMPTY If we are queueing requests, himq=OPPOSITE;
             //               otherwise, Error: Cannot initiate new request in the middle of negotiation.
             //         OPPOSITE Error: Already queued a disable request.
-            this.WantOption = false;
-            this.UsState = TelnetOptionState.WANTNO;
+            WantOption = false;
+            UsState = TelnetOptionState.WANTNO;
 
-            switch (this.HimState)
+            switch (HimState)
             {
                 case TelnetOptionState.NO:
                 case TelnetOptionState.YES:
-                    this.HimState = TelnetOptionState.WANTNO;
-                    this.Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DONT, (byte)this.OptionCode });
+                    HimState = TelnetOptionState.WANTNO;
+                    Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DONT, (byte)OptionCode });
                     break;
                 case TelnetOptionState.WANTNO:
-                    if (this.HimSubState == TelnetQueueState.EMPTY)
+                    if (HimSubState == TelnetQueueState.EMPTY)
                     {
                     }
                     else
                     {
-                        this.HimSubState = TelnetQueueState.EMPTY;
+                        HimSubState = TelnetQueueState.EMPTY;
                     }
 
                     break;
                 case TelnetOptionState.WANTYES:
-                    if (this.HimSubState == TelnetQueueState.EMPTY)
+                    if (HimSubState == TelnetQueueState.EMPTY)
                     {
-                        this.HimSubState = TelnetQueueState.OPPOSITE;
+                        HimSubState = TelnetQueueState.OPPOSITE;
                     }
                     else
                     {
@@ -196,58 +196,58 @@ namespace WheelMUD.Server.Telnet
             //         OPPOSITE Error: DONT answered by WILL. him=YES, himq=EMPTY.
             // WANTYES EMPTY him=YES.
             //         OPPOSITE him=WANTNO, himq=EMPTY, send DONT.
-            switch (this.HimState)
+            switch (HimState)
             {
                 case TelnetOptionState.NO:
                     // If we want to enable it him = yes, send DO; else send DONT.
-                    if (this.WantOption)
+                    if (WantOption)
                     {
                         // Send DO.
-                        this.HimState = TelnetOptionState.YES;
-                        this.Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DO, (byte)this.OptionCode });
+                        HimState = TelnetOptionState.YES;
+                        Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DO, (byte)OptionCode });
                     }
                     else
                     {
                         // Send DONT.
-                        this.Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DONT, (byte)this.OptionCode });
+                        Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DONT, (byte)OptionCode });
                     }
 
                     break;
                 case TelnetOptionState.YES:
                     break;
                 case TelnetOptionState.WANTNO:
-                    if (this.HimSubState == TelnetQueueState.EMPTY)
+                    if (HimSubState == TelnetQueueState.EMPTY)
                     {
-                        this.HimState = TelnetOptionState.NO;
+                        HimState = TelnetOptionState.NO;
                     }
                     else
                     {
-                        this.HimState = TelnetOptionState.YES;
-                        this.HimSubState = TelnetQueueState.EMPTY;
+                        HimState = TelnetOptionState.YES;
+                        HimSubState = TelnetQueueState.EMPTY;
                     }
 
                     break;
                 case TelnetOptionState.WANTYES:
-                    if (this.HimSubState == TelnetQueueState.EMPTY)
+                    if (HimSubState == TelnetQueueState.EMPTY)
                     {
-                        this.HimState = TelnetOptionState.YES;
+                        HimState = TelnetOptionState.YES;
                     }
                     else
                     {
                         // Send DONT
-                        this.HimState = TelnetOptionState.NO;
-                        this.HimSubState = TelnetQueueState.EMPTY;
-                        this.Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DONT, (byte)this.OptionCode });
+                        HimState = TelnetOptionState.NO;
+                        HimSubState = TelnetQueueState.EMPTY;
+                        Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DONT, (byte)OptionCode });
                     }
 
                     break;
             }
 
-            if (this.HimState == TelnetOptionState.YES)
+            if (HimState == TelnetOptionState.YES)
             {
                 // Successful negotiation.
-                this.UsState = TelnetOptionState.YES;
-                this.AfterNegotiation();
+                UsState = TelnetOptionState.YES;
+                AfterNegotiation();
             }
         }
 
@@ -263,46 +263,46 @@ namespace WheelMUD.Server.Telnet
             //         OPPOSITE him=WANTYES, himq=NONE, send DO.
             // WANTYES EMPTY him=NO.*
             //         OPPOSITE him=NO, himq=NONE.**
-            switch (this.HimState)
+            switch (HimState)
             {
                 case TelnetOptionState.NO:
                     break;
                 case TelnetOptionState.YES:
                     // SEND DONT
-                    this.HimState = TelnetOptionState.NO;
-                    this.Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DONT, (byte)this.OptionCode });
+                    HimState = TelnetOptionState.NO;
+                    Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DONT, (byte)OptionCode });
                     break;
                 case TelnetOptionState.WANTNO:
-                    if (this.HimSubState == TelnetQueueState.EMPTY)
+                    if (HimSubState == TelnetQueueState.EMPTY)
                     {
-                        this.HimState = TelnetOptionState.NO;
+                        HimState = TelnetOptionState.NO;
                     }
                     else
                     {
                         // SEND DO
-                        this.HimState = TelnetOptionState.WANTYES;
-                        this.Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DO, (byte)this.OptionCode });
+                        HimState = TelnetOptionState.WANTYES;
+                        Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.DO, (byte)OptionCode });
                     }
 
                     break;
                 case TelnetOptionState.WANTYES:
-                    if (this.HimSubState == TelnetQueueState.EMPTY)
+                    if (HimSubState == TelnetQueueState.EMPTY)
                     {
-                        this.HimState = TelnetOptionState.NO;
+                        HimState = TelnetOptionState.NO;
                     }
                     else
                     {
-                        this.HimState = TelnetOptionState.NO;
-                        this.HimSubState = TelnetQueueState.EMPTY;
+                        HimState = TelnetOptionState.NO;
+                        HimSubState = TelnetQueueState.EMPTY;
                     }
 
                     break;
             }
 
-            if (this.HimState == TelnetOptionState.NO)
+            if (HimState == TelnetOptionState.NO)
             {
-                this.UsState = TelnetOptionState.NO;
-                this.AfterNegotiation();
+                UsState = TelnetOptionState.NO;
+                AfterNegotiation();
             }
         }
 
@@ -318,56 +318,56 @@ namespace WheelMUD.Server.Telnet
             //         OPPOSITE Error: DONT answered by WILL. us=YES, usq=EMPTY.
             // WANTYES EMPTY us=YES.
             //         OPPOSITE us=WANTNO, usq=EMPTY, send DONT.
-            switch (this.UsState)
+            switch (UsState)
             {
                 case TelnetOptionState.NO:
-                    if (this.WantOption)
+                    if (WantOption)
                     {
                         // SEND DO
-                        this.UsState = TelnetOptionState.YES;
-                        this.Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.WILL, (byte)this.OptionCode });
+                        UsState = TelnetOptionState.YES;
+                        Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.WILL, (byte)OptionCode });
                     }
                     else
                     {
                         // SEND DONT
-                        this.Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.WONT, (byte)this.OptionCode });
+                        Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.WONT, (byte)OptionCode });
                     }
 
                     break;
                 case TelnetOptionState.YES:
                     break;
                 case TelnetOptionState.WANTNO:
-                    if (this.UsSubState == TelnetQueueState.EMPTY)
+                    if (UsSubState == TelnetQueueState.EMPTY)
                     {
-                        this.UsState = TelnetOptionState.NO;
+                        UsState = TelnetOptionState.NO;
                     }
                     else
                     {
-                        this.UsState = TelnetOptionState.YES;
-                        this.UsSubState = TelnetQueueState.EMPTY;
+                        UsState = TelnetOptionState.YES;
+                        UsSubState = TelnetQueueState.EMPTY;
                     }
 
                     break;
                 case TelnetOptionState.WANTYES:
-                    if (this.UsSubState == TelnetQueueState.EMPTY)
+                    if (UsSubState == TelnetQueueState.EMPTY)
                     {
-                        this.UsState = TelnetOptionState.YES;
+                        UsState = TelnetOptionState.YES;
                     }
                     else
                     {
                         // SEND DONT
-                        this.UsState = TelnetOptionState.WANTNO;
-                        this.UsSubState = TelnetQueueState.EMPTY;
-                        Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.WONT, (byte)this.OptionCode });
+                        UsState = TelnetOptionState.WANTNO;
+                        UsSubState = TelnetQueueState.EMPTY;
+                        Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.WONT, (byte)OptionCode });
                     }
 
                     break;
             }
 
-            if (this.UsState == TelnetOptionState.YES)
+            if (UsState == TelnetOptionState.YES)
             {
-                this.HimState = TelnetOptionState.YES;
-                this.AfterNegotiation();
+                HimState = TelnetOptionState.YES;
+                AfterNegotiation();
             }
         }
 
@@ -383,47 +383,47 @@ namespace WheelMUD.Server.Telnet
             //         OPPOSITE us=WANTYES, usq=NONE, send DO.
             // WANTYES EMPTY us=NO.*
             //         OPPOSITE us=NO, usq=NONE.**
-            switch (this.UsState)
+            switch (UsState)
             {
                 case TelnetOptionState.NO:
                     break;
                 case TelnetOptionState.YES:
                     // SEND WONT
-                    this.UsState = TelnetOptionState.NO;
-                    this.Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.WONT, (byte)this.OptionCode });
+                    UsState = TelnetOptionState.NO;
+                    Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.WONT, (byte)OptionCode });
                     break;
                 case TelnetOptionState.WANTNO:
-                    if (this.UsSubState == TelnetQueueState.EMPTY)
+                    if (UsSubState == TelnetQueueState.EMPTY)
                     {
-                        this.UsState = TelnetOptionState.NO;
+                        UsState = TelnetOptionState.NO;
                     }
                     else
                     {
                         // SEND DO
-                        this.UsState = TelnetOptionState.WANTYES;
-                        this.UsSubState = TelnetQueueState.EMPTY;
-                        this.Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.WILL, (byte)this.OptionCode });
+                        UsState = TelnetOptionState.WANTYES;
+                        UsSubState = TelnetQueueState.EMPTY;
+                        Connection.Send(new byte[] { 255, (byte)TelnetResponseCode.WILL, (byte)OptionCode });
                     }
 
                     break;
                 case TelnetOptionState.WANTYES:
-                    if (this.UsSubState == TelnetQueueState.EMPTY)
+                    if (UsSubState == TelnetQueueState.EMPTY)
                     {
-                        this.UsState = TelnetOptionState.NO;
+                        UsState = TelnetOptionState.NO;
                     }
                     else
                     {
-                        this.UsState = TelnetOptionState.NO;
-                        this.UsSubState = TelnetQueueState.EMPTY;
+                        UsState = TelnetOptionState.NO;
+                        UsSubState = TelnetQueueState.EMPTY;
                     }
 
                     break;
             }
 
-            if (this.UsState == TelnetOptionState.NO)
+            if (UsState == TelnetOptionState.NO)
             {
-                this.HimState = TelnetOptionState.NO;
-                this.AfterNegotiation();
+                HimState = TelnetOptionState.NO;
+                AfterNegotiation();
             }
         }
     }

--- a/src/Server/Telnet/TelnetOptionEcho.cs
+++ b/src/Server/Telnet/TelnetOptionEcho.cs
@@ -28,13 +28,13 @@ namespace WheelMUD.Server.Telnet
         /// <summary>Post-processing as called after negotiation.</summary>
         public override void AfterNegotiation()
         {
-            switch (this.UsState)
+            switch (UsState)
             {
                 case TelnetOptionState.YES:
-                    this.Connection.Terminal.UseEcho = true;
+                    Connection.Terminal.UseEcho = true;
                     break;
                 case TelnetOptionState.NO:
-                    this.Connection.Terminal.UseEcho = false;
+                    Connection.Terminal.UseEcho = false;
                     break;
             }
         }

--- a/src/Server/Telnet/TelnetOptionMCCP.cs
+++ b/src/Server/Telnet/TelnetOptionMCCP.cs
@@ -27,13 +27,13 @@ namespace WheelMUD.Server.Telnet
         /// <summary>Post-processing as called after negotiation.</summary>
         public override void AfterNegotiation()
         {
-            if (this.UsState == TelnetOptionState.YES)
+            if (UsState == TelnetOptionState.YES)
             {
-                this.Connection.Terminal.UseMCCP = true;
+                Connection.Terminal.UseMCCP = true;
             }
             else
             {
-                this.Connection.Terminal.UseMCCP = false;
+                Connection.Terminal.UseMCCP = false;
             }
         }
     }

--- a/src/Server/Telnet/TelnetOptionMXP.cs
+++ b/src/Server/Telnet/TelnetOptionMXP.cs
@@ -20,8 +20,8 @@ namespace WheelMUD.Server.Telnet
         {
             // Initialize the values of all automatic properties that need values 
             // to be assumed non-zero or null.
-            this.AwaitingVersionResponse = false;
-            this.VersionResponseBuffer = string.Empty;
+            AwaitingVersionResponse = false;
+            VersionResponseBuffer = string.Empty;
         }
 
         /// <summary>Represents version response state in the MXP telnet option.</summary>
@@ -65,13 +65,13 @@ namespace WheelMUD.Server.Telnet
         public override void AfterNegotiation()
         {
             // If we got a successful turn on.
-            if (this.UsState == TelnetOptionState.YES)
+            if (UsState == TelnetOptionState.YES)
             {
-                this.Connection.Terminal.UseMXP = true;
+                Connection.Terminal.UseMXP = true;
 
                 // Request a version tag from the client.
-                this.Connection.Send(AnsiHandler.Parse("<%mxpsecureline%><VERSION>"), true);
-                this.AwaitingVersionResponse = true;
+                Connection.Send(AnsiHandler.Parse("<%mxpsecureline%><VERSION>"), true);
+                AwaitingVersionResponse = true;
 
                 // TODO: Send our mxp headers.
             }

--- a/src/Server/Telnet/TelnetOptionNaws.cs
+++ b/src/Server/Telnet/TelnetOptionNaws.cs
@@ -24,8 +24,8 @@ namespace WheelMUD.Server.Telnet
         {
             if (data.Length > 3)
             {
-                this.Connection.Terminal.Width = data[1];
-                this.Connection.Terminal.Height = data[3];
+                Connection.Terminal.Width = data[1];
+                Connection.Terminal.Height = data[3];
             }
         }
     }

--- a/src/Server/Telnet/TelnetOptionTermType.cs
+++ b/src/Server/Telnet/TelnetOptionTermType.cs
@@ -28,18 +28,18 @@ namespace WheelMUD.Server.Telnet
             // The RFC (1091) says that we can loop through the different terminal types
             // that the terminal supports and the last one we receive is the one the terminal
             // sets itself to. We only get the first one which is normally the primary terminal emulation.
-            this.Connection.Terminal.TerminalType = Encoding.ASCII.GetString(data).TrimStart(new char[] { '\0' }).ToLower();
+            Connection.Terminal.TerminalType = Encoding.ASCII.GetString(data).TrimStart(new char[] { '\0' }).ToLower();
         }
 
         /// <summary>Post-processing as called after negotiation.</summary>
         public override void AfterNegotiation()
         {
             // If we got a successful turn on.
-            if (this.UsState == TelnetOptionState.YES)
+            if (UsState == TelnetOptionState.YES)
             {
                 // Send the request for terminal information. For example:
                 // IAC SB TERM SEND IAC SE
-                this.Connection.Send(new byte[] { 255, 250, 24, 1, 255, 240 });
+                Connection.Send(new byte[] { 255, 250, 24, 1, 255, 240 });
             }
         }
     }

--- a/src/Server/TelnetServer.cs
+++ b/src/Server/TelnetServer.cs
@@ -31,14 +31,14 @@ namespace WheelMUD.Server
         /// <param name="sender">The subscribing system; generally use 'this'.</param>
         public void SubscribeToSystem(ISubSystemHost sender)
         {
-            this.subSystemHost = sender;
+            subSystemHost = sender;
         }
 
         /// <summary>Inform subscribed system(s) of the specified update.</summary>
         /// <param name="msg">The message to be sent to subscribed system(s).</param>
         public void InformSubscribedSystem(string msg)
         {
-            this.subSystemHost.UpdateSubSystemHost(this, msg);
+            subSystemHost.UpdateSubSystemHost(this, msg);
         }
 
         /// <summary>Handles received data: Processes telnet escape codes and non-alpha characters.</summary>

--- a/src/ServerHarness/Commands/DynamicServerHarnessCommand.cs
+++ b/src/ServerHarness/Commands/DynamicServerHarnessCommand.cs
@@ -17,8 +17,8 @@ namespace ServerHarness
 
         public DynamicServerHarnessCommand(Action command, string[] names, string description)
         {
-            this.Names = names;
-            this.Description = description;
+            Names = names;
+            Description = description;
             this.command = command;
         }
 
@@ -28,7 +28,7 @@ namespace ServerHarness
 
         public void Execute(Application app, MultiUpdater display, string[] words)
         {
-            this.command();
+            command();
         }
     }
 }

--- a/src/ServerHarness/Commands/ExportServerHarnessCommand.cs
+++ b/src/ServerHarness/Commands/ExportServerHarnessCommand.cs
@@ -22,7 +22,7 @@ namespace ServerHarness
         public ExportServerHarnessCommandAttribute(int priority)
             : base(typeof(IServerHarnessCommand))
         {
-            this.Priority = priority;
+            Priority = priority;
         }
 
         /// <summary>Gets or sets the priority of the exported command; the command with the highest priority will be the one loaded.</summary>

--- a/src/ServerHarness/Commands/HelpCommand.cs
+++ b/src/ServerHarness/Commands/HelpCommand.cs
@@ -27,7 +27,7 @@ namespace ServerHarness
         /// <param name="words">TODO: Establish what this should be or remove; perhaps meant to be all supplied words beyond "help"?</param>
         public void Execute(Application app, MultiUpdater display, string[] words)
         {
-            display.Notify(this.DisplayHelp());
+            display.Notify(DisplayHelp());
         }
 
         /// <summary>Present the console command-line "HELP" response to the administrator.</summary>

--- a/src/ServerHarness/Commands/ServerHarnessCommands.cs
+++ b/src/ServerHarness/Commands/ServerHarnessCommands.cs
@@ -21,7 +21,7 @@ namespace ServerHarness
         /// <summary>Prevents a default instance of the ServerHarnessCommands class from being created.</summary>
         private ServerHarnessCommands()
         {
-            this.Recompose();
+            Recompose();
         }
 
         /// <summary>Gets, via MEF composition, a list of available server harness commands.</summary>
@@ -38,7 +38,7 @@ namespace ServerHarness
             {
                 lock (this)
                 {
-                    return (from command in this.ComposedCommands.Union(this.DynamicCommands)
+                    return (from command in ComposedCommands.Union(DynamicCommands)
                             orderby command.Names.First()
                             select command).ToArray();
                 }

--- a/src/ServerHarness/MultiUpdater.cs
+++ b/src/ServerHarness/MultiUpdater.cs
@@ -26,35 +26,35 @@ namespace ServerHarness
         /// <summary>Finalizes an instance of the MultiUpdater class.</summary>
         ~MultiUpdater()
         {
-            this.Dispose();
+            Dispose();
         }
 
         /// <summary>Dispose of all resources utilized by this MultiUpdater.</summary>
         public void Dispose()
         {
-            if (this.notifiers == null)
+            if (notifiers == null)
             {
                 return;
             }
 
-            foreach (var notifier in this.notifiers)
+            foreach (var notifier in notifiers)
             {
                 notifier.Dispose();
             }
 
-            this.notifiers = null;
+            notifiers = null;
         }
 
         /// <summary>Notify user of the specified message via logging to a text file.</summary>
         /// <param name="message">The message to pass along.</param>
         public void Notify(string message)
         {
-            if (this.notifiers == null)
+            if (notifiers == null)
             {
                 return;
             }
 
-            foreach (var notifier in this.notifiers)
+            foreach (var notifier in notifiers)
             {
                 notifier.Notify(message);
             }

--- a/src/ServerHarness/TextLogUpdater.cs
+++ b/src/ServerHarness/TextLogUpdater.cs
@@ -22,24 +22,24 @@ namespace ServerHarness
         /// <param name="textLogFilePath">The log file path to append text messages to.</param>
         public TextLogUpdater(string textLogFilePath)
         {
-            this.writer = new StreamWriter(textLogFilePath, true, Encoding.ASCII);
+            writer = new StreamWriter(textLogFilePath, true, Encoding.ASCII);
         }
 
         /// <summary>Finalizes an instance of the TextLogUpdater class.</summary>
         ~TextLogUpdater()
         {
-            this.Dispose();
+            Dispose();
         }
 
         /// <summary>Dispose of any resources used by this TextLogUpdater.</summary>
         public void Dispose()
         {
-            if (this.writer != null)
+            if (writer != null)
             {
                 try
                 {
-                    this.writer.Dispose();
-                    this.writer = null;
+                    writer.Dispose();
+                    writer = null;
                 }
                 catch (Exception ex)
                 {
@@ -53,8 +53,8 @@ namespace ServerHarness
         /// <param name="message">The message to pass along.</param>
         public void Notify(string message)
         {
-            this.writer.WriteLine(message);
-            this.writer.Flush();
+            writer.WriteLine(message);
+            writer.Flush();
         }
     }
 }

--- a/src/ServerHarness/WheelMUDService.cs
+++ b/src/ServerHarness/WheelMUDService.cs
@@ -21,18 +21,18 @@ namespace ServerHarness
         public WheelMudService()
         {
             Environment.CurrentDirectory = AppDomain.CurrentDomain.BaseDirectory;
-            this.application = Application.Instance;
+            application = Application.Instance;
         }
 
         public bool Start(HostControl hostControl)
         {
-            this.application.Start();
+            application.Start();
             return true;
         }
 
         public bool Stop(HostControl hostControl)
         {
-            this.application.Stop();
+            application.Stop();
             return true;
         }
     }

--- a/src/Tests/CoreTests/Behaviors/TestBehaviorManager.cs
+++ b/src/Tests/CoreTests/Behaviors/TestBehaviorManager.cs
@@ -25,8 +25,8 @@ namespace WheelMUD.Tests.Behaviors
         [SetUp]
         public void Init()
         {
-            this.thing = new Thing();
-            this.behaviorManager = new BehaviorManager(this.thing);
+            thing = new Thing();
+            behaviorManager = new BehaviorManager(thing);
         }
 
         /// <summary>Tests BehaviorManager support for simultaneous add/remove/iterate attempts.</summary>
@@ -36,30 +36,30 @@ namespace WheelMUD.Tests.Behaviors
             // Start with a bunch of behaviors already collected, to work with.
             for (int i = 0; i < 100; i++)
             {
-                this.behaviorManager.Add(new SimpleTestBehavior());
+                behaviorManager.Add(new SimpleTestBehavior());
             }
 
             // Prepare stress threads to determine if BehaviorManager is safe from simultaneous add/remove/iterate attempts.
             DateTime endTime = DateTime.Now.AddMilliseconds(100);
-            Action addAction = () => this.behaviorManager.Add(new SimpleTestBehavior());
+            Action addAction = () => behaviorManager.Add(new SimpleTestBehavior());
             Action removeAction = () =>
             {
-                var toRemove = this.behaviorManager.FindFirst<SimpleTestBehavior>();
+                var toRemove = behaviorManager.FindFirst<SimpleTestBehavior>();
                 if (toRemove != null)
                 {
-                    this.behaviorManager.Remove(toRemove);
+                    behaviorManager.Remove(toRemove);
                 }
             };
             Action iterateAction = () =>
             {
-                foreach (var behavior in this.behaviorManager.AllBehaviors)
+                foreach (var behavior in behaviorManager.AllBehaviors)
                 {
                     // Do nothing; just iterate.
                 }
             };
             Action typedAction = () =>
             {
-                foreach (var behavior in this.behaviorManager.OfType<SimpleTestBehavior>())
+                foreach (var behavior in behaviorManager.OfType<SimpleTestBehavior>())
                 {
                     // Do nothing; just iterate.
                 }

--- a/src/Tests/CoreTests/Behaviors/TestExitBehavior.cs
+++ b/src/Tests/CoreTests/Behaviors/TestExitBehavior.cs
@@ -25,10 +25,10 @@ namespace WheelMUD.Tests.Behaviors
         public void Init()
         {
             // Create 2 rooms and a basic ExitBehavior in prep for testing.
-            this.roomA = new Thing(new RoomBehavior()) { Name = "Room A", Id = TestThingID.Generate("testroom") };
-            this.roomB = new Thing(new RoomBehavior()) { Name = "Room B", Id = TestThingID.Generate("testroom") };
-            this.exitBehavior = new ExitBehavior();
-            this.exit = new Thing(this.exitBehavior) { Name = "Exit", Id = TestThingID.Generate("testexit") };
+            roomA = new Thing(new RoomBehavior()) { Name = "Room A", Id = TestThingID.Generate("testroom") };
+            roomB = new Thing(new RoomBehavior()) { Name = "Room B", Id = TestThingID.Generate("testroom") };
+            exitBehavior = new ExitBehavior();
+            exit = new Thing(exitBehavior) { Name = "Exit", Id = TestThingID.Generate("testexit") };
         }
 
         /// <summary>Test behaviors of a one-way exit.</summary>
@@ -36,31 +36,31 @@ namespace WheelMUD.Tests.Behaviors
         public void TestOneWayExitBehavior()
         {
             // Put the exit in room A only, and register an exit command to travel one way.
-            this.roomA.Add(this.exit);
-            this.exitBehavior.AddDestination("east", this.roomB.Id);
+            roomA.Add(exit);
+            exitBehavior.AddDestination("east", roomB.Id);
 
             // Ensure the exit is rigged up to the correct location now, but does not work the other way around.
-            Assert.AreSame(this.exitBehavior.GetDestination(this.roomA), this.roomB);
-            Assert.AreSame(this.exitBehavior.GetDestination(this.roomA), this.roomB);
-            Assert.AreNotSame(this.exitBehavior.GetDestination(this.roomB), this.roomA);
+            Assert.AreSame(exitBehavior.GetDestination(roomA), roomB);
+            Assert.AreSame(exitBehavior.GetDestination(roomA), roomB);
+            Assert.AreNotSame(exitBehavior.GetDestination(roomB), roomA);
 
             // Create an unmovable actor, and ensure that said actor cannot move through.
-            this.actor = new Thing() { Name = "Actor" };
-            this.roomA.Add(this.actor);
-            this.exitBehavior.MoveThrough(this.actor);
-            Assert.AreSame(this.actor.Parent, this.roomA);
+            actor = new Thing() { Name = "Actor" };
+            roomA.Add(actor);
+            exitBehavior.MoveThrough(actor);
+            Assert.AreSame(actor.Parent, roomA);
 
             // Make the actor movable, and try moving the actor through again.
-            this.actor.Behaviors.Add(new MovableBehavior());
-            this.exitBehavior.MoveThrough(this.actor);
-            Assert.AreSame(this.actor.Parent, this.roomB);
+            actor.Behaviors.Add(new MovableBehavior());
+            exitBehavior.MoveThrough(actor);
+            Assert.AreSame(actor.Parent, roomB);
 
             // Ensure the actor does not end up in room A if we try to shove the actor through again.
-            this.exitBehavior.MoveThrough(this.actor);
-            Assert.AreSame(this.actor.Parent, this.roomB);
+            exitBehavior.MoveThrough(actor);
+            Assert.AreSame(actor.Parent, roomB);
 
             // TODO: Place the actor back in room A, and try using the context command to move it?
-            this.roomA.Add(this.actor);
+            roomA.Add(actor);
         }
 
         /// <summary>Test behaviors of a two-way exit.</summary>
@@ -68,34 +68,34 @@ namespace WheelMUD.Tests.Behaviors
         public void TestTwoWayExitBehavior()
         {
             // Allow the exit to reside in two places, and place it in both room A and room B.
-            this.exit.Behaviors.Add(new MultipleParentsBehavior());
-            this.roomA.Add(this.exit);
-            this.roomB.Add(this.exit);
+            exit.Behaviors.Add(new MultipleParentsBehavior());
+            roomA.Add(exit);
+            roomB.Add(exit);
 
             // Ensure there are no destinations before rigging them up.
-            Assert.AreSame(this.exitBehavior.GetDestination(this.roomA), null);
-            Assert.AreSame(this.exitBehavior.GetDestination(this.roomB), null);
+            Assert.AreSame(exitBehavior.GetDestination(roomA), null);
+            Assert.AreSame(exitBehavior.GetDestination(roomB), null);
 
             // Rig the exits and ensure both got rigged up to the correct destinations.
-            this.exitBehavior.AddDestination("north", this.roomB.Id);
-            this.exitBehavior.AddDestination("south", this.roomA.Id);
-            Assert.AreSame(this.exitBehavior.GetDestination(this.roomA), this.roomB);
-            Assert.AreSame(this.exitBehavior.GetDestination(this.roomB), this.roomA);
+            exitBehavior.AddDestination("north", roomB.Id);
+            exitBehavior.AddDestination("south", roomA.Id);
+            Assert.AreSame(exitBehavior.GetDestination(roomA), roomB);
+            Assert.AreSame(exitBehavior.GetDestination(roomB), roomA);
 
             // Create an unmovable actor, and ensure that said actor cannot move through.
-            this.actor = new Thing() { Name = "Actor", Id = TestThingID.Generate("testactor") };
-            this.roomA.Add(this.actor);
-            this.exitBehavior.MoveThrough(this.actor);
-            Assert.AreSame(this.actor.Parent, this.roomA);
+            actor = new Thing() { Name = "Actor", Id = TestThingID.Generate("testactor") };
+            roomA.Add(actor);
+            exitBehavior.MoveThrough(actor);
+            Assert.AreSame(actor.Parent, roomA);
 
             // Make the actoc movable, and ensure they end up in the next room when moving through.
-            this.actor.Behaviors.Add(new MovableBehavior());
-            this.exitBehavior.MoveThrough(this.actor);
-            Assert.AreSame(this.actor.Parent, this.roomB);
+            actor.Behaviors.Add(new MovableBehavior());
+            exitBehavior.MoveThrough(actor);
+            Assert.AreSame(actor.Parent, roomB);
 
             // Move the actor back through the exit again, and ensure they end up in the starting room.
-            this.exitBehavior.MoveThrough(this.actor);
-            Assert.AreSame(this.actor.Parent, this.roomA);
+            exitBehavior.MoveThrough(actor);
+            Assert.AreSame(actor.Parent, roomA);
 
             // TODO: Ensure the actor does not move through when using the wrong context command?
             // TODO: Ensure the actor moves through both ways when using correct context commands?

--- a/src/Tests/CoreTests/Behaviors/TestFollowingBehavior.cs
+++ b/src/Tests/CoreTests/Behaviors/TestFollowingBehavior.cs
@@ -30,44 +30,44 @@ namespace WheelMUD.Tests.Behaviors
         public void Init()
         {
             // Create the basic actor instances and behavior for test.
-            this.witness = new Thing() { Name = "Witness", Id = TestThingID.Generate("testthing") };
-            this.stalker1 = new Thing() { Name = "Stalker1", Id = TestThingID.Generate("testthing") };
-            this.stalker2 = new Thing() { Name = "Stalker2", Id = TestThingID.Generate("testthing") };
-            this.victim1 = new Thing() { Name = "Victim1", Id = TestThingID.Generate("testthing") };
-            this.victim2 = new Thing() { Name = "Victim2", Id = TestThingID.Generate("testthing") };
+            witness = new Thing() { Name = "Witness", Id = TestThingID.Generate("testthing") };
+            stalker1 = new Thing() { Name = "Stalker1", Id = TestThingID.Generate("testthing") };
+            stalker2 = new Thing() { Name = "Stalker2", Id = TestThingID.Generate("testthing") };
+            victim1 = new Thing() { Name = "Victim1", Id = TestThingID.Generate("testthing") };
+            victim2 = new Thing() { Name = "Victim2", Id = TestThingID.Generate("testthing") };
 
             // Set up the rooms.
-            this.room1 = new Thing() { Name = "Room", Id = TestThingID.Generate("room") };
-            this.room2 = new Thing() { Name = "Room 2", Id = TestThingID.Generate("room") };
+            room1 = new Thing() { Name = "Room", Id = TestThingID.Generate("room") };
+            room2 = new Thing() { Name = "Room 2", Id = TestThingID.Generate("room") };
 
             // Set up an exit connecting the two rooms.
-            this.exit = new Thing() { Name = "East Exit", Id = TestThingID.Generate("exit") };
+            exit = new Thing() { Name = "East Exit", Id = TestThingID.Generate("exit") };
             var exitBehavior = new ExitBehavior();
             ////exitBehavior.AddDestination("west", room1.ID);
             ////exitBehavior.AddDestination("east", room1.ID);
-            ////this.exit.BehaviorManager.Add(exitBehavior);
+            ////exit.BehaviorManager.Add(exitBehavior);
 
-            this.room1.Add(this.exit);
-            this.room2.Add(this.exit);
+            room1.Add(exit);
+            room2.Add(exit);
 
             // Populate the first room.
-            this.room1.Add(this.witness);
-            this.room1.Add(this.stalker1);
-            this.room1.Add(this.stalker2);
-            this.room1.Add(this.victim1);
-            this.room1.Add(this.victim2);
+            room1.Add(witness);
+            room1.Add(stalker1);
+            room1.Add(stalker2);
+            room1.Add(victim1);
+            room1.Add(victim2);
 
             // Prepare to verify correct eventing occurs.
-            this.witness.Eventing.MovementRequest += (root, e) => { this.lastWitnessRequest = e; };
-            this.witness.Eventing.MovementEvent += (root, e) => { this.lastWitnessEvent = e; };
-            this.stalker1.Eventing.MovementRequest += (root, e) => { this.lastStalkerRequest = e; };
-            this.stalker1.Eventing.MovementEvent += (root, e) => { this.lastStalkerEvent = e; };
-            this.stalker2.Eventing.MovementRequest += (root, e) => { this.lastStalkerRequest = e; };
-            this.stalker2.Eventing.MovementEvent += (root, e) => { this.lastStalkerEvent = e; };
-            this.victim1.Eventing.MovementRequest += (root, e) => { this.lastVictimRequest = e; };
-            this.victim1.Eventing.MovementEvent += (root, e) => { this.lastVictimEvent = e; };
-            this.victim2.Eventing.MovementRequest += (root, e) => { this.lastVictimRequest = e; };
-            this.victim2.Eventing.MovementEvent += (root, e) => { this.lastVictimEvent = e; };
+            witness.Eventing.MovementRequest += (root, e) => { lastWitnessRequest = e; };
+            witness.Eventing.MovementEvent += (root, e) => { lastWitnessEvent = e; };
+            stalker1.Eventing.MovementRequest += (root, e) => { lastStalkerRequest = e; };
+            stalker1.Eventing.MovementEvent += (root, e) => { lastStalkerEvent = e; };
+            stalker2.Eventing.MovementRequest += (root, e) => { lastStalkerRequest = e; };
+            stalker2.Eventing.MovementEvent += (root, e) => { lastStalkerEvent = e; };
+            victim1.Eventing.MovementRequest += (root, e) => { lastVictimRequest = e; };
+            victim1.Eventing.MovementEvent += (root, e) => { lastVictimEvent = e; };
+            victim2.Eventing.MovementRequest += (root, e) => { lastVictimRequest = e; };
+            victim2.Eventing.MovementEvent += (root, e) => { lastVictimEvent = e; };
         }
 
         /// <summary>Test FollowingBehavior without an attached parent.</summary>
@@ -75,7 +75,7 @@ namespace WheelMUD.Tests.Behaviors
         public void TestUnattachedFollowingBehaviorCanNotTrackTargets()
         {
             var followingBehavior = new FollowingBehavior();
-            followingBehavior.Target = this.victim1;
+            followingBehavior.Target = victim1;
             Assert.AreEqual(null, followingBehavior.Target);
         }
 
@@ -83,9 +83,9 @@ namespace WheelMUD.Tests.Behaviors
         [Test]
         public void TestFollowingBehaviorStartsOutNull()
         {
-            this.ClearTrackedEvents();
+            ClearTrackedEvents();
             var followingBehavior = new FollowingBehavior();
-            this.stalker1.Behaviors.Add(followingBehavior);
+            stalker1.Behaviors.Add(followingBehavior);
             Assert.IsNull(followingBehavior.Target);
         }
 
@@ -93,12 +93,12 @@ namespace WheelMUD.Tests.Behaviors
         [Test]
         public void TestSettingTarget()
         {
-            this.ClearTrackedEvents();
+            ClearTrackedEvents();
             var followingBehavior = new FollowingBehavior();
-            this.stalker1.Behaviors.Add(followingBehavior);
-            followingBehavior.Target = this.victim1;
+            stalker1.Behaviors.Add(followingBehavior);
+            followingBehavior.Target = victim1;
             Assert.IsNotNull(followingBehavior.Target);
-            Assert.AreEqual(followingBehavior.Target, this.victim1);
+            Assert.AreEqual(followingBehavior.Target, victim1);
         }
 
         /// <summary>
@@ -108,51 +108,51 @@ namespace WheelMUD.Tests.Behaviors
         [Test]
         public void TestRemovingTarget()
         {
-            this.ClearTrackedEvents();
+            ClearTrackedEvents();
 
-            Assert.IsNull(this.lastStalkerRequest);
-            Assert.IsNull(this.lastStalkerEvent);
+            Assert.IsNull(lastStalkerRequest);
+            Assert.IsNull(lastStalkerEvent);
 
-            Assert.IsNull(this.lastVictimRequest);
-            Assert.IsNull(this.lastVictimEvent);
+            Assert.IsNull(lastVictimRequest);
+            Assert.IsNull(lastVictimEvent);
 
             var followingBehavior = new FollowingBehavior();
-            this.stalker1.Behaviors.Add(followingBehavior);
-            followingBehavior.Target = this.victim1;
+            stalker1.Behaviors.Add(followingBehavior);
+            followingBehavior.Target = victim1;
             followingBehavior.Target = null;
 
             Assert.IsNull(followingBehavior.Target);
 
-            Assert.IsNotNull(this.lastStalkerRequest);
-            Assert.IsNotNull(this.lastStalkerEvent);
+            Assert.IsNotNull(lastStalkerRequest);
+            Assert.IsNotNull(lastStalkerEvent);
 
-            Assert.IsNotNull(this.lastVictimRequest);
-            Assert.IsNotNull(this.lastVictimEvent);
+            Assert.IsNotNull(lastVictimRequest);
+            Assert.IsNotNull(lastVictimEvent);
         }
 
         /// <summary>Verify sensory messages seen by stalker/victim and unseen by witness.</summary>
         [Test]
         public void TestFollowingMessages()
         {
-            this.ClearTrackedEvents();
+            ClearTrackedEvents();
             var followingBehavior = new FollowingBehavior();
-            this.stalker1.Behaviors.Add(followingBehavior);
-            Assert.AreEqual(this.lastWitnessEvent, null);
-            Assert.AreEqual(this.lastStalkerEvent, null);
-            Assert.AreEqual(this.lastVictimEvent, null);
+            stalker1.Behaviors.Add(followingBehavior);
+            Assert.AreEqual(lastWitnessEvent, null);
+            Assert.AreEqual(lastStalkerEvent, null);
+            Assert.AreEqual(lastVictimEvent, null);
 
-            followingBehavior.Target = this.victim1;
-            var witnessMessage = this.lastWitnessEvent.SensoryMessage.Message.Parse(this.witness);
-            var stalkerMessage = this.lastStalkerEvent.SensoryMessage.Message.Parse(this.stalker1);
-            var victimMessage = this.lastVictimEvent.SensoryMessage.Message.Parse(this.victim1);
+            followingBehavior.Target = victim1;
+            var witnessMessage = lastWitnessEvent.SensoryMessage.Message.Parse(witness);
+            var stalkerMessage = lastStalkerEvent.SensoryMessage.Message.Parse(stalker1);
+            var victimMessage = lastVictimEvent.SensoryMessage.Message.Parse(victim1);
             Assert.AreEqual(witnessMessage, "Stalker1 starts following Victim1.");
             Assert.AreEqual(stalkerMessage, "You start following Victim1.");
             Assert.AreEqual(victimMessage, "Stalker1 starts following you.");
 
             followingBehavior.Target = null;
-            witnessMessage = this.lastWitnessEvent.SensoryMessage.Message.Parse(this.witness);
-            stalkerMessage = this.lastStalkerEvent.SensoryMessage.Message.Parse(this.stalker1);
-            victimMessage = this.lastVictimEvent.SensoryMessage.Message.Parse(this.victim1);
+            witnessMessage = lastWitnessEvent.SensoryMessage.Message.Parse(witness);
+            stalkerMessage = lastStalkerEvent.SensoryMessage.Message.Parse(stalker1);
+            victimMessage = lastVictimEvent.SensoryMessage.Message.Parse(victim1);
             Assert.IsTrue(string.IsNullOrEmpty(witnessMessage));
             Assert.AreEqual(stalkerMessage, "You stop following Victim1.");
             Assert.AreEqual(victimMessage, "Stalker1 stops following you.");
@@ -163,10 +163,10 @@ namespace WheelMUD.Tests.Behaviors
         [Test]
         public void TestGarbageCollectedTarget()
         {
-            ////this.ClearTrackedEvents();
+            ////ClearTrackedEvents();
             ////var followingBehavior = new FollowingBehavior();
             ////stalker1.BehaviorManager.Add(followingBehavior);
-            ////followingBehavior.Target = this.victim1;
+            ////followingBehavior.Target = victim1;
 
             ////Assert.IsNotNull(followingBehavior.Target);
             ////victim1 = null;
@@ -185,12 +185,12 @@ namespace WheelMUD.Tests.Behaviors
         /// <summary>Clear all potentially tracked events so we can verify new ones.</summary>
         private void ClearTrackedEvents()
         {
-            this.lastStalkerEvent = null;
-            this.lastStalkerRequest = null;
-            this.lastVictimEvent = null;
-            this.lastVictimRequest = null;
-            this.lastWitnessEvent = null;
-            this.lastWitnessRequest = null;
+            lastStalkerEvent = null;
+            lastStalkerRequest = null;
+            lastVictimEvent = null;
+            lastVictimRequest = null;
+            lastWitnessEvent = null;
+            lastWitnessRequest = null;
         }
     }
 }

--- a/src/Tests/CoreTests/Behaviors/TestLocksUnlocksBehavior.cs
+++ b/src/Tests/CoreTests/Behaviors/TestLocksUnlocksBehavior.cs
@@ -33,22 +33,22 @@ namespace WheelMUD.Tests.Behaviors
         public void Init()
         {
             // Create the basic actor instances and behavior for test.
-            this.witnessThing = new Thing() { Name = "WitnessThing", Id = TestThingID.Generate("testthing") };
-            this.actingThing = new Thing() { Name = "ActingThing", Id = TestThingID.Generate("testthing") };
-            this.lockableThing = new Thing() { Name = "LockableThing", Id = TestThingID.Generate("testthing") };
-            this.locksUnlocksBehavior = new LocksUnlocksBehavior();
+            witnessThing = new Thing() { Name = "WitnessThing", Id = TestThingID.Generate("testthing") };
+            actingThing = new Thing() { Name = "ActingThing", Id = TestThingID.Generate("testthing") };
+            lockableThing = new Thing() { Name = "LockableThing", Id = TestThingID.Generate("testthing") };
+            locksUnlocksBehavior = new LocksUnlocksBehavior();
 
             // Set up the actors inside another (which we'll call a "room" although it needn't actually be a room).
-            this.room = new Thing() { Name = "Room", Id = TestThingID.Generate("room") };
-            this.room.Add(this.witnessThing);
-            this.room.Add(this.actingThing);
-            this.room.Add(this.lockableThing);
+            room = new Thing() { Name = "Room", Id = TestThingID.Generate("room") };
+            room.Add(witnessThing);
+            room.Add(actingThing);
+            room.Add(lockableThing);
 
             // Prepare to verify correct eventing occurs.
-            this.witnessThing.Eventing.MiscellaneousRequest += (root, e) => { this.lastWitnessRequest = e; };
-            this.witnessThing.Eventing.MiscellaneousEvent += (root, e) => { this.lastWitnessEvent = e; };
-            this.actingThing.Eventing.MiscellaneousRequest += (root, e) => { this.lastActorRequest = e; };
-            this.actingThing.Eventing.MiscellaneousEvent += (root, e) => { this.lastActorEvent = e; };
+            witnessThing.Eventing.MiscellaneousRequest += (root, e) => { lastWitnessRequest = e; };
+            witnessThing.Eventing.MiscellaneousEvent += (root, e) => { lastWitnessEvent = e; };
+            actingThing.Eventing.MiscellaneousRequest += (root, e) => { lastActorRequest = e; };
+            actingThing.Eventing.MiscellaneousEvent += (root, e) => { lastActorEvent = e; };
         }
 
         /// <summary>Test LocksUnlocksBehavior without an attached parent.</summary>
@@ -58,70 +58,70 @@ namespace WheelMUD.Tests.Behaviors
             // Verify that an unattached behavior does not change state between Lock/Unlock attempts, and
             // that such attempts do not throw. (This keeps the behavior solid in the face of the parent
             // being destroyed or whatnot as a race versus a user trying to activate it.)
-            bool initialState = this.locksUnlocksBehavior.IsLocked;
-            this.locksUnlocksBehavior.Lock(this.actingThing);
-            Assert.AreEqual(initialState, this.locksUnlocksBehavior.IsLocked);
-            this.locksUnlocksBehavior.Unlock(this.actingThing);
-            Assert.AreEqual(initialState, this.locksUnlocksBehavior.IsLocked);
+            bool initialState = locksUnlocksBehavior.IsLocked;
+            locksUnlocksBehavior.Lock(actingThing);
+            Assert.AreEqual(initialState, locksUnlocksBehavior.IsLocked);
+            locksUnlocksBehavior.Unlock(actingThing);
+            Assert.AreEqual(initialState, locksUnlocksBehavior.IsLocked);
         }
 
         /// <summary>Test normal LocksUnlocksBehavior operation.</summary>
         [Test]
         public void TestLockingAndUnlocking()
         {
-            this.lockableThing.Behaviors.Add(this.locksUnlocksBehavior);
+            lockableThing.Behaviors.Add(locksUnlocksBehavior);
 
             // Verify that the default state is locked.
-            Assert.IsTrue(this.locksUnlocksBehavior.IsLocked);
+            Assert.IsTrue(locksUnlocksBehavior.IsLocked);
 
             // Verify locking a locked thing => locked.
-            this.ClearTrackedEvents();
-            this.locksUnlocksBehavior.Lock(this.actingThing);
-            Assert.IsTrue(this.locksUnlocksBehavior.IsLocked);
+            ClearTrackedEvents();
+            locksUnlocksBehavior.Lock(actingThing);
+            Assert.IsTrue(locksUnlocksBehavior.IsLocked);
 
             // Verify that no event occurred (but any potentially-cancelled requests are irrelevant).
-            Assert.IsTrue(this.lastWitnessEvent == null);
-            Assert.IsTrue(this.lastActorEvent == null);
+            Assert.IsTrue(lastWitnessEvent == null);
+            Assert.IsTrue(lastActorEvent == null);
 
             // Verify unlocking a locked thing => unlocked.
-            this.ClearTrackedEvents();
-            this.locksUnlocksBehavior.Unlock(this.actingThing);
-            Assert.IsTrue(!this.locksUnlocksBehavior.IsLocked);
+            ClearTrackedEvents();
+            locksUnlocksBehavior.Unlock(actingThing);
+            Assert.IsTrue(!locksUnlocksBehavior.IsLocked);
 
             // Verify that an appropriate unlock request and unlock event were witnessed by both the actor and the witness.
-            Assert.IsTrue(this.lastWitnessRequest != null);
-            Assert.IsTrue(this.lastActorRequest != null);
-            Assert.IsTrue(this.lastWitnessEvent != null);
-            Assert.IsTrue(this.lastActorEvent != null);
+            Assert.IsTrue(lastWitnessRequest != null);
+            Assert.IsTrue(lastActorRequest != null);
+            Assert.IsTrue(lastWitnessEvent != null);
+            Assert.IsTrue(lastActorEvent != null);
 
-            string witnessMessage = this.lastWitnessEvent.SensoryMessage.Message.Parse(this.witnessThing);
+            string witnessMessage = lastWitnessEvent.SensoryMessage.Message.Parse(witnessThing);
             Assert.IsTrue(witnessMessage.Contains(" unlocks "));
-            string actorMessage = this.lastActorEvent.SensoryMessage.Message.Parse(this.actingThing);
+            string actorMessage = lastActorEvent.SensoryMessage.Message.Parse(actingThing);
             Assert.IsTrue(actorMessage.Contains("You unlock "));
 
             // Verify unlocking an unlocked thing => unlocked.
-            this.ClearTrackedEvents();
-            this.locksUnlocksBehavior.Unlock(this.actingThing);
-            Assert.IsTrue(!this.locksUnlocksBehavior.IsLocked);
+            ClearTrackedEvents();
+            locksUnlocksBehavior.Unlock(actingThing);
+            Assert.IsTrue(!locksUnlocksBehavior.IsLocked);
 
             // Verify that no event occurred (but any potentially-cancelled requests are irrelevant).
-            Assert.IsTrue(this.lastWitnessEvent == null);
-            Assert.IsTrue(this.lastActorEvent == null);
+            Assert.IsTrue(lastWitnessEvent == null);
+            Assert.IsTrue(lastActorEvent == null);
 
             // Verify locking an unlocked thing => locked.
-            this.ClearTrackedEvents();
-            this.locksUnlocksBehavior.Lock(this.actingThing);
-            Assert.IsTrue(this.locksUnlocksBehavior.IsLocked);
+            ClearTrackedEvents();
+            locksUnlocksBehavior.Lock(actingThing);
+            Assert.IsTrue(locksUnlocksBehavior.IsLocked);
 
             // Verify that an appropriate lock request and lock event were witnessed by both the actor and the witness.
-            Assert.IsTrue(this.lastWitnessRequest != null);
-            Assert.IsTrue(this.lastActorRequest != null);
-            Assert.IsTrue(this.lastWitnessEvent != null);
-            Assert.IsTrue(this.lastActorEvent != null);
+            Assert.IsTrue(lastWitnessRequest != null);
+            Assert.IsTrue(lastActorRequest != null);
+            Assert.IsTrue(lastWitnessEvent != null);
+            Assert.IsTrue(lastActorEvent != null);
 
-            witnessMessage = this.lastWitnessEvent.SensoryMessage.Message.Parse(this.witnessThing);
+            witnessMessage = lastWitnessEvent.SensoryMessage.Message.Parse(witnessThing);
             Assert.IsTrue(witnessMessage.Contains(" locks "));
-            actorMessage = this.lastActorEvent.SensoryMessage.Message.Parse(this.actingThing);
+            actorMessage = lastActorEvent.SensoryMessage.Message.Parse(actingThing);
             Assert.IsTrue(actorMessage.Contains("You lock "));
         }
 
@@ -131,41 +131,41 @@ namespace WheelMUD.Tests.Behaviors
         {
             // Make our lockable thing also openable.
             var opensClosesBehavior = new OpensClosesBehavior();
-            this.lockableThing.Behaviors.Add(opensClosesBehavior);
-            this.lockableThing.Behaviors.Add(this.locksUnlocksBehavior);
+            lockableThing.Behaviors.Add(opensClosesBehavior);
+            lockableThing.Behaviors.Add(locksUnlocksBehavior);
 
             // Verify that the thing is still in the default locked state.
-            Assert.IsTrue(this.locksUnlocksBehavior.IsLocked);
+            Assert.IsTrue(locksUnlocksBehavior.IsLocked);
 
             // Verify that attempts to open the locked thing do not work.
             // (Note that adding player-convenience features like automatic unlock attempts on behalf of the 
             // player when trying to open something, depending on their settings or whatnot, may require such 
             // tests to become much more robust here.)
-            opensClosesBehavior.Open(this.actingThing);
-            Assert.IsTrue(this.locksUnlocksBehavior.IsLocked);
+            opensClosesBehavior.Open(actingThing);
+            Assert.IsTrue(locksUnlocksBehavior.IsLocked);
             Assert.IsTrue(!opensClosesBehavior.IsOpen);
 
             // Verify that attempts to open an unlocked thing do work though.
-            this.locksUnlocksBehavior.Unlock(this.actingThing);
-            opensClosesBehavior.Open(this.actingThing);
-            Assert.IsTrue(!this.locksUnlocksBehavior.IsLocked);
+            locksUnlocksBehavior.Unlock(actingThing);
+            opensClosesBehavior.Open(actingThing);
+            Assert.IsTrue(!locksUnlocksBehavior.IsLocked);
             Assert.IsTrue(opensClosesBehavior.IsOpen);
 
             // Verify that trying to lock an open thing is either cancelled (leaving it open and unlocked) 
             // or is automatically closed for the actor since the intent could be implied.
-            this.locksUnlocksBehavior.Lock(this.actingThing);
-            bool isClosedAndLocked = !opensClosesBehavior.IsOpen && this.locksUnlocksBehavior.IsLocked;
-            bool isOpenAndUnlocked = opensClosesBehavior.IsOpen && !this.locksUnlocksBehavior.IsLocked;
+            locksUnlocksBehavior.Lock(actingThing);
+            bool isClosedAndLocked = !opensClosesBehavior.IsOpen && locksUnlocksBehavior.IsLocked;
+            bool isOpenAndUnlocked = opensClosesBehavior.IsOpen && !locksUnlocksBehavior.IsLocked;
             Assert.IsTrue(isClosedAndLocked || isOpenAndUnlocked);
         }
 
         /// <summary>Clear all potentially tracked events so we can verify new ones.</summary>
         private void ClearTrackedEvents()
         {
-            this.lastActorEvent = null;
-            this.lastActorRequest = null;
-            this.lastWitnessEvent = null;
-            this.lastWitnessRequest = null;
+            lastActorEvent = null;
+            lastActorRequest = null;
+            lastWitnessEvent = null;
+            lastWitnessRequest = null;
         }
     }
 }

--- a/src/Tests/CoreTests/Behaviors/TestMultipleParentsBehavior.cs
+++ b/src/Tests/CoreTests/Behaviors/TestMultipleParentsBehavior.cs
@@ -25,10 +25,10 @@ namespace WheelMUD.Tests.Behaviors
         public void Init()
         {
             // Create 2 things and a basic MultipleParentsBehavior for testing.
-            this.parent1 = new Thing() { Name = "Thing1", Id = TestThingID.Generate("testthing") };
-            this.parent2 = new Thing() { Name = "Thing2", Id = TestThingID.Generate("testthing") };
-            this.child = new Thing() { Name = "Child1", Id = TestThingID.Generate("testthing") };
-            this.multipleParentsBehavior = new MultipleParentsBehavior();
+            parent1 = new Thing() { Name = "Thing1", Id = TestThingID.Generate("testthing") };
+            parent2 = new Thing() { Name = "Thing2", Id = TestThingID.Generate("testthing") };
+            child = new Thing() { Name = "Child1", Id = TestThingID.Generate("testthing") };
+            multipleParentsBehavior = new MultipleParentsBehavior();
         }
 
         /// <summary>Test normal parenting behaviors without a MultipleParentsBehavior being attached.</summary>
@@ -36,25 +36,25 @@ namespace WheelMUD.Tests.Behaviors
         public void TestSingleParentingBehavior()
         {
             // Verify that a thing which has not yet been added to a parent, has none.
-            Assert.IsTrue(this.child.Parent == null);
+            Assert.IsTrue(child.Parent == null);
 
             // Verify that a basic thing can be added to a parent correctly.
-            this.parent1.Add(this.child);
-            Assert.IsTrue(this.parent1.Children.Contains(this.child));
-            Assert.IsTrue(!this.parent2.Children.Contains(this.child));
-            Assert.IsTrue(this.child.Parent == this.parent1);
+            parent1.Add(child);
+            Assert.IsTrue(parent1.Children.Contains(child));
+            Assert.IsTrue(!parent2.Children.Contains(child));
+            Assert.IsTrue(child.Parent == parent1);
 
             // Verify adding it to a second parent actually reassigns the parent.
-            this.parent2.Add(this.child);
-            Assert.IsTrue(this.parent2.Children.Contains(this.child));
-            Assert.IsTrue(!this.parent1.Children.Contains(this.child));
-            Assert.IsTrue(this.child.Parent == this.parent2);
+            parent2.Add(child);
+            Assert.IsTrue(parent2.Children.Contains(child));
+            Assert.IsTrue(!parent1.Children.Contains(child));
+            Assert.IsTrue(child.Parent == parent2);
 
             // Verify removing it from the last parent, cleans up the parent/child relationships.
-            this.parent2.Remove(this.child);
-            Assert.IsTrue(!this.parent1.Children.Contains(this.child));
-            Assert.IsTrue(!this.parent2.Children.Contains(this.child));
-            Assert.IsTrue(this.child.Parent == null);
+            parent2.Remove(child);
+            Assert.IsTrue(!parent1.Children.Contains(child));
+            Assert.IsTrue(!parent2.Children.Contains(child));
+            Assert.IsTrue(child.Parent == null);
         }
 
         /// <summary>Test an unattached MultipleParentsBehavior.</summary>
@@ -63,8 +63,8 @@ namespace WheelMUD.Tests.Behaviors
         {
             // Verify that messing with a MultipleParentsBehavior while it is not attached to a host thing
             // does not throw (IE during possible deconstruction race conditions and such).
-            this.multipleParentsBehavior.AddParent(this.parent1);
-            this.multipleParentsBehavior.RemoveParent(this.parent1);
+            multipleParentsBehavior.AddParent(parent1);
+            multipleParentsBehavior.RemoveParent(parent1);
         }
 
         /// <summary>Test parenting behaviors with a MultipleParentsBehavior attached.</summary>
@@ -72,37 +72,37 @@ namespace WheelMUD.Tests.Behaviors
         public void TestMultipleParentingBehavior()
         {
             // Verify we can add and retrieve the MultipleParentsBehavior of a Thing.
-            this.child.Behaviors.Add(this.multipleParentsBehavior);
-            Assert.IsTrue(this.child.Behaviors.FindFirst<MultipleParentsBehavior>() == this.multipleParentsBehavior);
+            child.Behaviors.Add(multipleParentsBehavior);
+            Assert.IsTrue(child.Behaviors.FindFirst<MultipleParentsBehavior>() == multipleParentsBehavior);
 
             // Verify it can now be a child of multiple parents, and one of those can be found as the primary Parent.
-            this.parent1.Add(this.child);
-            this.parent2.Add(this.child);
-            Assert.IsTrue(this.parent1.Children.Contains(this.child));
-            Assert.IsTrue(this.parent2.Children.Contains(this.child));
-            Assert.IsTrue(this.child.Parent == this.parent1 || this.child.Parent == this.parent2);
+            parent1.Add(child);
+            parent2.Add(child);
+            Assert.IsTrue(parent1.Children.Contains(child));
+            Assert.IsTrue(parent2.Children.Contains(child));
+            Assert.IsTrue(child.Parent == parent1 || child.Parent == parent2);
 
             // Verify we can remove the item from a secondary parent, and still be attached well to the primary.
-            this.parent2.Remove(this.child);
-            Assert.IsTrue(this.parent1.Children.Contains(this.child));
-            Assert.IsTrue(!this.parent2.Children.Contains(this.child));
-            Assert.IsTrue(this.child.Parent == this.parent1);
-            this.parent2.Add(this.child);
+            parent2.Remove(child);
+            Assert.IsTrue(parent1.Children.Contains(child));
+            Assert.IsTrue(!parent2.Children.Contains(child));
+            Assert.IsTrue(child.Parent == parent1);
+            parent2.Add(child);
 
             // Verify we can remove the item from a primary parent, and a secondary parent becomes the primary.
-            this.parent1.Remove(this.child);
-            Assert.IsTrue(!this.parent1.Children.Contains(this.child));
-            Assert.IsTrue(this.parent2.Children.Contains(this.child));
-            Assert.IsTrue(this.child.Parent == this.parent2);
-            this.parent1.Add(this.child);
+            parent1.Remove(child);
+            Assert.IsTrue(!parent1.Children.Contains(child));
+            Assert.IsTrue(parent2.Children.Contains(child));
+            Assert.IsTrue(child.Parent == parent2);
+            parent1.Add(child);
 
             // Verify we can be attached to more than 2 parents.
             Thing parent3 = new Thing() { Name = "Thing3", Id = TestThingID.Generate("testthing") };
-            parent3.Add(this.child);
-            Assert.IsTrue(this.parent1.Children.Contains(this.child));
-            Assert.IsTrue(this.parent2.Children.Contains(this.child));
-            Assert.IsTrue(parent3.Children.Contains(this.child));
-            Assert.IsTrue(this.child.Parent != null);
+            parent3.Add(child);
+            Assert.IsTrue(parent1.Children.Contains(child));
+            Assert.IsTrue(parent2.Children.Contains(child));
+            Assert.IsTrue(parent3.Children.Contains(child));
+            Assert.IsTrue(child.Parent != null);
         }
     }
 }

--- a/src/Tests/CoreTests/Behaviors/TestOpensClosesBehavior.cs
+++ b/src/Tests/CoreTests/Behaviors/TestOpensClosesBehavior.cs
@@ -32,22 +32,22 @@ namespace WheelMUD.Tests.Behaviors
         public void Init()
         {
             // Create the basic actor instances and behavior for test.
-            this.witnessThing = new Thing() { Name = "WitnessThing", Id = TestThingID.Generate("testthing") };
-            this.actingThing = new Thing() { Name = "ActingThing", Id = TestThingID.Generate("testthing") };
-            this.openableThing = new Thing() { Name = "OpenableThing", Id = TestThingID.Generate("testthing") };
-            this.opensClosesBehavior = new OpensClosesBehavior();
+            witnessThing = new Thing() { Name = "WitnessThing", Id = TestThingID.Generate("testthing") };
+            actingThing = new Thing() { Name = "ActingThing", Id = TestThingID.Generate("testthing") };
+            openableThing = new Thing() { Name = "OpenableThing", Id = TestThingID.Generate("testthing") };
+            opensClosesBehavior = new OpensClosesBehavior();
 
             // Set up the actors inside another (which we'll call a "room" although it needn't actually be a room).
-            this.room = new Thing() { Name = "Room", Id = TestThingID.Generate("room") };
-            this.room.Add(this.witnessThing);
-            this.room.Add(this.actingThing);
-            this.room.Add(this.openableThing);
+            room = new Thing() { Name = "Room", Id = TestThingID.Generate("room") };
+            room.Add(witnessThing);
+            room.Add(actingThing);
+            room.Add(openableThing);
 
             // Prepare to verify correct eventing occurs.
-            this.witnessThing.Eventing.MiscellaneousRequest += (root, e) => { this.lastWitnessRequest = e; };
-            this.witnessThing.Eventing.MiscellaneousEvent += (root, e) => { this.lastWitnessEvent = e; };
-            this.actingThing.Eventing.MiscellaneousRequest += (root, e) => { this.lastActorRequest = e; };
-            this.actingThing.Eventing.MiscellaneousEvent += (root, e) => { this.lastActorEvent = e; };
+            witnessThing.Eventing.MiscellaneousRequest += (root, e) => { lastWitnessRequest = e; };
+            witnessThing.Eventing.MiscellaneousEvent += (root, e) => { lastWitnessEvent = e; };
+            actingThing.Eventing.MiscellaneousRequest += (root, e) => { lastActorRequest = e; };
+            actingThing.Eventing.MiscellaneousEvent += (root, e) => { lastActorEvent = e; };
         }
 
         /// <summary>Test OpensClosesBehavior without an attached parent.</summary>
@@ -57,70 +57,70 @@ namespace WheelMUD.Tests.Behaviors
             // Verify that an unattached behavior does not change state between Open/Close attempts, and
             // that such attempts do not throw. (This keeps the behavior solid in the face of the parent
             // being destroyed or whatnot as a race versus a user trying to activate it.)
-            bool initialState = this.opensClosesBehavior.IsOpen;
-            this.opensClosesBehavior.Close(this.actingThing);
-            Assert.AreEqual(initialState, this.opensClosesBehavior.IsOpen);
-            this.opensClosesBehavior.Open(this.actingThing);
-            Assert.AreEqual(initialState, this.opensClosesBehavior.IsOpen);
+            bool initialState = opensClosesBehavior.IsOpen;
+            opensClosesBehavior.Close(actingThing);
+            Assert.AreEqual(initialState, opensClosesBehavior.IsOpen);
+            opensClosesBehavior.Open(actingThing);
+            Assert.AreEqual(initialState, opensClosesBehavior.IsOpen);
         }
 
         /// <summary>Test normal OpensClosesBehavior operation.</summary>
         [Test]
         public void TestOpeningAndClosing()
         {
-            this.openableThing.Behaviors.Add(this.opensClosesBehavior);
+            openableThing.Behaviors.Add(opensClosesBehavior);
 
             // Verify that the default state is closed.
-            Assert.IsTrue(!this.opensClosesBehavior.IsOpen);
+            Assert.IsTrue(!opensClosesBehavior.IsOpen);
 
             // Closing closed thing => closed.
-            this.ClearTrackedEvents();
-            this.opensClosesBehavior.Close(this.actingThing);
-            Assert.IsTrue(!this.opensClosesBehavior.IsOpen);
+            ClearTrackedEvents();
+            opensClosesBehavior.Close(actingThing);
+            Assert.IsTrue(!opensClosesBehavior.IsOpen);
 
             // Verify that no event occurred (but any potentially-cancelled requests are irrelevant).
-            Assert.IsTrue(this.lastWitnessEvent == null);
-            Assert.IsTrue(this.lastActorEvent == null);
+            Assert.IsTrue(lastWitnessEvent == null);
+            Assert.IsTrue(lastActorEvent == null);
 
             // Opening a closed thing => open.
-            this.ClearTrackedEvents();
-            this.opensClosesBehavior.Open(this.actingThing);
-            Assert.IsTrue(this.opensClosesBehavior.IsOpen);
+            ClearTrackedEvents();
+            opensClosesBehavior.Open(actingThing);
+            Assert.IsTrue(opensClosesBehavior.IsOpen);
 
             // Verify that an appropriate close request and close event were witnessed by both the actor and the witness.
-            Assert.IsTrue(this.lastWitnessRequest != null);
-            Assert.IsTrue(this.lastActorRequest != null);
-            Assert.IsTrue(this.lastWitnessEvent != null);
-            Assert.IsTrue(this.lastActorEvent != null);
+            Assert.IsTrue(lastWitnessRequest != null);
+            Assert.IsTrue(lastActorRequest != null);
+            Assert.IsTrue(lastWitnessEvent != null);
+            Assert.IsTrue(lastActorEvent != null);
 
-            string witnessMessage = this.lastWitnessEvent.SensoryMessage.Message.Parse(this.witnessThing);
+            string witnessMessage = lastWitnessEvent.SensoryMessage.Message.Parse(witnessThing);
             Assert.IsTrue(witnessMessage.Contains("opens"));
-            string actorMessage = this.lastActorEvent.SensoryMessage.Message.Parse(this.actingThing);
+            string actorMessage = lastActorEvent.SensoryMessage.Message.Parse(actingThing);
             Assert.IsTrue(actorMessage.Contains("You open"));
 
             // Opening an open thing => open.
-            this.ClearTrackedEvents();
-            this.opensClosesBehavior.Open(this.actingThing);
-            Assert.IsTrue(this.opensClosesBehavior.IsOpen);
+            ClearTrackedEvents();
+            opensClosesBehavior.Open(actingThing);
+            Assert.IsTrue(opensClosesBehavior.IsOpen);
 
             // Verify that no event occurred (but any potentially-cancelled requests are irrelevant).
-            Assert.IsTrue(this.lastWitnessEvent == null);
-            Assert.IsTrue(this.lastActorEvent == null);
+            Assert.IsTrue(lastWitnessEvent == null);
+            Assert.IsTrue(lastActorEvent == null);
 
             // Closing an open thing => closed.
-            this.ClearTrackedEvents();
-            this.opensClosesBehavior.Close(this.actingThing);
-            Assert.IsTrue(!this.opensClosesBehavior.IsOpen);
+            ClearTrackedEvents();
+            opensClosesBehavior.Close(actingThing);
+            Assert.IsTrue(!opensClosesBehavior.IsOpen);
 
             // Verify that an appropriate open request and open event were witnessed by both the actor and the witness.
-            Assert.IsTrue(this.lastWitnessRequest != null);
-            Assert.IsTrue(this.lastActorRequest != null);
-            Assert.IsTrue(this.lastWitnessEvent != null);
-            Assert.IsTrue(this.lastActorEvent != null);
+            Assert.IsTrue(lastWitnessRequest != null);
+            Assert.IsTrue(lastActorRequest != null);
+            Assert.IsTrue(lastWitnessEvent != null);
+            Assert.IsTrue(lastActorEvent != null);
 
-            witnessMessage = this.lastWitnessEvent.SensoryMessage.Message.Parse(this.witnessThing);
+            witnessMessage = lastWitnessEvent.SensoryMessage.Message.Parse(witnessThing);
             Assert.IsTrue(witnessMessage.Contains("closes"));
-            actorMessage = this.lastActorEvent.SensoryMessage.Message.Parse(this.actingThing);
+            actorMessage = lastActorEvent.SensoryMessage.Message.Parse(actingThing);
             Assert.IsTrue(actorMessage.Contains("You close"));
         }
 
@@ -142,41 +142,41 @@ namespace WheelMUD.Tests.Behaviors
             var exitBehaviorB = new ExitBehavior();
             var opensClosesBehaviorB = new OpensClosesBehavior();
             openableExitA.Behaviors.Add(exitBehaviorA);
-            openableExitA.Behaviors.Add(this.opensClosesBehavior);
+            openableExitA.Behaviors.Add(opensClosesBehavior);
             openableExitB.Behaviors.Add(opensClosesBehaviorB);
             openableExitB.Behaviors.Add(exitBehaviorB);
 
             // Rig up behaviors so the actor can move, and move from one A to B, and from B to A.
-            this.actingThing.Behaviors.Add(new MovableBehavior());
+            actingThing.Behaviors.Add(new MovableBehavior());
             exitBehaviorA.AddDestination("toB", roomB.Id);
             exitBehaviorB.AddDestination("toA", roomA.Id);
 
             // Ensure that the actingThing cannot move through either exit while it is in default (closed) state.
-            roomA.Add(this.actingThing);
-            exitBehaviorA.MoveThrough(this.actingThing);
-            Assert.AreSame(roomA, this.actingThing.Parent);
+            roomA.Add(actingThing);
+            exitBehaviorA.MoveThrough(actingThing);
+            Assert.AreSame(roomA, actingThing.Parent);
 
-            roomB.Add(this.actingThing);
-            exitBehaviorB.MoveThrough(this.actingThing);
-            Assert.AreSame(roomB, this.actingThing.Parent);
+            roomB.Add(actingThing);
+            exitBehaviorB.MoveThrough(actingThing);
+            Assert.AreSame(roomB, actingThing.Parent);
 
             // Ensure that the actingThing can open and move through each openable exit to get between rooms.
-            opensClosesBehaviorB.Open(this.actingThing);
-            exitBehaviorB.MoveThrough(this.actingThing);
-            Assert.AreSame(roomA, this.actingThing.Parent);
+            opensClosesBehaviorB.Open(actingThing);
+            exitBehaviorB.MoveThrough(actingThing);
+            Assert.AreSame(roomA, actingThing.Parent);
 
-            this.opensClosesBehavior.Open(this.actingThing);
-            exitBehaviorA.MoveThrough(this.actingThing);
-            Assert.AreSame(roomB, this.actingThing.Parent);
+            opensClosesBehavior.Open(actingThing);
+            exitBehaviorA.MoveThrough(actingThing);
+            Assert.AreSame(roomB, actingThing.Parent);
         }
 
         /// <summary>Clear all potentially tracked events so we can verify new ones.</summary>
         private void ClearTrackedEvents()
         {
-            this.lastActorEvent = null;
-            this.lastActorRequest = null;
-            this.lastWitnessEvent = null;
-            this.lastWitnessRequest = null;
+            lastActorEvent = null;
+            lastActorRequest = null;
+            lastWitnessEvent = null;
+            lastWitnessRequest = null;
         }
     }
 }

--- a/src/Tests/CoreTests/Behaviors/TestPlayerBehavior.cs
+++ b/src/Tests/CoreTests/Behaviors/TestPlayerBehavior.cs
@@ -21,24 +21,24 @@ namespace WheelMUD.Tests.Behaviors
         [SetUp]
         public void Init()
         {
-            this.playerBehavior = new PlayerBehavior();
+            playerBehavior = new PlayerBehavior();
         }
 
         [Test]
         public void TestAddAndRemoveFriends()
         {
-            Assert.AreEqual(this.playerBehavior.Friends.Count, 0);
-            this.playerBehavior.AddFriend("fufa");
-            Assert.AreEqual(this.playerBehavior.Friends.Count, 1);
-            this.playerBehavior.AddFriend("fufa");
-            Assert.AreEqual(this.playerBehavior.Friends.Count, 1);
-            this.playerBehavior.AddFriend("another");
-            Assert.AreEqual(this.playerBehavior.Friends.Count, 2);
+            Assert.AreEqual(playerBehavior.Friends.Count, 0);
+            playerBehavior.AddFriend("fufa");
+            Assert.AreEqual(playerBehavior.Friends.Count, 1);
+            playerBehavior.AddFriend("fufa");
+            Assert.AreEqual(playerBehavior.Friends.Count, 1);
+            playerBehavior.AddFriend("another");
+            Assert.AreEqual(playerBehavior.Friends.Count, 2);
 
-            this.playerBehavior.RemoveFriend("invalid");
-            Assert.AreEqual(this.playerBehavior.Friends.Count, 2);
-            this.playerBehavior.RemoveFriend("fufa");
-            Assert.AreEqual(this.playerBehavior.Friends.Count, 1);
+            playerBehavior.RemoveFriend("invalid");
+            Assert.AreEqual(playerBehavior.Friends.Count, 2);
+            playerBehavior.RemoveFriend("fufa");
+            Assert.AreEqual(playerBehavior.Friends.Count, 1);
         }
     }
 }

--- a/src/Tests/CoreTests/Session/TestSession.cs
+++ b/src/Tests/CoreTests/Session/TestSession.cs
@@ -106,7 +106,7 @@ namespace WheelMUD.Tests.Session
         {
             public FakeConnection()
             {
-                this.Reset();
+                Reset();
             }
 
             public List<string> FakeMessagesSent { get; set; }
@@ -167,7 +167,7 @@ namespace WheelMUD.Tests.Session
 
             public void Reset()
             {
-                this.FakeMessagesSent = new List<string>();
+                FakeMessagesSent = new List<string>();
             }
 
             public void Disconnect()
@@ -177,12 +177,12 @@ namespace WheelMUD.Tests.Session
 
             public void Send(byte[] data)
             {
-                this.Send(Encoding.ASCII.GetString(data));
+                Send(Encoding.ASCII.GetString(data));
             }
 
             public void Send(string data)
             {
-                this.FakeMessagesSent.Add(data);
+                FakeMessagesSent.Add(data);
             }
 
             public void Send(string data, bool bypassDataFormatter)

--- a/src/Tests/TestFramework/BackgroundTestThread.cs
+++ b/src/Tests/TestFramework/BackgroundTestThread.cs
@@ -28,17 +28,17 @@ namespace WheelMUD.Tests
                 }
                 catch (Exception ex)
                 {
-                    this.Exception = ex;
+                    Exception = ex;
                 }
             };
-            this.thread = new Thread(wrappedAction)
+            thread = new Thread(wrappedAction)
             {
                 IsBackground = true,
             };
 
             if (autoStart)
             {
-                this.Start();
+                Start();
             }
         }
 
@@ -57,13 +57,13 @@ namespace WheelMUD.Tests
         /// <summary>Starts running this thread.</summary>
         public void Start()
         {
-            this.thread.Start();
+            thread.Start();
         }
 
         /// <summary>Blocks the calling thread until this thread terminates.</summary>
         public void Join()
         {
-            this.thread.Join();
+            thread.Join();
         }
     }
 }

--- a/src/Tests/WarriorRogueMageTests/Behaviors/TestSkillsBehavior.cs
+++ b/src/Tests/WarriorRogueMageTests/Behaviors/TestSkillsBehavior.cs
@@ -22,7 +22,7 @@ namespace WheelMUD.Tests.Behaviors
         [SetUp]
         public void Init()
         {
-            this.playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
+            playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
         }
 
         /// <summary>Test to make sure WRM behaviors are attaching properly.</summary>
@@ -30,9 +30,9 @@ namespace WheelMUD.Tests.Behaviors
         public void AttachSkillsBehaviorToPlayerTest()
         {
             var skillsBehavior = new SkillsBehavior(null);
-            this.playerThing.Behaviors.Add(skillsBehavior);
-            Assert.IsNotNull(this.playerThing.Behaviors.FindFirst<SkillsBehavior>());
-            this.playerThing.Behaviors.Remove(skillsBehavior);
+            playerThing.Behaviors.Add(skillsBehavior);
+            Assert.IsNotNull(playerThing.Behaviors.FindFirst<SkillsBehavior>());
+            playerThing.Behaviors.Remove(skillsBehavior);
         }
 
         [Test]
@@ -41,14 +41,14 @@ namespace WheelMUD.Tests.Behaviors
             var skillsBehavior = new SkillsBehavior(null);
             var testSkill = new SkillUnarmed();
             skillsBehavior.Add(testSkill);
-            this.playerThing.Behaviors.Add(skillsBehavior);
+            playerThing.Behaviors.Add(skillsBehavior);
 
-            var behavior = this.playerThing.Behaviors.FindFirst<SkillsBehavior>();
+            var behavior = playerThing.Behaviors.FindFirst<SkillsBehavior>();
             Assert.IsTrue(behavior.ManagedSkills.Contains(testSkill));
             Assert.IsNotNull(testSkill.PlayerThing);
 
             behavior.Remove(testSkill);
-            this.playerThing.Behaviors.Remove(skillsBehavior);
+            playerThing.Behaviors.Remove(skillsBehavior);
         }
 
         [Test]
@@ -56,15 +56,15 @@ namespace WheelMUD.Tests.Behaviors
         {
             var skillsBehavior = new SkillsBehavior(null);
             var testSkill = new SkillUnarmed();
-            this.playerThing.Behaviors.Add(skillsBehavior);
+            playerThing.Behaviors.Add(skillsBehavior);
             skillsBehavior.Add(testSkill);
 
-            var behavior = this.playerThing.Behaviors.FindFirst<SkillsBehavior>();
-            Assert.IsTrue(this.playerThing.Behaviors.FindFirst<SkillsBehavior>().ManagedSkills.Contains(testSkill));
+            var behavior = playerThing.Behaviors.FindFirst<SkillsBehavior>();
+            Assert.IsTrue(playerThing.Behaviors.FindFirst<SkillsBehavior>().ManagedSkills.Contains(testSkill));
             Assert.IsNotNull(testSkill.PlayerThing);
 
             behavior.Remove(testSkill);
-            this.playerThing.Behaviors.Remove(skillsBehavior);
+            playerThing.Behaviors.Remove(skillsBehavior);
         }
     }
 }

--- a/src/Tests/WarriorRogueMageTests/Behaviors/TestTalentsBehavior.cs
+++ b/src/Tests/WarriorRogueMageTests/Behaviors/TestTalentsBehavior.cs
@@ -24,7 +24,7 @@ namespace WheelMUD.Tests.Behaviors
         [SetUp]
         public void Init()
         {
-            this.playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
+            playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
         }
 
         /// <summary>Test to make sure WRM behaviors are attaching properly.</summary>
@@ -32,9 +32,9 @@ namespace WheelMUD.Tests.Behaviors
         public void AttachTalentsBehaviorToPlayerTest()
         {
             var testBehavior = new TalentsBehavior(null);
-            this.playerThing.Behaviors.Add(testBehavior);
-            Assert.IsNotNull(this.playerThing.Behaviors.FindFirst<TalentsBehavior>());
-            this.playerThing.Behaviors.Remove(testBehavior);
+            playerThing.Behaviors.Add(testBehavior);
+            Assert.IsNotNull(playerThing.Behaviors.FindFirst<TalentsBehavior>());
+            playerThing.Behaviors.Remove(testBehavior);
         }
 
         [Test]
@@ -43,14 +43,14 @@ namespace WheelMUD.Tests.Behaviors
             var testTalent = new CraftsmanTalent();
             var testBehavior = new TalentsBehavior(null);
             testBehavior.AddTalent(testTalent);
-            this.playerThing.Behaviors.Add(testBehavior);
-            var behavior = this.playerThing.Behaviors.FindFirst<TalentsBehavior>();
+            playerThing.Behaviors.Add(testBehavior);
+            var behavior = playerThing.Behaviors.FindFirst<TalentsBehavior>();
 
             Assert.IsTrue(behavior.ManagedTalents.Contains(testTalent));
             Assert.IsNotNull(testTalent.PlayerThing);
 
             behavior.RemoveTalent(testTalent);
-            this.playerThing.Behaviors.Remove(testBehavior);
+            playerThing.Behaviors.Remove(testBehavior);
         }
 
         [Test]
@@ -63,32 +63,32 @@ namespace WheelMUD.Tests.Behaviors
             var damageStat = new DamageStat();
             var attackStat = new AttackStat();
 
-            warriorAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(warriorAttribute);
+            warriorAttribute.Parent = playerThing;
+            playerThing.AddAttribute(warriorAttribute);
 
-            mageAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(rogueAttribute);
+            mageAttribute.Parent = playerThing;
+            playerThing.AddAttribute(rogueAttribute);
 
-            rogueAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(mageAttribute);
+            rogueAttribute.Parent = playerThing;
+            playerThing.AddAttribute(mageAttribute);
 
-            warriorAttribute.SetValue(10, this.playerThing);
-            rogueAttribute.SetValue(10, this.playerThing);
-            mageAttribute.SetValue(10, this.playerThing);
+            warriorAttribute.SetValue(10, playerThing);
+            rogueAttribute.SetValue(10, playerThing);
+            mageAttribute.SetValue(10, playerThing);
 
-            this.playerThing.Stats.Add(damageStat.Name, damageStat);
-            this.playerThing.Stats.Add(attackStat.Name, attackStat);
+            playerThing.Stats.Add(damageStat.Name, damageStat);
+            playerThing.Stats.Add(attackStat.Name, attackStat);
 
             var testTalent = new ChampionTalent();
-            this.playerThing.Behaviors.Add(testBehavior);
+            playerThing.Behaviors.Add(testBehavior);
 
-            var behavior = this.playerThing.Behaviors.FindFirst<TalentsBehavior>();
+            var behavior = playerThing.Behaviors.FindFirst<TalentsBehavior>();
             behavior.AddTalent(testTalent);
             Assert.IsTrue(behavior.ManagedTalents.Contains(testTalent));
             Assert.IsNotNull(testTalent.PlayerThing);
 
             behavior.RemoveTalent(testTalent);
-            this.playerThing.Behaviors.Remove(testBehavior);
+            playerThing.Behaviors.Remove(testBehavior);
         }
 
         [Test]
@@ -96,14 +96,14 @@ namespace WheelMUD.Tests.Behaviors
         {
             var testTalent = new CraftsmanTalent();
             var testBehavior = new TalentsBehavior(null);
-            this.playerThing.Behaviors.Add(testBehavior);
-            var behavior = this.playerThing.Behaviors.FindFirst<TalentsBehavior>();
+            playerThing.Behaviors.Add(testBehavior);
+            var behavior = playerThing.Behaviors.FindFirst<TalentsBehavior>();
             testBehavior.AddTalent(testTalent);
             Assert.IsTrue(behavior.ManagedTalents.Contains(testTalent));
             Assert.IsNotNull(testTalent.PlayerThing);
 
             behavior.RemoveTalent(testTalent);
-            this.playerThing.Behaviors.Remove(testBehavior);
+            playerThing.Behaviors.Remove(testBehavior);
         }
 
         [Test]
@@ -116,30 +116,30 @@ namespace WheelMUD.Tests.Behaviors
             var damageStat = new DamageStat();
             var attackStat = new AttackStat();
 
-            warriorAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(warriorAttribute);
+            warriorAttribute.Parent = playerThing;
+            playerThing.AddAttribute(warriorAttribute);
 
-            mageAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(rogueAttribute);
+            mageAttribute.Parent = playerThing;
+            playerThing.AddAttribute(rogueAttribute);
 
-            rogueAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(mageAttribute);
+            rogueAttribute.Parent = playerThing;
+            playerThing.AddAttribute(mageAttribute);
 
-            warriorAttribute.SetValue(10, this.playerThing);
-            rogueAttribute.SetValue(10, this.playerThing);
-            mageAttribute.SetValue(10, this.playerThing);
+            warriorAttribute.SetValue(10, playerThing);
+            rogueAttribute.SetValue(10, playerThing);
+            mageAttribute.SetValue(10, playerThing);
 
-            this.playerThing.Stats.Add(damageStat.Name, damageStat);
-            this.playerThing.Stats.Add(attackStat.Name, attackStat);
+            playerThing.Stats.Add(damageStat.Name, damageStat);
+            playerThing.Stats.Add(attackStat.Name, attackStat);
             var testTalent = new ChampionTalent();
-            this.playerThing.Behaviors.Add(testBehavior);
-            var behavior = this.playerThing.Behaviors.FindFirst<TalentsBehavior>();
+            playerThing.Behaviors.Add(testBehavior);
+            var behavior = playerThing.Behaviors.FindFirst<TalentsBehavior>();
             testBehavior.AddTalent(testTalent);
             Assert.IsTrue(behavior.ManagedTalents.Contains(testTalent));
             Assert.IsNotNull(testTalent.PlayerThing);
 
             behavior.RemoveTalent(testTalent);
-            this.playerThing.Behaviors.Remove(testBehavior);
+            playerThing.Behaviors.Remove(testBehavior);
         }
     }
 }

--- a/src/Tests/WarriorRogueMageTests/Combat/TestWRMCombat.cs
+++ b/src/Tests/WarriorRogueMageTests/Combat/TestWRMCombat.cs
@@ -26,7 +26,7 @@ namespace WheelMUD.Tests.WRMCombat
         [SetUp]
         public void Init()
         {
-            this.playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
+            playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
 
             var testBehavior = new TalentsBehavior(null);
             var warriorAttribute = new WarriorAttribute();
@@ -37,31 +37,31 @@ namespace WheelMUD.Tests.WRMCombat
             var initiativeStat = new InitiativeStat();
             var awarenessSkill = new SkillAwareness();
 
-            warriorAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(warriorAttribute);
+            warriorAttribute.Parent = playerThing;
+            playerThing.AddAttribute(warriorAttribute);
 
-            mageAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(rogueAttribute);
+            mageAttribute.Parent = playerThing;
+            playerThing.AddAttribute(rogueAttribute);
 
-            rogueAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(mageAttribute);
+            rogueAttribute.Parent = playerThing;
+            playerThing.AddAttribute(mageAttribute);
 
-            warriorAttribute.SetValue(10, this.playerThing);
-            rogueAttribute.SetValue(10, this.playerThing);
-            mageAttribute.SetValue(10, this.playerThing);
+            warriorAttribute.SetValue(10, playerThing);
+            rogueAttribute.SetValue(10, playerThing);
+            mageAttribute.SetValue(10, playerThing);
 
-            this.playerThing.Stats.Add(damageStat.Name, damageStat);
-            this.playerThing.Stats.Add(attackStat.Name, attackStat);
-            this.playerThing.Stats.Add(initiativeStat.Name, initiativeStat);
-            this.playerThing.Skills.Add(awarenessSkill.Name, awarenessSkill);
-            this.playerThing.Behaviors.Add(testBehavior);
+            playerThing.Stats.Add(damageStat.Name, damageStat);
+            playerThing.Stats.Add(attackStat.Name, attackStat);
+            playerThing.Stats.Add(initiativeStat.Name, initiativeStat);
+            playerThing.Skills.Add(awarenessSkill.Name, awarenessSkill);
+            playerThing.Behaviors.Add(testBehavior);
         }
 
         /// <summary>A test for checking for the awareness skill using an instance.</summary>
         [Test]
         public void CheckAwarenessByInstanceTest()
         {
-            GameSkill awareness = this.playerThing.FindGameSkill<SkillAwareness>();
+            GameSkill awareness = playerThing.FindGameSkill<SkillAwareness>();
             Assert.IsNotNull(awareness);
         }
 
@@ -69,7 +69,7 @@ namespace WheelMUD.Tests.WRMCombat
         [Test]
         public void CheckAwarenessByNameTest()
         {
-            GameSkill awareness = this.playerThing.FindGameSkill("Awareness");
+            GameSkill awareness = playerThing.FindGameSkill("Awareness");
             Assert.IsNotNull(awareness);
         }
 
@@ -78,7 +78,7 @@ namespace WheelMUD.Tests.WRMCombat
         public void CombatSessionTest()
         {
             var expected = new GameCombatSession();
-            expected.AddCombatant(ref this.playerThing);
+            expected.AddCombatant(ref playerThing);
             Assert.AreEqual(1, expected.Combatants.Count);
         }
 

--- a/src/Tests/WarriorRogueMageTests/Talents/TestChampionTalent.cs
+++ b/src/Tests/WarriorRogueMageTests/Talents/TestChampionTalent.cs
@@ -31,25 +31,25 @@ namespace WheelMUD.Tests.Talents
             var damageStat = new DamageStat();
             var attackStat = new AttackStat();
 
-            this.playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
+            playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
 
-            this.playerThing.Behaviors.Add(testBehavior);
+            playerThing.Behaviors.Add(testBehavior);
 
-            warriorAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(warriorAttribute);
+            warriorAttribute.Parent = playerThing;
+            playerThing.AddAttribute(warriorAttribute);
 
-            mageAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(rogueAttribute);
+            mageAttribute.Parent = playerThing;
+            playerThing.AddAttribute(rogueAttribute);
 
-            rogueAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(mageAttribute);
+            rogueAttribute.Parent = playerThing;
+            playerThing.AddAttribute(mageAttribute);
 
-            warriorAttribute.SetValue(10, this.playerThing);
-            rogueAttribute.SetValue(10, this.playerThing);
-            mageAttribute.SetValue(10, this.playerThing);
+            warriorAttribute.SetValue(10, playerThing);
+            rogueAttribute.SetValue(10, playerThing);
+            mageAttribute.SetValue(10, playerThing);
 
-            this.playerThing.Stats.Add(damageStat.Name, damageStat);
-            this.playerThing.Stats.Add(attackStat.Name, attackStat);
+            playerThing.Stats.Add(damageStat.Name, damageStat);
+            playerThing.Stats.Add(attackStat.Name, attackStat);
         }
 
         /// <summary>Tests the champion talent added mechanism.</summary>
@@ -58,9 +58,9 @@ namespace WheelMUD.Tests.Talents
         {
             var champion = new ChampionTalent();
 
-            this.playerThing.Behaviors.FindFirst<TalentsBehavior>().AddTalent(champion);
+            playerThing.Behaviors.FindFirst<TalentsBehavior>().AddTalent(champion);
 
-            var behavior = this.playerThing.Behaviors.FindFirst<TalentsBehavior>();
+            var behavior = playerThing.Behaviors.FindFirst<TalentsBehavior>();
 
             Assert.IsTrue(behavior.ManagedTalents.Contains(champion));
             Assert.IsNotNull(behavior.FindFirst<ChampionTalent>().PlayerThing);

--- a/src/Tests/WarriorRogueMageTests/Talents/TestChannelerTalent.cs
+++ b/src/Tests/WarriorRogueMageTests/Talents/TestChannelerTalent.cs
@@ -30,24 +30,24 @@ namespace WheelMUD.Tests.Talents
             var mageAttribute = new MageAttribute();
             var damageStat = new DamageStat();
 
-            this.playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
+            playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
 
-            this.playerThing.Behaviors.Add(testBehavior);
+            playerThing.Behaviors.Add(testBehavior);
 
-            warriorAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(warriorAttribute);
+            warriorAttribute.Parent = playerThing;
+            playerThing.AddAttribute(warriorAttribute);
 
-            mageAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(rogueAttribute);
+            mageAttribute.Parent = playerThing;
+            playerThing.AddAttribute(rogueAttribute);
 
-            rogueAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(mageAttribute);
+            rogueAttribute.Parent = playerThing;
+            playerThing.AddAttribute(mageAttribute);
 
-            warriorAttribute.SetValue(10, this.playerThing);
-            rogueAttribute.SetValue(10, this.playerThing);
-            mageAttribute.SetValue(10, this.playerThing);
+            warriorAttribute.SetValue(10, playerThing);
+            rogueAttribute.SetValue(10, playerThing);
+            mageAttribute.SetValue(10, playerThing);
 
-            this.playerThing.Stats.Add(damageStat.Name, damageStat);
+            playerThing.Stats.Add(damageStat.Name, damageStat);
         }
 
         /// <summary>Tests the channeler talent added mechanism.</summary>
@@ -56,9 +56,9 @@ namespace WheelMUD.Tests.Talents
         {
             var channeler = new ChannelerTalent();
 
-            this.playerThing.Behaviors.FindFirst<TalentsBehavior>().AddTalent(channeler);
+            playerThing.Behaviors.FindFirst<TalentsBehavior>().AddTalent(channeler);
 
-            var behavior = this.playerThing.Behaviors.FindFirst<TalentsBehavior>();
+            var behavior = playerThing.Behaviors.FindFirst<TalentsBehavior>();
 
             Assert.IsTrue(behavior.ManagedTalents.Contains(channeler));
             Assert.IsNotNull(behavior.FindFirst<ChannelerTalent>().PlayerThing);

--- a/src/Tests/WarriorRogueMageTests/Talents/TestMassiveAttackTalent.cs
+++ b/src/Tests/WarriorRogueMageTests/Talents/TestMassiveAttackTalent.cs
@@ -30,24 +30,24 @@ namespace WheelMUD.Tests.Talents
             var mageAttribute = new MageAttribute();
             var damageStat = new DamageStat();
 
-            this.playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
+            playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
 
-            this.playerThing.Behaviors.Add(testBehavior);
+            playerThing.Behaviors.Add(testBehavior);
 
-            warriorAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(warriorAttribute);
+            warriorAttribute.Parent = playerThing;
+            playerThing.AddAttribute(warriorAttribute);
 
-            mageAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(rogueAttribute);
+            mageAttribute.Parent = playerThing;
+            playerThing.AddAttribute(rogueAttribute);
 
-            rogueAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(mageAttribute);
+            rogueAttribute.Parent = playerThing;
+            playerThing.AddAttribute(mageAttribute);
 
-            warriorAttribute.SetValue(10, this.playerThing);
-            rogueAttribute.SetValue(10, this.playerThing);
-            mageAttribute.SetValue(10, this.playerThing);
+            warriorAttribute.SetValue(10, playerThing);
+            rogueAttribute.SetValue(10, playerThing);
+            mageAttribute.SetValue(10, playerThing);
 
-            this.playerThing.Stats.Add(damageStat.Name, damageStat);
+            playerThing.Stats.Add(damageStat.Name, damageStat);
         }
 
         /// <summary>Tests the massive attack talent added mechanism.</summary>
@@ -55,8 +55,8 @@ namespace WheelMUD.Tests.Talents
         public void TestMassiveAttackTalentAddedMechanism()
         {
             var massiveAttack = new MassiveAttackTalent();
-            this.playerThing.Behaviors.FindFirst<TalentsBehavior>().AddTalent(massiveAttack);
-            var behavior = this.playerThing.Behaviors.FindFirst<TalentsBehavior>();
+            playerThing.Behaviors.FindFirst<TalentsBehavior>().AddTalent(massiveAttack);
+            var behavior = playerThing.Behaviors.FindFirst<TalentsBehavior>();
 
             Assert.IsTrue(behavior.ManagedTalents.Contains(massiveAttack));
             Assert.IsNotNull(behavior.FindFirst<MassiveAttackTalent>().PlayerThing);

--- a/src/Tests/WarriorRogueMageTests/Talents/TestPreciseShotTalent.cs
+++ b/src/Tests/WarriorRogueMageTests/Talents/TestPreciseShotTalent.cs
@@ -30,24 +30,24 @@ namespace WheelMUD.Tests.Talents
             var mageAttribute = new MageAttribute();
             var damageStat = new DamageStat();
 
-            this.playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
+            playerThing = new Thing() { Name = "PlayerThing", Id = TestThingID.Generate("testthing") };
 
-            this.playerThing.Behaviors.Add(testBehavior);
+            playerThing.Behaviors.Add(testBehavior);
 
-            warriorAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(warriorAttribute);
+            warriorAttribute.Parent = playerThing;
+            playerThing.AddAttribute(warriorAttribute);
 
-            mageAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(rogueAttribute);
+            mageAttribute.Parent = playerThing;
+            playerThing.AddAttribute(rogueAttribute);
 
-            rogueAttribute.Parent = this.playerThing;
-            this.playerThing.AddAttribute(mageAttribute);
+            rogueAttribute.Parent = playerThing;
+            playerThing.AddAttribute(mageAttribute);
 
-            warriorAttribute.SetValue(10, this.playerThing);
-            rogueAttribute.SetValue(10, this.playerThing);
-            mageAttribute.SetValue(10, this.playerThing);
+            warriorAttribute.SetValue(10, playerThing);
+            rogueAttribute.SetValue(10, playerThing);
+            mageAttribute.SetValue(10, playerThing);
 
-            this.playerThing.Stats.Add(damageStat.Name, damageStat);
+            playerThing.Stats.Add(damageStat.Name, damageStat);
         }
 
         /// <summary>Tests the precise shot talent added mechanism.</summary>
@@ -55,8 +55,8 @@ namespace WheelMUD.Tests.Talents
         public void TestPreciseShotTalentAddedMechanism()
         {
             var preciseShot = new PreciseShotTalent();
-            this.playerThing.Behaviors.FindFirst<TalentsBehavior>().AddTalent(preciseShot);
-            var behavior = this.playerThing.Behaviors.FindFirst<TalentsBehavior>();
+            playerThing.Behaviors.FindFirst<TalentsBehavior>().AddTalent(preciseShot);
+            var behavior = playerThing.Behaviors.FindFirst<TalentsBehavior>();
             Assert.IsTrue(behavior.ManagedTalents.Contains(preciseShot));
             Assert.IsNotNull(behavior.FindFirst<PreciseShotTalent>().PlayerThing);
             behavior.RemoveTalent(preciseShot);

--- a/src/Universe/Behaviors/ActivationBehavior.cs
+++ b/src/Universe/Behaviors/ActivationBehavior.cs
@@ -26,7 +26,7 @@ namespace WheelMUD.Universe
         public ActivationBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Sets the default properties of this behavior instance.</summary>

--- a/src/Universe/Behaviors/ArmorBehavior.cs
+++ b/src/Universe/Behaviors/ArmorBehavior.cs
@@ -27,7 +27,7 @@ namespace WheelMUD.Universe
         public ArmorBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Use the specified armor.</summary>

--- a/src/Universe/Behaviors/ContainerBehavior.cs
+++ b/src/Universe/Behaviors/ContainerBehavior.cs
@@ -25,7 +25,7 @@ namespace WheelMUD.Universe
         public ContainerBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets or sets a value indicating whether the container is able to hold liquid without leaking.</summary>
@@ -40,9 +40,9 @@ namespace WheelMUD.Universe
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.HoldsLiquid = false;
-            this.Volume = 0;
-            this.VolumeUnitOfMeasurement = null;
+            HoldsLiquid = false;
+            Volume = 0;
+            VolumeUnitOfMeasurement = null;
         }
     }
 }

--- a/src/Universe/Behaviors/CurrencyBehavior.cs
+++ b/src/Universe/Behaviors/CurrencyBehavior.cs
@@ -25,7 +25,7 @@ namespace WheelMUD.Universe
         public CurrencyBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Sets the default properties of this effect instance.</summary>

--- a/src/Universe/Behaviors/DrinkableBehavior.cs
+++ b/src/Universe/Behaviors/DrinkableBehavior.cs
@@ -25,7 +25,7 @@ namespace WheelMUD.Universe
         public DrinkableBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Have a thing try to drink from this drinkable thing.</summary>

--- a/src/Universe/Behaviors/FlammableBehavior.cs
+++ b/src/Universe/Behaviors/FlammableBehavior.cs
@@ -25,7 +25,7 @@ namespace WheelMUD.Universe
         public FlammableBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets or sets a value indicating whether the item is consumed when ignited.</summary>
@@ -37,8 +37,8 @@ namespace WheelMUD.Universe
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.IsConsumed = true;
-            this.DamageFormula = null;
+            IsConsumed = true;
+            DamageFormula = null;
         }
     }
 }

--- a/src/Universe/Behaviors/FurnitureBehavior.cs
+++ b/src/Universe/Behaviors/FurnitureBehavior.cs
@@ -29,7 +29,7 @@ namespace WheelMUD.Universe
         public FurnitureBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets or sets a value indicating whether the object may be moved.</summary>
@@ -47,10 +47,10 @@ namespace WheelMUD.Universe
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.IsMoveable = true;
-            this.IsObscuringExit = false;
-            this.ObscuredExit = null;
-            this.WillObscureExit = false;
+            IsMoveable = true;
+            IsObscuringExit = false;
+            ObscuredExit = null;
+            WillObscureExit = false;
         }
     }
 }

--- a/src/Universe/Behaviors/HoldsLiquidBehavior.cs
+++ b/src/Universe/Behaviors/HoldsLiquidBehavior.cs
@@ -26,13 +26,13 @@ namespace WheelMUD.Universe
         public HoldsLiquidBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         public void FillFrom(IController sender, HoldsLiquidBehavior source)
         {
             // TODO: If this behavior's thing has no room left, abort.
-            // sender.Write(string.Format("The {0} is full and no more can be added to it.", this.destinationContainerName));
+            // sender.Write(string.Format("The {0} is full and no more can be added to it.", destinationContainerName));
 
             // Iterate through the source thing's Children to find the first Liquid thing.
             LiquidBehavior liquidBehavior = null;
@@ -57,11 +57,11 @@ namespace WheelMUD.Universe
             // TODO: Determine the maximum amount we can take from that liquid stack.
 
             // Move that liquid stack over into this liquid-holder.
-            if (this.Parent.Add(liquidBehavior.Parent))
+            if (Parent.Add(liquidBehavior.Parent))
             {
                 string message = string.Format(
                     "You filled {0} with {1} from {2}.",
-                    this.Parent.Name,
+                    Parent.Name,
                     liquidBehavior.Parent.Name,
                     source.Parent.Name);
                 sender.Write(message);

--- a/src/Universe/Behaviors/LiquidBehavior.cs
+++ b/src/Universe/Behaviors/LiquidBehavior.cs
@@ -25,7 +25,7 @@ namespace WheelMUD.Universe
         public LiquidBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets or sets the viscosity of the liquid.</summary>
@@ -37,8 +37,8 @@ namespace WheelMUD.Universe
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.Viscosity = "medium";
-            this.UnitsOfMeasurement = "pint";
+            Viscosity = "medium";
+            UnitsOfMeasurement = "pint";
         }
     }
 }

--- a/src/Universe/Behaviors/LiquidSourceBehavior.cs
+++ b/src/Universe/Behaviors/LiquidSourceBehavior.cs
@@ -25,7 +25,7 @@ namespace WheelMUD.Universe
         public LiquidSourceBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets or sets the ID of the liquid that this produces.</summary>
@@ -52,9 +52,9 @@ namespace WheelMUD.Universe
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.LiquidName = "water";
-            this.IsFlowing = true;
-            this.FlowingSound = "bubbling";
+            LiquidName = "water";
+            IsFlowing = true;
+            FlowingSound = "bubbling";
         }
     }
 }

--- a/src/Universe/Behaviors/LocksUnlocksBehavior.cs
+++ b/src/Universe/Behaviors/LocksUnlocksBehavior.cs
@@ -36,28 +36,28 @@ namespace WheelMUD.Universe
         public LocksUnlocksBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.commands = new LocksUnlocksBehaviorCommands(this);
-            this.ID = instanceID;
+            commands = new LocksUnlocksBehaviorCommands(this);
+            ID = instanceID;
         }
 
         /// <summary>Gets a value indicating whether the attached thing is currently locked.</summary>
         public bool IsLocked { get; private set; }
 
-        /// <summary>Called when a parent has just been assigned to this behavior. (Refer to this.Parent)</summary>
+        /// <summary>Called when a parent has just been assigned to this behavior. (Refer to Parent)</summary>
         protected override void OnAddBehavior()
         {
-            var parent = this.Parent;
+            var parent = Parent;
             if (parent != null)
             {
                 // When adding this behavior to a Thing, register relevant events so we can cancel
                 // the opening of our parent Thing while our parent Thing is "locked".
-                parent.Eventing.MiscellaneousRequest += this.RequestHandler;
+                parent.Eventing.MiscellaneousRequest += RequestHandler;
 
                 // Register the "lock" and "unlock" context commands to be available to siblings of our parent,
                 // and to the lockable/unlockable thing's children (IE in case it can be entered itself).
                 var contextAvailability = ContextAvailability.ToSiblings | ContextAvailability.ToChildren;
-                var lockContextCommand = new ContextCommand(this.commands, LockString, contextAvailability, SecurityRole.all);
-                var unlockContextCommand = new ContextCommand(this.commands, UnlockString, contextAvailability, SecurityRole.all);
+                var lockContextCommand = new ContextCommand(commands, LockString, contextAvailability, SecurityRole.all);
+                var unlockContextCommand = new ContextCommand(commands, UnlockString, contextAvailability, SecurityRole.all);
                 Debug.Assert(!parent.Commands.ContainsKey(LockString), "The Thing this LocksUnlocksBehavior attached to already had a Lock command.");
                 Debug.Assert(!parent.Commands.ContainsKey(UnlockString), "The Thing this LocksUnlocksBehavior attached to already had an Unlock command.");
                 parent.Commands.Add(LockString, lockContextCommand);
@@ -71,20 +71,20 @@ namespace WheelMUD.Universe
         /// <param name="locker">The actor who is locking this Thing.</param>
         public void Lock(Thing locker)
         {
-            this.LockOrUnlock(locker, LockString, true);
+            LockOrUnlock(locker, LockString, true);
         }
 
         /// <summary>Unlock this Thing.</summary>
         /// <param name="unlocker">The actor who is unlocking this Thing.</param>
         public void Unlock(Thing unlocker)
         {
-            this.LockOrUnlock(unlocker, UnlockString, false);
+            LockOrUnlock(unlocker, UnlockString, false);
         }
 
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.IsLocked = true;
+            IsLocked = true;
         }
 
         /// <summary>Lock or unlock this behavior's parent, via the specified actor.</summary>
@@ -94,14 +94,14 @@ namespace WheelMUD.Universe
         private void LockOrUnlock(Thing actor, string verb, bool newLockedState)
         {
             // If we're already in the desired locked/unlocked state, we're already done with state changes.
-            if (newLockedState == this.IsLocked)
+            if (newLockedState == IsLocked)
             {
                 // TODO: Message to the actor that it is already locked/unlocked.
                 return;
             }
 
             // Use a temporary ref to our own parent to avoid race conditions like sudden parent removal.
-            var thisThing = this.Parent;
+            var thisThing = Parent;
             if (thisThing == null)
             {
                 return; // Abort if the behavior is unattached (e.g. being destroyed).
@@ -134,7 +134,7 @@ namespace WheelMUD.Universe
             if (!e.IsCancelled)
             {
                 // Lock or Unlock the thing.
-                this.IsLocked = newLockedState;
+                IsLocked = newLockedState;
 
                 // Broadcast the Lock or Unlock event.
                 thisThing.Eventing.OnMiscellaneousEvent(e, EventScope.ParentsDown);
@@ -147,16 +147,16 @@ namespace WheelMUD.Universe
         private void RequestHandler(Thing root, CancellableGameEvent e)
         {
             // Only cancel requestes to open our parent if it is currently locked.
-            if (this.IsLocked)
+            if (IsLocked)
             {
-                var parent = this.Parent;
+                var parent = Parent;
                 if (parent != null)
                 {
                     // If this is a standard open request, find out if we need to cancel it.
                     var openCloseEvent = e as OpenCloseEvent;
-                    if (openCloseEvent != null && openCloseEvent.IsBeingOpened && openCloseEvent.Target == this.Parent)
+                    if (openCloseEvent != null && openCloseEvent.IsBeingOpened && openCloseEvent.Target == Parent)
                     {
-                        string message = string.Format("You cannot open {0} since it is locked!", this.Parent.Name);
+                        string message = string.Format("You cannot open {0} since it is locked!", Parent.Name);
                         openCloseEvent.Cancel(message);
                     }
                 }
@@ -193,11 +193,11 @@ namespace WheelMUD.Universe
                 // If the user invoked the context command, try to lock or unlock their target.
                 if (LockString.Equals(actionInput.Noun, StringComparison.CurrentCultureIgnoreCase))
                 {
-                    this.locksUnlocksBehavior.Lock(actionInput.Controller.Thing);
+                    locksUnlocksBehavior.Lock(actionInput.Controller.Thing);
                 }
                 else if (UnlockString.Equals(actionInput.Noun, StringComparison.CurrentCultureIgnoreCase))
                 {
-                    this.locksUnlocksBehavior.Unlock(actionInput.Controller.Thing);
+                    locksUnlocksBehavior.Unlock(actionInput.Controller.Thing);
                 }
             }
 
@@ -206,7 +206,7 @@ namespace WheelMUD.Universe
             /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
             public override string Guards(ActionInput actionInput)
             {
-                string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+                string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
                 if (commonFailure != null)
                 {
                     return commonFailure;

--- a/src/Universe/Behaviors/PortalBehavior.cs
+++ b/src/Universe/Behaviors/PortalBehavior.cs
@@ -21,7 +21,7 @@ namespace WheelMUD.Universe
         public PortalBehavior()
             : base(null)
         {
-            this.Parent.Eventing.MovementRequest += this.Parent_MovementRequest;
+            Parent.Eventing.MovementRequest += Parent_MovementRequest;
         }
 
         /// <summary>Initializes a new instance of the PortalBehavior class.</summary>
@@ -30,7 +30,7 @@ namespace WheelMUD.Universe
         public PortalBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets or sets the destination room ID for this portal.</summary>
@@ -39,7 +39,7 @@ namespace WheelMUD.Universe
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.DestinationThingID = null;
+            DestinationThingID = null;
         }
 
         /// <summary>Handle movement requests from the parent Thing.</summary>
@@ -59,17 +59,17 @@ namespace WheelMUD.Universe
         public void Use(Entity enteringEntity, Thing world)
         {
             // If the current exit isn't rigged up to the current destination, rig it up.
-            if (this.exitLocation == null || this.exitLocation.Id != this.DestinationThingID)
+            if (exitLocation == null || exitLocation.Id != DestinationThingID)
             {
-                // TODO Repair: this.exitLocation = world.FindThing(this.DestinationThingID);
+                // TODO Repair: exitLocation = world.FindThing(DestinationThingID);
             }
 
             // Send a sensory event for entering the portal.
             var leaveMessage = new ContextualString(enteringEntity, enteringEntity)
             {
-                ToOriginator = $"You step into {this.Parent.Name}.",
+                ToOriginator = $"You step into {Parent.Name}.",
                 ToReceiver = $"{actor.Name} steps into you.",
-                ToOthers = $"{actor.Name} steps into {this.Parent.Name}.",
+                ToOthers = $"{actor.Name} steps into {Parent.Name}.",
             };
             Thing parent = enteringEntity.Parent;
             SensoryMessage enterMessage = new SensoryMessage(SensoryType.Sight, 100, leaveMessage);
@@ -77,29 +77,29 @@ namespace WheelMUD.Universe
             parent.EventBroadcaster.Broadcast(enterEvent);
 
             // Move the specified entity to the destination room.
-            bool moved = enteringEntity.Move(this.exitLocation);
+            bool moved = enteringEntity.Move(exitLocation);
 
             if (moved)
             {
                 // If entity moved to the other side, send a sensory event to depict the arrival.
                 var arriveMessage = new ContextualString(enteringEntity, enteringEntity)
                 {
-                    ToOriginator = $"You step out of {this.Parent.Name}, into {this.exitLocation.Name}.",
+                    ToOriginator = $"You step out of {Parent.Name}, into {exitLocation.Name}.",
                     ToReceiver = $"{actor.Name} steps out of you.",
-                    ToOthers = $"{actor.Name} steps out of {this.Parent.Name}.",
+                    ToOthers = $"{actor.Name} steps out of {Parent.Name}.",
                 }
                 SensoryMessage exitMessage = new SensoryMessage(SensoryType.Sight, 100, arriveMessage);
-                SensoryEvent exitEvent = new SensoryEvent(enteringEntity, this.exitLocation, exitMessage);
-                this.exitLocation.EventBroadcaster.Broadcast(exitEvent);
+                SensoryEvent exitEvent = new SensoryEvent(enteringEntity, exitLocation, exitMessage);
+                exitLocation.EventBroadcaster.Broadcast(exitEvent);
             }
             else
             {
                 // If entity failed to emerge at the other side, send a sensory event to describe the failure.
                 var failedMessage = new ContextualString(enteringEntity, enteringEntity)
                 {
-                    ToOriginator = $"{this.Parent.Name} seems to be inactive.",
+                    ToOriginator = $"{Parent.Name} seems to be inactive.",
                     ToReceiver = $"{actor.Name} tried to move through you, but couldn't.",
-                    ToOthers = $"{actor.Name} could not pass through {this.Parent.Name}.",
+                    ToOthers = $"{actor.Name} could not pass through {Parent.Name}.",
                 }
                 SensoryMessage cancelMessage = new SensoryMessage(SensoryType.Sight, 100, failedMessage);
                 SensoryEvent cancelEvent = new SensoryEvent(enteringEntity, parent, cancelMessage);

--- a/src/Universe/Behaviors/PotionBehavior.cs
+++ b/src/Universe/Behaviors/PotionBehavior.cs
@@ -26,7 +26,7 @@ namespace WheelMUD.Universe
         public PotionBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets or sets the maximum sips this potion can contain.</summary>
@@ -48,7 +48,7 @@ namespace WheelMUD.Universe
         /// <param name="entity">The entity to drink the potion.</param>
         public void Drink(Thing entity)
         {
-            if (this.SipsLeft <= 0)
+            if (SipsLeft <= 0)
             {
                 return;
             }
@@ -58,24 +58,24 @@ namespace WheelMUD.Universe
 
             if (entity.Effects.TryCreateEffect<StatEffect>(entity, out effect))
             {
-                effect.Modifier = this.Modifier;
-                effect.Name = this.PotionType;
-                effect.Apply(this.Duration);
+                effect.Modifier = Modifier;
+                effect.Name = PotionType;
+                effect.Apply(Duration);
             }
             */
-            this.SipsLeft--;
+            SipsLeft--;
 
-            ////this.Save(); TODO: Bring back as Save from base class?
+            ////Save(); TODO: Bring back as Save from base class?
         }
 
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.MaxSips = 5;
-            this.SipsLeft = 2;
-            this.Duration = new TimeSpan(0, 0, 15);
-            this.Modifier = 100;
-            this.PotionType = "health";
+            MaxSips = 5;
+            SipsLeft = 2;
+            Duration = new TimeSpan(0, 0, 15);
+            Modifier = 100;
+            PotionType = "health";
         }
     }
 }

--- a/src/Universe/Behaviors/ShieldBehavior.cs
+++ b/src/Universe/Behaviors/ShieldBehavior.cs
@@ -26,7 +26,7 @@ namespace WheelMUD.Universe
         public ShieldBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Use the specified shield.</summary>

--- a/src/Universe/Behaviors/WeaponBehavior.cs
+++ b/src/Universe/Behaviors/WeaponBehavior.cs
@@ -31,7 +31,7 @@ namespace WheelMUD.Universe
         public WeaponBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>Gets or sets the minimum strength to use the weapon.</summary>
@@ -54,9 +54,9 @@ namespace WheelMUD.Universe
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.MinimumStrength = 0;
-            this.RequiresTwoHands = false;
-            this.DamageFormula = null;
+            MinimumStrength = 0;
+            RequiresTwoHands = false;
+            DamageFormula = null;
         }
     }
 }

--- a/src/Universe/Information/TypoEntry.cs
+++ b/src/Universe/Information/TypoEntry.cs
@@ -25,21 +25,21 @@ namespace WheelMUD.Universe.Information
         /// <param name="record"> The record that contains the information from the database.</param>
         public TypoEntry(TypoRecord record)
         {
-            this.Id = record.ID;
-            this.Note = record.Note;
-            this.Resolved = record.Resolved;
-            this.ResolvedByPlayerId = record.ResolvedByPlayerID;
-            this.PlaceID = record.RoomID.ToString(CultureInfo.InvariantCulture);
-            this.SubmittedByPlayerID = record.SubmittedByPlayerID.ToString(CultureInfo.InvariantCulture);
-            this.SubmittedDateTime = DateTime.Parse(record.SubmittedDateTime);
+            Id = record.ID;
+            Note = record.Note;
+            Resolved = record.Resolved;
+            ResolvedByPlayerId = record.ResolvedByPlayerID;
+            PlaceID = record.RoomID.ToString(CultureInfo.InvariantCulture);
+            SubmittedByPlayerID = record.SubmittedByPlayerID.ToString(CultureInfo.InvariantCulture);
+            SubmittedDateTime = DateTime.Parse(record.SubmittedDateTime);
 
             if (record.ResolvedDateTime != null)
             {
-                this.ResolvedDateTime = DateTime.Parse(record.ResolvedDateTime);
+                ResolvedDateTime = DateTime.Parse(record.ResolvedDateTime);
             }
             else
             {
-                this.ResolvedDateTime = null;
+                ResolvedDateTime = null;
             }
         }
 
@@ -74,29 +74,29 @@ namespace WheelMUD.Universe.Information
 
             var typoRecord = new TypoRecord
             {
-                ID = this.Id,
-                Note = this.Note,
-                Resolved = this.Resolved,
-                ResolvedByPlayerID = (long)this.ResolvedByPlayerId,
-                RoomID = Convert.ToInt64(this.PlaceID),
-                SubmittedByPlayerID = Convert.ToInt64(this.SubmittedByPlayerID),
+                ID = Id,
+                Note = Note,
+                Resolved = Resolved,
+                ResolvedByPlayerID = (long)ResolvedByPlayerId,
+                RoomID = Convert.ToInt64(PlaceID),
+                SubmittedByPlayerID = Convert.ToInt64(SubmittedByPlayerID),
             };
 
-            if (this.ResolvedDateTime != null)
+            if (ResolvedDateTime != null)
             {
-                typoRecord.ResolvedDateTime = this.ResolvedDateTime.ToString();
+                typoRecord.ResolvedDateTime = ResolvedDateTime.ToString();
             }
             else
             {
                 typoRecord.ResolvedDateTime = null;
             }
 
-            typoRecord.SubmittedDateTime = this.SubmittedDateTime.ToString(CultureInfo.InvariantCulture);
+            typoRecord.SubmittedDateTime = SubmittedDateTime.ToString(CultureInfo.InvariantCulture);
 
             if (typoRecord.ID == 0)
             {
                 typoRepository.Add(typoRecord);
-                this.Id = typoRecord.ID;
+                Id = typoRecord.ID;
             }
             else
             {

--- a/src/Utilities/DisposableList.cs
+++ b/src/Utilities/DisposableList.cs
@@ -28,22 +28,22 @@ namespace WheelMUD.Utilities
         /// <summary>Finalizes an instance of the DisposableList class.</summary>
         ~DisposableList()
         {
-            this.Dispose();
+            Dispose();
         }
 
         /// <summary>Dispose of all disposable resources that are managed by this list.</summary>
         public void Dispose()
         {
-            lock (this.lockObject)
+            lock (lockObject)
             {
-                if (this.Count > 0)
+                if (Count > 0)
                 {
                     foreach (T t in this)
                     {
                         t.Dispose();
                     }
 
-                    this.Clear();
+                    Clear();
                 }
             }
         }

--- a/src/WarriorRogueMage/Actions/Admin/CreateWeapon.cs
+++ b/src/WarriorRogueMage/Actions/Admin/CreateWeapon.cs
@@ -59,7 +59,7 @@ namespace WheelMUD.Actions.Temporary
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/WarriorRogueMage/Actions/Prompt.cs
+++ b/src/WarriorRogueMage/Actions/Prompt.cs
@@ -40,7 +40,7 @@ namespace WarriorRogueMage.Actions
                 // Save tail as player's new prompt
                 try
                 {
-                    this.playerBehavior.Prompt = actionInput.Tail;
+                    playerBehavior.Prompt = actionInput.Tail;
                 }
                 catch (Exception)
                 {
@@ -58,7 +58,7 @@ namespace WarriorRogueMage.Actions
             output.AppendFormat("{0}{1}{2}\n", "-----".PadRight(15), "-------------".PadRight(15), "-----------".PadRight(40));
 
             // Discover all methods with the promptable attribute in the adapter
-            foreach (var m in this.playerBehavior.GetType().GetMethods())
+            foreach (var m in playerBehavior.GetType().GetMethods())
             {
                 var promptAttr = m.GetCustomAttributes(typeof(PlayerPromptableAttribute), false);
                 if (promptAttr.Length > 0)
@@ -66,14 +66,14 @@ namespace WarriorRogueMage.Actions
                     var tokenInfo = (PlayerPromptableAttribute)promptAttr[0];
 
                     // Invoke the method to get current values
-                    var currentValue = (string)m.Invoke(this.playerBehavior, new object[] { });
+                    var currentValue = (string)m.Invoke(playerBehavior, new object[] { });
 
                     output.AppendFormat("{0}{1}{2}\n", tokenInfo.Token.PadRight(15), currentValue.PadRight(15), tokenInfo.Description.PadRight(40));
                 }
             }
 
-            output.AppendFormat("\nCurrent prompt is '{0}'\n", this.playerBehavior.Prompt);
-            output.AppendFormat("Parsed prompt is '{0}'\n", this.playerBehavior.BuildPrompt());
+            output.AppendFormat("\nCurrent prompt is '{0}'\n", playerBehavior.Prompt);
+            output.AppendFormat("Parsed prompt is '{0}'\n", playerBehavior.BuildPrompt());
             sender.Write(output.ToString());
         }
 
@@ -82,13 +82,13 @@ namespace WarriorRogueMage.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
             }
 
-            this.playerBehavior = actionInput.Controller.Thing.Behaviors.FindFirst<PlayerBehavior>();
+            playerBehavior = actionInput.Controller.Thing.Behaviors.FindFirst<PlayerBehavior>();
 
             return null;
         }

--- a/src/WarriorRogueMage/Actions/Spar.cs
+++ b/src/WarriorRogueMage/Actions/Spar.cs
@@ -53,7 +53,7 @@ namespace WarriorRogueMage.Actions
         /// <returns>An error message describing the failure for the user, or null if all guards pass.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;

--- a/src/WarriorRogueMage/Actions/Unwield.cs
+++ b/src/WarriorRogueMage/Actions/Unwield.cs
@@ -42,20 +42,20 @@ namespace WarriorRogueMage.Actions
         {
             IController sender = actionInput.Controller;
 
-            this.itemToUnwieldBehavior.Wielder = null;
+            itemToUnwieldBehavior.Wielder = null;
 
             // Remove the event handler that prevents dropping the item while wielded.
-            var interceptor = this.itemToUnwieldBehavior.MovementInterceptor;
-            this.itemToUnwield.Eventing.MovementRequest -= interceptor;
+            var interceptor = itemToUnwieldBehavior.MovementInterceptor;
+            itemToUnwield.Eventing.MovementRequest -= interceptor;
 
-            var contextMessage = new ContextualString(sender.Thing, this.itemToUnwield.Parent)
+            var contextMessage = new ContextualString(sender.Thing, itemToUnwield.Parent)
             {
-                ToOriginator = $"You unwield {this.itemToUnwield.Name}.",
-                ToOthers = $"{sender.Thing.Name} unwields {this.itemToUnwield.Name}.",
+                ToOriginator = $"You unwield {itemToUnwield.Name}.",
+                ToOthers = $"{sender.Thing.Name} unwields {itemToUnwield.Name}.",
             };
             var sensoryMessage = new SensoryMessage(SensoryType.Sight, 100, contextMessage);
 
-            var unwieldEvent = new WieldUnwieldEvent(this.itemToUnwield, true, sender.Thing, sensoryMessage);
+            var unwieldEvent = new WieldUnwieldEvent(itemToUnwield, true, sender.Thing, sensoryMessage);
 
             sender.Thing.Eventing.OnCombatRequest(unwieldEvent, EventScope.ParentsDown);
 
@@ -73,7 +73,7 @@ namespace WarriorRogueMage.Actions
             IController sender = actionInput.Controller;
             Thing wielder = sender.Thing;
 
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -84,19 +84,19 @@ namespace WarriorRogueMage.Actions
             // First look for a matching item in inventory and make sure it can
             // be wielded. If nothing was found in inventory, look for a matching
             // wieldable item in the surrounding environment.
-            this.itemToUnwield = wielder.FindChild(item => item.Name.ToLower() == itemName && item.HasBehavior<WieldableBehavior>() && item.Behaviors.FindFirst<WieldableBehavior>().Wielder == sender.Thing);
+            itemToUnwield = wielder.FindChild(item => item.Name.ToLower() == itemName && item.HasBehavior<WieldableBehavior>() && item.Behaviors.FindFirst<WieldableBehavior>().Wielder == sender.Thing);
 
-            if (this.itemToUnwield == null)
+            if (itemToUnwield == null)
             {
-                this.itemToUnwield = wielder.Parent.FindChild(item => item.Name.ToLower() == itemName && item.HasBehavior<WieldableBehavior>() && item.Behaviors.FindFirst<WieldableBehavior>().Wielder == sender.Thing);
+                itemToUnwield = wielder.Parent.FindChild(item => item.Name.ToLower() == itemName && item.HasBehavior<WieldableBehavior>() && item.Behaviors.FindFirst<WieldableBehavior>().Wielder == sender.Thing);
             }
 
-            if (this.itemToUnwield == null)
+            if (itemToUnwield == null)
             {
                 return "You are not wielding the " + itemName + ".";
             }
 
-            this.itemToUnwieldBehavior = this.itemToUnwield.Behaviors.FindFirst<WieldableBehavior>();
+            itemToUnwieldBehavior = itemToUnwield.Behaviors.FindFirst<WieldableBehavior>();
 
             return null;
         }

--- a/src/WarriorRogueMage/Actions/Wield.cs
+++ b/src/WarriorRogueMage/Actions/Wield.cs
@@ -42,25 +42,25 @@ namespace WarriorRogueMage.Actions
         {
             IController sender = actionInput.Controller;
 
-            this.itemToWieldBehavior.Wielder = sender.Thing;
+            itemToWieldBehavior.Wielder = sender.Thing;
 
             // Create an event handler that intercepts the ChangeOwnerEvent and
             // prevents dropping/trading the item around while it is wielded.
             // A reference is stored in the WieldableBehavior instance so it
             // can be easily removed by the unwield command.
-            var interceptor = new CancellableGameEventHandler(this.Eventing_MovementRequest);
-            this.itemToWieldBehavior.MovementInterceptor = interceptor;
-            this.itemToWield.Eventing.MovementRequest += interceptor;
+            var interceptor = new CancellableGameEventHandler(Eventing_MovementRequest);
+            itemToWieldBehavior.MovementInterceptor = interceptor;
+            itemToWield.Eventing.MovementRequest += interceptor;
 
-            var contextMessage = new ContextualString(sender.Thing, this.itemToWield.Parent)
+            var contextMessage = new ContextualString(sender.Thing, itemToWield.Parent)
             {
-                ToOriginator = $"You wield {this.itemToWield.Name}.",
-                ToOthers = $"{sender.Thing.Name} wields {this.itemToWield.Name}.",
+                ToOriginator = $"You wield {itemToWield.Name}.",
+                ToOthers = $"{sender.Thing.Name} wields {itemToWield.Name}.",
             };
 
             var sensoryMessage = new SensoryMessage(SensoryType.Sight, 100, contextMessage);
 
-            var wieldEvent = new WieldUnwieldEvent(this.itemToWield, true, sender.Thing, sensoryMessage);
+            var wieldEvent = new WieldUnwieldEvent(itemToWield, true, sender.Thing, sensoryMessage);
 
             sender.Thing.Eventing.OnCombatRequest(wieldEvent, EventScope.ParentsDown);
 
@@ -75,7 +75,7 @@ namespace WarriorRogueMage.Actions
         /// <returns>A string with the error message for the user upon guard failure, else null.</returns>
         public override string Guards(ActionInput actionInput)
         {
-            string commonFailure = this.VerifyCommonGuards(actionInput, ActionGuards);
+            string commonFailure = VerifyCommonGuards(actionInput, ActionGuards);
             if (commonFailure != null)
             {
                 return commonFailure;
@@ -94,15 +94,15 @@ namespace WarriorRogueMage.Actions
 
             if (itemInInventory != null)
             {
-                this.itemToWieldBehavior = itemInInventory.Behaviors.FindFirst<WieldableBehavior>();
+                itemToWieldBehavior = itemInInventory.Behaviors.FindFirst<WieldableBehavior>();
 
                 // Item was found in inventory, but it cannot be wielded.
-                if (this.itemToWieldBehavior == null)
+                if (itemToWieldBehavior == null)
                 {
                     return "This item cannot be wielded!";
                 }
 
-                this.itemToWield = itemInInventory;
+                itemToWield = itemInInventory;
             }
             else
             {
@@ -114,30 +114,30 @@ namespace WarriorRogueMage.Actions
                     return "Unable to find: " + itemName;
                 }
 
-                this.itemToWieldBehavior = itemInRoom.Behaviors.FindFirst<WieldableBehavior>();
+                itemToWieldBehavior = itemInRoom.Behaviors.FindFirst<WieldableBehavior>();
 
                 // Item was found in the room, but it cannot be wielded.
-                if (this.itemToWieldBehavior == null)
+                if (itemToWieldBehavior == null)
                 {
                     return "This item cannot be wielded!";
                 }
 
                 // Item was found in the room, but it must be picked up first.
-                if (this.itemToWieldBehavior.MustBeHeld)
+                if (itemToWieldBehavior.MustBeHeld)
                 {
                     return "You are not holding the " + itemInRoom.FullName + ".";
                 }
 
-                this.itemToWield = itemInRoom;
+                itemToWield = itemInRoom;
             }
 
             // Make sure the item is not already wielded by someone else.
             // This shouldn't happen (famous last words) if the item is in
             // inventory, but it could happen with stationary wieldable items
             // in the room.
-            if (this.itemToWieldBehavior.Wielder != null)
+            if (itemToWieldBehavior.Wielder != null)
             {
-                return string.Format("The {0} is already wielded by {1}.", this.itemToWield.Name, this.itemToWieldBehavior.Wielder.FullName);
+                return string.Format("The {0} is already wielded by {1}.", itemToWield.Name, itemToWieldBehavior.Wielder.FullName);
             }
 
             return null;
@@ -152,9 +152,9 @@ namespace WarriorRogueMage.Actions
             var evt = e as ChangeOwnerEvent;
             if (evt != null)
             {
-                if (evt.Thing.Id == this.itemToWield.Id)
+                if (evt.Thing.Id == itemToWield.Id)
                 {
-                    evt.Cancel(string.Format("The {0} is still wielded!", this.itemToWield.Name));
+                    evt.Cancel(string.Format("The {0} is still wielded!", itemToWield.Name));
                 }
             }
         }

--- a/src/WarriorRogueMage/Behaviors/SkillsBehavior.cs
+++ b/src/WarriorRogueMage/Behaviors/SkillsBehavior.cs
@@ -20,26 +20,26 @@ namespace WarriorRogueMage.Behaviors
         public SkillsBehavior(Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ManagedSkills = new List<WRMSkill>();
+            ManagedSkills = new List<WRMSkill>();
         }
 
         /// <summary>Gets or sets the list of active skills.</summary>
         /// <value>The active skills.</value>
         public List<WRMSkill> ManagedSkills { get; set; }
 
-        /// <summary>Called when a parent has just been assigned to this behavior. (Refer to this.Parent)</summary>
+        /// <summary>Called when a parent has just been assigned to this behavior. (Refer to Parent)</summary>
         protected override void OnAddBehavior()
         {
             // When adding this behavior to a Thing, register relevant movement events so we can cancel
             // the movement of anything through our parent Thing while our parent Thing is "closed".
-            var parent = this.Parent;
+            var parent = Parent;
             if (parent != null)
             {
-                foreach (var managedSkill in this.ManagedSkills)
+                foreach (var managedSkill in ManagedSkills)
                 {
                     if (managedSkill.PlayerThing == null)
                     {
-                        managedSkill.PlayerThing = this.Parent;
+                        managedSkill.PlayerThing = Parent;
                     }
                 }
             }
@@ -47,13 +47,13 @@ namespace WarriorRogueMage.Behaviors
             base.OnAddBehavior();
         }
 
-        /// <summary>Called when the current parent of this behavior is about to be removed. (Refer to this.Parent)</summary>
+        /// <summary>Called when the current parent of this behavior is about to be removed. (Refer to Parent)</summary>
         protected override void OnRemoveBehavior()
         {
-            var parent = this.Parent;
+            var parent = Parent;
             if (parent != null)
             {
-                foreach (var managedSkill in this.ManagedSkills)
+                foreach (var managedSkill in ManagedSkills)
                 {
                     managedSkill.PlayerThing = null;
                 }
@@ -67,19 +67,19 @@ namespace WarriorRogueMage.Behaviors
         /// <returns>The first managed skill of the specified type, if found, else null.</returns>
         public U FindFirst<U>() where U : WRMSkill
         {
-            return this.ManagedSkills.OfType<U>().FirstOrDefault();
+            return ManagedSkills.OfType<U>().FirstOrDefault();
         }
 
         /// <summary>Add a new skill to the list of managed talents.</summary>
         /// <param name="newTalent">The new skill to add.</param>
         public void Add(WRMSkill newTalent)
         {
-            lock (this.ManagedSkills)
+            lock (ManagedSkills)
             {
-                if (!this.ManagedSkills.Contains(newTalent))
+                if (!ManagedSkills.Contains(newTalent))
                 {
-                    this.ManagedSkills.Add(newTalent);
-                    newTalent.PlayerThing = this.Parent;
+                    ManagedSkills.Add(newTalent);
+                    newTalent.PlayerThing = Parent;
                     newTalent.OnAddSkill();
                 }
             }
@@ -89,11 +89,11 @@ namespace WarriorRogueMage.Behaviors
         /// <param name="talent">The skill to remove.</param>
         public void Remove(WRMSkill talent)
         {
-            lock (this.ManagedSkills)
+            lock (ManagedSkills)
             {
-                if (this.ManagedSkills.Contains(talent))
+                if (ManagedSkills.Contains(talent))
                 {
-                    this.ManagedSkills.Remove(talent);
+                    ManagedSkills.Remove(talent);
                     talent.OnRemoveSkill();
                     talent.PlayerThing = null;
                 }

--- a/src/WarriorRogueMage/Behaviors/TalentsBehavior.cs
+++ b/src/WarriorRogueMage/Behaviors/TalentsBehavior.cs
@@ -18,27 +18,27 @@ namespace WarriorRogueMage.Behaviors
         /// <param name="instanceProperties">Dictionary of properties to spawn this behavior instance with, if any.</param>
         public TalentsBehavior(Dictionary<string, object> instanceProperties) : base(instanceProperties)
         {
-            this.ManagedTalents = new List<Talent>();
+            ManagedTalents = new List<Talent>();
         }
 
         /// <summary>Gets or sets the list of active talents.</summary>
         public List<Talent> ManagedTalents { get; set; }
 
-        /// <summary>Called when a parent has just been assigned to this behavior. (Refer to this.Parent)</summary>
+        /// <summary>Called when a parent has just been assigned to this behavior. (Refer to Parent)</summary>
         protected override void OnAddBehavior()
         {
             // When adding this behavior to a Thing, register relevant movement events so we can cancel
             // the movement of anything through our parent Thing while our parent Thing is "closed".
-            var parent = this.Parent;
+            var parent = Parent;
             if (parent != null)
             {
                 // This is to handle the case when talents have been added to the behavior
                 // before it being added to a thing.
-                foreach (var managedTalent in this.ManagedTalents)
+                foreach (var managedTalent in ManagedTalents)
                 {
                     if (managedTalent.PlayerThing == null)
                     {
-                        managedTalent.PlayerThing = this.Parent;
+                        managedTalent.PlayerThing = Parent;
                     }
                 }
             }
@@ -46,15 +46,15 @@ namespace WarriorRogueMage.Behaviors
             base.OnAddBehavior();
         }
 
-        /// <summary>Called when the current parent of this behavior is about to be removed. (Refer to this.Parent.)</summary>
+        /// <summary>Called when the current parent of this behavior is about to be removed. (Refer to Parent.)</summary>
         protected override void OnRemoveBehavior()
         {
-            var parent = this.Parent;
+            var parent = Parent;
             if (parent != null)
             {
                 // Make sure to "unhook" all children talents from the player Thing object.
                 // Otherwise we could have a memory leak, and/or weird errors.
-                foreach (var managedTalent in this.ManagedTalents)
+                foreach (var managedTalent in ManagedTalents)
                 {
                     managedTalent.PlayerThing = null;
                 }
@@ -68,19 +68,19 @@ namespace WarriorRogueMage.Behaviors
         /// <returns>The first managed talent of the specified type, if found, else null.</returns>
         public U FindFirst<U>() where U : Talent
         {
-            return this.ManagedTalents.OfType<U>().FirstOrDefault();
+            return ManagedTalents.OfType<U>().FirstOrDefault();
         }
 
         /// <summary>Add a new talent to the list of managed talents.</summary>
         /// <param name="newTalent">The new talent to add.</param>
         public void AddTalent(Talent newTalent)
         {
-            lock (this.ManagedTalents)
+            lock (ManagedTalents)
             {
-                if (!this.ManagedTalents.Contains(newTalent))
+                if (!ManagedTalents.Contains(newTalent))
                 {
-                    this.ManagedTalents.Add(newTalent);
-                    newTalent.PlayerThing = this.Parent;
+                    ManagedTalents.Add(newTalent);
+                    newTalent.PlayerThing = Parent;
                     newTalent.OnAddTalent();
                 }
             }
@@ -90,11 +90,11 @@ namespace WarriorRogueMage.Behaviors
         /// <param name="talent">The talent to remove.</param>
         public void RemoveTalent(Talent talent)
         {
-            lock (this.ManagedTalents)
+            lock (ManagedTalents)
             {
-                if (this.ManagedTalents.Contains(talent))
+                if (ManagedTalents.Contains(talent))
                 {
-                    this.ManagedTalents.Remove(talent);
+                    ManagedTalents.Remove(talent);
                     talent.OnRemoveTalent();
                     talent.PlayerThing = null;
                 }

--- a/src/WarriorRogueMage/Behaviors/WRMPlayerBehavior.cs
+++ b/src/WarriorRogueMage/Behaviors/WRMPlayerBehavior.cs
@@ -18,7 +18,7 @@ namespace WarriorRogueMage.Behaviors
         [PlayerPromptable("%FATE%", "Displays your current Fate.")]
         public string GetCurrentFate()
         {
-            return this.Parent.Stats["FATE"].Value.ToString();
+            return Parent.Stats["FATE"].Value.ToString();
         }
 
         /// <summary>Builds the prompt string for this player.</summary>
@@ -28,7 +28,7 @@ namespace WarriorRogueMage.Behaviors
             return "WRM> ";
             /* TODO: Allow for player-customized prompts...
             // Returns a string with the %tokens% replaced with appropriate values
-            string prompt = this.Prompt;
+            string prompt = Prompt;
 
             if (prompt != null && prompt.Contains("%"))  // Quick check, we can skip parsing if we have no chance of tokens
             {

--- a/src/WarriorRogueMage/Behaviors/WieldableBehavior.cs
+++ b/src/WarriorRogueMage/Behaviors/WieldableBehavior.cs
@@ -30,7 +30,7 @@ namespace WarriorRogueMage.Behaviors
         public WieldableBehavior(long instanceID, Dictionary<string, object> instanceProperties)
             : base(instanceProperties)
         {
-            this.ID = instanceID;
+            ID = instanceID;
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace WarriorRogueMage.Behaviors
         /// <summary>Sets the default properties of this behavior instance.</summary>
         protected override void SetDefaultProperties()
         {
-            this.MustBeHeld = true;
+            MustBeHeld = true;
         }
     }
 }

--- a/src/WarriorRogueMage/CharacterCreation/PickGenderState.cs
+++ b/src/WarriorRogueMage/CharacterCreation/PickGenderState.cs
@@ -23,20 +23,20 @@ namespace WarriorRogueMage.CharacterCreation
         public PickGenderState(Session session)
             : base(session)
         {
-            this.RefreshScreen(false);
+            RefreshScreen(false);
         }
 
         /// <summary>ProcessInput is used to receive the user input during this state.</summary>
         /// <param name="command">The command text to be processed.</param>
         public override void ProcessInput(string command)
         {
-            if (!string.IsNullOrEmpty(command) && this.SetGender(command))
+            if (!string.IsNullOrEmpty(command) && SetGender(command))
             {
-                this.ProcessDone();
+                ProcessDone();
             }
-            else if (!this.HandleCommand(command))
+            else if (!HandleCommand(command))
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "Invalid command. Please select a gender.");
+                WrmChargenCommon.SendErrorMessage(Session, "Invalid command. Please select a gender.");
             }
         }
 
@@ -57,28 +57,28 @@ namespace WarriorRogueMage.CharacterCreation
             // Support strings of format "select m" and "m" by ignoring "select " from the input.
             string currentGender = specifiedGender.Replace("select ", string.Empty);
 
-            this.selectedGender = (from g in GameSystemController.Instance.GameGenders
-                                   where g.Name.Equals(currentGender, StringComparison.CurrentCultureIgnoreCase) ||
-                                         g.Abbreviation.Equals(currentGender, StringComparison.CurrentCultureIgnoreCase)
-                                   select g).FirstOrDefault();
-            if (this.selectedGender == null)
+            selectedGender = (from g in GameSystemController.Instance.GameGenders
+                              where g.Name.Equals(currentGender, StringComparison.CurrentCultureIgnoreCase) ||
+                                    g.Abbreviation.Equals(currentGender, StringComparison.CurrentCultureIgnoreCase)
+                              select g).FirstOrDefault();
+            if (selectedGender == null)
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, string.Format("'{0}' is an invalid gender selection.", currentGender));
-                this.RefreshScreen();
+                WrmChargenCommon.SendErrorMessage(Session, string.Format("'{0}' is an invalid gender selection.", currentGender));
+                RefreshScreen();
             }
 
-            return this.selectedGender != null;
+            return selectedGender != null;
         }
 
         private void ProcessDone()
         {
-            var playerBehavior = this.Session.Thing.Behaviors.FindFirst<PlayerBehavior>();
-            playerBehavior.Gender = this.selectedGender;
-            string doneMessage = string.Format("<%green%>The chosen gender is {0}.<%n%>" + Environment.NewLine, this.selectedGender.Name);
-            this.Session.Write(doneMessage, false);
+            var playerBehavior = Session.Thing.Behaviors.FindFirst<PlayerBehavior>();
+            playerBehavior.Gender = selectedGender;
+            string doneMessage = string.Format("<%green%>The chosen gender is {0}.<%n%>" + Environment.NewLine, selectedGender.Name);
+            Session.Write(doneMessage, false);
 
             // Proceed to the next step.
-            this.StateMachine.HandleNextStep(this, StepStatus.Success);
+            StateMachine.HandleNextStep(this, StepStatus.Success);
         }
 
         private void RefreshScreen(bool sendPrompt = true)
@@ -98,7 +98,7 @@ namespace WarriorRogueMage.CharacterCreation
             sb.AppendLine("Type your gender selection.");
             sb.AppendLine("===============================================================<%n%>");
 
-            this.Session.Write(sb.ToString(), sendPrompt);
+            Session.Write(sb.ToString(), sendPrompt);
         }
     }
 }

--- a/src/WarriorRogueMage/CharacterCreation/PickRaceState.cs
+++ b/src/WarriorRogueMage/CharacterCreation/PickRaceState.cs
@@ -29,10 +29,10 @@ namespace WarriorRogueMage.CharacterCreation
         public PickRaceState(Session session)
             : base(session)
         {
-            this.Session.Write("You will now pick your character's race.");
-            this.gameRaces = GameSystemController.Instance.GameRaces;
-            this.FormatRaceText();
-            this.RefreshScreen(false);
+            Session.Write("You will now pick your character's race.");
+            gameRaces = GameSystemController.Instance.GameRaces;
+            FormatRaceText();
+            RefreshScreen(false);
         }
 
         /// <summary>ProcessInput is used to receive the user input during this state.</summary>
@@ -44,22 +44,22 @@ namespace WarriorRogueMage.CharacterCreation
             switch (currentCommand)
             {
                 case "view":
-                    this.ViewRaceDescription(currentCommand);
+                    ViewRaceDescription(currentCommand);
                     break;
                 case "list":
-                    this.RefreshScreen();
+                    RefreshScreen();
                     break;
                 default:
-                    var race = this.GetRace(currentCommand);
+                    var race = GetRace(currentCommand);
                     if (race != null)
                     {
-                        var playerBehavior = this.Session.Thing.Behaviors.FindFirst<PlayerBehavior>();
+                        var playerBehavior = Session.Thing.Behaviors.FindFirst<PlayerBehavior>();
                         playerBehavior.Race = race;
-                        this.StateMachine.HandleNextStep(this, StepStatus.Success);
+                        StateMachine.HandleNextStep(this, StepStatus.Success);
                     }
                     else
                     {
-                        WrmChargenCommon.SendErrorMessage(this.Session, "Invalid race. Try again, or use 'view [race]' or 'list'.");
+                        WrmChargenCommon.SendErrorMessage(Session, "Invalid race. Try again, or use 'view [race]' or 'list'.");
                     }
                     break;
             }
@@ -84,7 +84,7 @@ namespace WarriorRogueMage.CharacterCreation
 
             string properCaseRace = textInfo.ToTitleCase(raceToView);
 
-            var foundRace = (from r in this.gameRaces
+            var foundRace = (from r in gameRaces
                              where r.Name == properCaseRace
                              select r).FirstOrDefault();
 
@@ -97,11 +97,11 @@ namespace WarriorRogueMage.CharacterCreation
                 sb.Append("<%b%><%white%>" + foundRace.Description + Environment.NewLine);
                 sb.Append("<%b%><%yellow%>=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=<%n%>");
 
-                this.Session.Write(sb.ToString());
+                Session.Write(sb.ToString());
             }
             else
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "That race does not exist.");
+                WrmChargenCommon.SendErrorMessage(Session, "That race does not exist.");
             }
         }
 
@@ -109,14 +109,14 @@ namespace WarriorRogueMage.CharacterCreation
         {
             var raceQueue = new Queue<GameRace>();
             var text = new StringBuilder();
-            int rows = this.gameRaces.Count / 4;
+            int rows = gameRaces.Count / 4;
 
-            foreach (var gameRace in this.gameRaces)
+            foreach (var gameRace in gameRaces)
             {
                 // Find out what skill name is the longest
-                if (gameRace.Name.Length > this.longestRaceName)
+                if (gameRace.Name.Length > longestRaceName)
                 {
-                    this.longestRaceName = gameRace.Name.Length;
+                    longestRaceName = gameRace.Name.Length;
                 }
 
                 raceQueue.Enqueue(gameRace);
@@ -126,32 +126,32 @@ namespace WarriorRogueMage.CharacterCreation
             {
                 for (int i = 0; i < rows; i++)
                 {
-                    string race1 = WrmChargenCommon.FormatToColumn(this.longestRaceName, raceQueue.Dequeue().Name);
-                    string race2 = WrmChargenCommon.FormatToColumn(this.longestRaceName, raceQueue.Dequeue().Name);
-                    string race3 = WrmChargenCommon.FormatToColumn(this.longestRaceName, raceQueue.Dequeue().Name);
-                    string race4 = WrmChargenCommon.FormatToColumn(this.longestRaceName, raceQueue.Dequeue().Name);
+                    string race1 = WrmChargenCommon.FormatToColumn(longestRaceName, raceQueue.Dequeue().Name);
+                    string race2 = WrmChargenCommon.FormatToColumn(longestRaceName, raceQueue.Dequeue().Name);
+                    string race3 = WrmChargenCommon.FormatToColumn(longestRaceName, raceQueue.Dequeue().Name);
+                    string race4 = WrmChargenCommon.FormatToColumn(longestRaceName, raceQueue.Dequeue().Name);
                     text.AppendFormat("{0}  {1}  {2}  {3}" + Environment.NewLine, race1, race2, race3, race4);
                 }
 
-                if ((this.gameRaces.Count % 4) > 0)
+                if ((gameRaces.Count % 4) > 0)
                 {
-                    int columns = this.gameRaces.Count - (rows * 4);
+                    int columns = gameRaces.Count - (rows * 4);
 
                     switch (columns)
                     {
                         case 1:
-                            string racecolumn1 = WrmChargenCommon.FormatToColumn(this.longestRaceName, raceQueue.Dequeue().Name);
+                            string racecolumn1 = WrmChargenCommon.FormatToColumn(longestRaceName, raceQueue.Dequeue().Name);
                             text.AppendFormat("{0}" + Environment.NewLine, racecolumn1);
                             break;
                         case 2:
-                            string rc = WrmChargenCommon.FormatToColumn(this.longestRaceName, raceQueue.Dequeue().Name);
-                            string rcc1 = WrmChargenCommon.FormatToColumn(this.longestRaceName, raceQueue.Dequeue().Name);
+                            string rc = WrmChargenCommon.FormatToColumn(longestRaceName, raceQueue.Dequeue().Name);
+                            string rcc1 = WrmChargenCommon.FormatToColumn(longestRaceName, raceQueue.Dequeue().Name);
                             text.AppendFormat("{0}  {1}" + Environment.NewLine, rc, rcc1);
                             break;
                         case 3:
-                            string rc1 = WrmChargenCommon.FormatToColumn(this.longestRaceName, raceQueue.Dequeue().Name);
-                            string rc2 = WrmChargenCommon.FormatToColumn(this.longestRaceName, raceQueue.Dequeue().Name);
-                            string rc3 = WrmChargenCommon.FormatToColumn(this.longestRaceName, raceQueue.Dequeue().Name);
+                            string rc1 = WrmChargenCommon.FormatToColumn(longestRaceName, raceQueue.Dequeue().Name);
+                            string rc2 = WrmChargenCommon.FormatToColumn(longestRaceName, raceQueue.Dequeue().Name);
+                            string rc3 = WrmChargenCommon.FormatToColumn(longestRaceName, raceQueue.Dequeue().Name);
                             text.AppendFormat("{0}  {1}  {2}" + Environment.NewLine, rc1, rc2, rc3);
                             break;
                     }
@@ -163,7 +163,7 @@ namespace WarriorRogueMage.CharacterCreation
 
             text.Append(Environment.NewLine);
 
-            this.formattedRaces = text.ToString();
+            formattedRaces = text.ToString();
         }
 
         private string GetCommardPart(string command)
@@ -188,14 +188,14 @@ namespace WarriorRogueMage.CharacterCreation
             sb.AppendLine();
             sb.AppendLine();
             sb.AppendLine("<%green%>Please select 1 from the list below:<%n%>");
-            sb.AppendLine(this.formattedRaces);
+            sb.AppendLine(formattedRaces);
             sb.AppendLine("<%yellow%>=========================================================================");
             sb.AppendLine("To pick a race, just type the race's name. Example: human");
             sb.AppendLine("To view a races's description use the view command. Example: view orc");
             sb.AppendLine("To see this screen again type 'list'.");
             sb.AppendLine("=========================================================================<%n%>");
 
-            this.Session.Write(sb.ToString(), sendPrompt);
+            Session.Write(sb.ToString(), sendPrompt);
         }
     }
 }

--- a/src/WarriorRogueMage/CharacterCreation/PickSkillsState.cs
+++ b/src/WarriorRogueMage/CharacterCreation/PickSkillsState.cs
@@ -27,10 +27,10 @@ namespace WarriorRogueMage.CharacterCreation
         public PickSkillsState(Session session)
             : base(session)
         {
-            this.Session.Write("You will now pick your character's starting skills.");
-            this.gameSkills = GameSystemController.Instance.GameSkills;
-            this.formattedSkills = this.FormatSkillText();
-            this.RefreshScreen(false);
+            Session.Write("You will now pick your character's starting skills.");
+            gameSkills = GameSystemController.Instance.GameSkills;
+            formattedSkills = FormatSkillText();
+            RefreshScreen(false);
         }
 
         /// <summary>Processes the text that the player sends while in this state.</summary>
@@ -42,26 +42,26 @@ namespace WarriorRogueMage.CharacterCreation
             switch (currentCommand)
             {
                 case "clear":
-                    this.ClearSkills();
+                    ClearSkills();
                     break;
                 case "view":
                     if (commandParts.Length > 1)
                     {
-                        this.ViewSkillDescription(commandParts[1]);
+                        ViewSkillDescription(commandParts[1]);
                     }
                     else
                     {
-                        WrmChargenCommon.SendErrorMessage(this.Session, "Please select which skill you would like to view details for, like 'view axes'.");
+                        WrmChargenCommon.SendErrorMessage(Session, "Please select which skill you would like to view details for, like 'view axes'.");
                     }
                     break;
                 case "list":
-                    this.RefreshScreen();
+                    RefreshScreen();
                     break;
                 case "done":
-                    this.ProcessDone();
+                    ProcessDone();
                     break;
                 default:
-                    this.SetSkill(currentCommand);
+                    SetSkill(currentCommand);
                     break;
             }
         }
@@ -81,33 +81,33 @@ namespace WarriorRogueMage.CharacterCreation
             var selectedSkill = GetSkill(skillName);
             if (selectedSkill == null)
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "That skill does not exist.");
+                WrmChargenCommon.SendErrorMessage(Session, "That skill does not exist.");
                 return false;
             }
 
             if (selectedSkills.Contains(selectedSkill))
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "You have already selected that skill.");
+                WrmChargenCommon.SendErrorMessage(Session, "You have already selected that skill.");
                 return false;
             }
 
-            if (this.selectedSkills.Count() >= 3)
+            if (selectedSkills.Count() >= 3)
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "You have already selected all 3 skills.");
+                WrmChargenCommon.SendErrorMessage(Session, "You have already selected all 3 skills.");
                 return false;
             }
 
-            this.selectedSkills.Add(selectedSkill);
-            this.RefreshScreen();
-            this.Session.WritePrompt();
+            selectedSkills.Add(selectedSkill);
+            RefreshScreen();
+            Session.WritePrompt();
             return true;
         }
 
         private void ClearSkills()
         {
-            this.selectedSkills.Clear();
-            this.RefreshScreen();
-            this.Session.WritePrompt();
+            selectedSkills.Clear();
+            RefreshScreen();
+            Session.WritePrompt();
         }
 
         private void ViewSkillDescription(string skillName)
@@ -115,7 +115,7 @@ namespace WarriorRogueMage.CharacterCreation
             GameSkill foundSkill = GetSkill(skillName);
             if (foundSkill == null)
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "That skill does not exist.");
+                WrmChargenCommon.SendErrorMessage(Session, "That skill does not exist.");
                 return;
             }
 
@@ -126,36 +126,36 @@ namespace WarriorRogueMage.CharacterCreation
             sb.Append("<%b%><%white%>" + foundSkill.Description + Environment.NewLine);
             sb.Append("<%b%><%yellow%>=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=<%n%>");
 
-            this.Session.Write(sb.ToString());
+            Session.Write(sb.ToString());
         }
 
         private void ProcessDone()
         {
-            if (this.selectedSkills.Count() != 3)
+            if (selectedSkills.Count() != 3)
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "Please select all your starting skills before proceeding to the next step.");
+                WrmChargenCommon.SendErrorMessage(Session, "Please select all your starting skills before proceeding to the next step.");
                 return;
             }
 
             // Assign the skills to the PlayerBehavior's parent, which should be a Thing object.
-            var playerBehavior = this.Session.Thing.Behaviors.FindFirst<PlayerBehavior>();
-            foreach (var gameSkill in this.selectedSkills)
+            var playerBehavior = Session.Thing.Behaviors.FindFirst<PlayerBehavior>();
+            foreach (var gameSkill in selectedSkills)
             {
                 playerBehavior.Parent.Skills.Add(gameSkill.Name, gameSkill);
             }
 
             // Proceed to the next step.
-            this.StateMachine.HandleNextStep(this, StepStatus.Success);
+            StateMachine.HandleNextStep(this, StepStatus.Success);
         }
 
         private string FormatSkillText()
         {
             var skillQueue = new Queue();
             var text = new StringBuilder();
-            int rows = this.gameSkills.Count / 4;
+            int rows = gameSkills.Count / 4;
             var longestSkillName = 0;
 
-            foreach (var gameSkill in this.gameSkills)
+            foreach (var gameSkill in gameSkills)
             {
                 // Find out what skill name is the longest
                 if (gameSkill.Name.Length > longestSkillName)
@@ -176,9 +176,9 @@ namespace WarriorRogueMage.CharacterCreation
                 text.AppendFormat("{0}  {1}  {2}  {3}" + Environment.NewLine, skill1, skill2, skill3, skill4);
             }
 
-            if ((this.gameSkills.Count % 4) > 0)
+            if ((gameSkills.Count % 4) > 0)
             {
-                int columns = this.gameSkills.Count - (rows * 4);
+                int columns = gameSkills.Count - (rows * 4);
                 switch (columns)
                 {
                     case 1:
@@ -211,15 +211,15 @@ namespace WarriorRogueMage.CharacterCreation
             sb.AppendLine();
             sb.AppendLine("You may pick three starting skills for your character.");
             int n = 1;
-            foreach (var skill in this.selectedSkills)
+            foreach (var skill in selectedSkills)
             {
                 sb.AppendFormat("Skill #{0} : {1}{2}", n, skill.Name, nl);
                 n++;
             }
             sb.AppendLine();
             sb.AppendLine("<%green%>Please select 3 from the list below:<%n%>");
-            sb.AppendLine(this.formattedSkills);
-            sb.AppendFormat("<%green%>You have {0} skills left.<%n%>" + Environment.NewLine, 3 - this.selectedSkills.Count());
+            sb.AppendLine(formattedSkills);
+            sb.AppendFormat("<%green%>You have {0} skills left.<%n%>" + Environment.NewLine, 3 - selectedSkills.Count());
             sb.AppendLine("<%yellow%>=========================================================================");
             sb.AppendLine("To pick a skill, type the skill's name. Example: unarmed");
             sb.AppendLine("To view a skill's description use the view command. Example: view unarmed");
@@ -227,7 +227,7 @@ namespace WarriorRogueMage.CharacterCreation
             sb.AppendLine("When you are done picking your three skills, type done.");
             sb.AppendLine("=========================================================================<%n%>");
 
-            this.Session.Write(sb.ToString(), sendPrompt);
+            Session.Write(sb.ToString(), sendPrompt);
         }
     }
 }

--- a/src/WarriorRogueMage/CharacterCreation/PickTalentsState.cs
+++ b/src/WarriorRogueMage/CharacterCreation/PickTalentsState.cs
@@ -25,10 +25,10 @@ namespace WarriorRogueMage.CharacterCreation
         public PickTalentsState(Session session)
             : base(session)
         {
-            this.Session.Write("You will now pick your character's starting talent.");
-            this.talents = TalentFinder.Instance.NormalTalents;
-            this.formattedTalents = this.FormatTalentText();
-            this.RefreshScreen(false);
+            Session.Write("You will now pick your character's starting talent.");
+            talents = TalentFinder.Instance.NormalTalents;
+            formattedTalents = FormatTalentText();
+            RefreshScreen(false);
         }
 
         /// <summary>ProcessInput is used to receive the user input during this state.</summary>
@@ -43,26 +43,26 @@ namespace WarriorRogueMage.CharacterCreation
                     if (commandParts.Length > 1)
                     {
                         string talentName = string.Join(" ", commandParts, 1, commandParts.Length - 1);
-                        this.ViewTalentDescription(talentName);
+                        ViewTalentDescription(talentName);
                     }
                     else
                     {
-                        WrmChargenCommon.SendErrorMessage(this.Session, "Please select which talent you would like to view details for, like 'view sailor'.");
+                        WrmChargenCommon.SendErrorMessage(Session, "Please select which talent you would like to view details for, like 'view sailor'.");
                     }
                     break;
                 case "list":
-                    this.RefreshScreen();
+                    RefreshScreen();
                     break;
                 default:
-                    var talent = this.GetTalent(currentCommand);
+                    var talent = GetTalent(currentCommand);
                     if (talent != null)
                     {
                         // TODO: Save talent to a WRM-specific Behavior?
-                        this.StateMachine.HandleNextStep(this, StepStatus.Success);
+                        StateMachine.HandleNextStep(this, StepStatus.Success);
                     }
                     else
                     {
-                        WrmChargenCommon.SendErrorMessage(this.Session, "Invalid talent. Try again, or use 'view [talent]' or 'list'.");
+                        WrmChargenCommon.SendErrorMessage(Session, "Invalid talent. Try again, or use 'view [talent]' or 'list'.");
                     }
                     break;
             }
@@ -90,11 +90,11 @@ namespace WarriorRogueMage.CharacterCreation
                 sb.Append("<%b%><%white%>" + foundTalent.Description + Environment.NewLine);
                 sb.Append("<%b%><%yellow%>=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=<%n%>");
 
-                this.Session.Write(sb.ToString());
+                Session.Write(sb.ToString());
             }
             else
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "That talent does not exist.");
+                WrmChargenCommon.SendErrorMessage(Session, "That talent does not exist.");
             }
         }
 
@@ -103,27 +103,27 @@ namespace WarriorRogueMage.CharacterCreation
             var talentQueue = new Queue<Talent>();
             var text = new StringBuilder();
 
-            foreach (var gameTalent in this.talents)
+            foreach (var gameTalent in talents)
             {
                 // Find out what talent name is the longest
-                if (gameTalent.Name.Length > this.longestTalentName)
+                if (gameTalent.Name.Length > longestTalentName)
                 {
-                    this.longestTalentName = gameTalent.Name.Length;
+                    longestTalentName = gameTalent.Name.Length;
                 }
 
                 talentQueue.Enqueue(gameTalent);
             }
 
-            int rows = this.talents.Count / 4;
+            int rows = talents.Count / 4;
 
             try
             {
                 for (int i = 0; i < rows; i++)
                 {
-                    string talent1 = WrmChargenCommon.FormatToColumn(this.longestTalentName, talentQueue.Dequeue().Name);
-                    string talent2 = WrmChargenCommon.FormatToColumn(this.longestTalentName, talentQueue.Dequeue().Name);
-                    string talent3 = WrmChargenCommon.FormatToColumn(this.longestTalentName, talentQueue.Dequeue().Name);
-                    string talent4 = WrmChargenCommon.FormatToColumn(this.longestTalentName, talentQueue.Dequeue().Name);
+                    string talent1 = WrmChargenCommon.FormatToColumn(longestTalentName, talentQueue.Dequeue().Name);
+                    string talent2 = WrmChargenCommon.FormatToColumn(longestTalentName, talentQueue.Dequeue().Name);
+                    string talent3 = WrmChargenCommon.FormatToColumn(longestTalentName, talentQueue.Dequeue().Name);
+                    string talent4 = WrmChargenCommon.FormatToColumn(longestTalentName, talentQueue.Dequeue().Name);
                     text.AppendFormat("{0}  {1}  {2}  {3}" + Environment.NewLine, talent1, talent2, talent3, talent4);
                 }
 
@@ -134,18 +134,18 @@ namespace WarriorRogueMage.CharacterCreation
                     switch (columns)
                     {
                         case 1:
-                            string talentcolumn1 = WrmChargenCommon.FormatToColumn(this.longestTalentName, talentQueue.Dequeue().Name);
+                            string talentcolumn1 = WrmChargenCommon.FormatToColumn(longestTalentName, talentQueue.Dequeue().Name);
                             text.AppendFormat("{0}" + Environment.NewLine, talentcolumn1);
                             break;
                         case 2:
-                            string tk1 = WrmChargenCommon.FormatToColumn(this.longestTalentName, talentQueue.Dequeue().Name);
-                            string tk2 = WrmChargenCommon.FormatToColumn(this.longestTalentName, talentQueue.Dequeue().Name);
+                            string tk1 = WrmChargenCommon.FormatToColumn(longestTalentName, talentQueue.Dequeue().Name);
+                            string tk2 = WrmChargenCommon.FormatToColumn(longestTalentName, talentQueue.Dequeue().Name);
                             text.AppendFormat("{0}  {1}" + Environment.NewLine, tk1, tk2);
                             break;
                         case 3:
-                            string tkl1 = WrmChargenCommon.FormatToColumn(this.longestTalentName, talentQueue.Dequeue().Name);
-                            string tkl2 = WrmChargenCommon.FormatToColumn(this.longestTalentName, talentQueue.Dequeue().Name);
-                            string tkl3 = WrmChargenCommon.FormatToColumn(this.longestTalentName, talentQueue.Dequeue().Name);
+                            string tkl1 = WrmChargenCommon.FormatToColumn(longestTalentName, talentQueue.Dequeue().Name);
+                            string tkl2 = WrmChargenCommon.FormatToColumn(longestTalentName, talentQueue.Dequeue().Name);
+                            string tkl3 = WrmChargenCommon.FormatToColumn(longestTalentName, talentQueue.Dequeue().Name);
                             text.AppendFormat("{0}  {1}  {2}" + Environment.NewLine, tkl1, tkl2, tkl3);
                             break;
                     }
@@ -166,13 +166,13 @@ namespace WarriorRogueMage.CharacterCreation
             sb.AppendLine();
             sb.AppendLine("You may pick one starting talent for your character.");
             sb.AppendLine("<%green%>Please select 1 from the list below:<%n%>");
-            sb.AppendLine(this.formattedTalents);
+            sb.AppendLine(formattedTalents);
             sb.AppendLine("<%yellow%>==========================================================================");
             sb.AppendLine("To pick a talent, type the talent's name. Example: sailor");
             sb.AppendLine("To view a talent's description use the view command. Example: view sailor");
             sb.AppendLine("To see this screen again type list.");
             sb.AppendLine("==========================================================================<%n%>");
-            this.Session.Write(sb.ToString(), sendPrompt);
+            Session.Write(sb.ToString(), sendPrompt);
         }
     }
 }

--- a/src/WarriorRogueMage/CharacterCreation/SetAttributesState.cs
+++ b/src/WarriorRogueMage/CharacterCreation/SetAttributesState.cs
@@ -46,52 +46,52 @@ namespace WarriorRogueMage.CharacterCreation
         public SetAttributesState(Session session)
             : base(session)
         {
-            this.Session.Write("You will now set your basic attributes.\n\n", false);
-            this.RefreshScreen(false);
+            Session.Write("You will now set your basic attributes.\n\n", false);
+            RefreshScreen(false);
         }
 
         /// <summary>Gets the total points spent so far by the character.</summary>
         private int SpentPoints
         {
-            get { return this.warriorPoints + this.roguePoints + this.magePoints; }
+            get { return warriorPoints + roguePoints + magePoints; }
         }
 
         /// <summary>Processes the text that the player sends while in this state.</summary>
         /// <param name="s">The command that the player just sent.</param>
         public override void ProcessInput(string s)
         {
-            var command = this.FindTargetCommand(s);
+            var command = FindTargetCommand(s);
             switch (command)
             {
                 case SetAttributeCommand.Warrior:
-                    this.ProcessAttributeCommand(command, s, ref this.warriorPoints);
+                    ProcessAttributeCommand(command, s, ref warriorPoints);
                     break;
                 case SetAttributeCommand.Rogue:
-                    this.ProcessAttributeCommand(command, s, ref this.roguePoints);
+                    ProcessAttributeCommand(command, s, ref roguePoints);
                     break;
                 case SetAttributeCommand.Mage:
-                    this.ProcessAttributeCommand(command, s, ref this.magePoints);
+                    ProcessAttributeCommand(command, s, ref magePoints);
                     break;
                 case SetAttributeCommand.Done:
-                    if (this.SpentPoints != MaxPoints)
+                    if (SpentPoints != MaxPoints)
                     {
-                        WrmChargenCommon.SendErrorMessage(this.Session, "You have not spent all your points.");
+                        WrmChargenCommon.SendErrorMessage(Session, "You have not spent all your points.");
                     }
                     else
                     {
                         // Proceed to the next step.
-                        this.SetPlayerBehaviorAttributes();
-                        this.StateMachine.HandleNextStep(this, StepStatus.Success);
+                        SetPlayerBehaviorAttributes();
+                        StateMachine.HandleNextStep(this, StepStatus.Success);
                         return;
                     }
 
                     break;
                 default:
-                    WrmChargenCommon.SendErrorMessage(this.Session, "Unknown command. Please use warrior, rogue, mage, or done.");
+                    WrmChargenCommon.SendErrorMessage(Session, "Unknown command. Please use warrior, rogue, mage, or done.");
                     break;
             }
 
-            this.RefreshScreen();
+            RefreshScreen();
         }
 
         /// <summary>Builds the prompt.</summary>
@@ -103,33 +103,33 @@ namespace WarriorRogueMage.CharacterCreation
 
         private void ProcessAttributeCommand(SetAttributeCommand command, string s, ref int targetPoints)
         {
-            var op = this.FindOperation(s);
+            var op = FindOperation(s);
             var numberString = Regex.Match(s, @"\d+").Value;
             if (string.IsNullOrWhiteSpace(numberString))
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "No valid number was found.");
+                WrmChargenCommon.SendErrorMessage(Session, "No valid number was found.");
                 return;
             }
 
             int n;
             if (!int.TryParse(numberString, out n))
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "Could not process the number.");
+                WrmChargenCommon.SendErrorMessage(Session, "Could not process the number.");
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(op))
             {
                 // No operator? Try to set the value directly to the number provided.
-                this.SetAttributeTarget(ref targetPoints, n);
+                SetAttributeTarget(ref targetPoints, n);
             }
             else if (op == "+")
             {
-                this.SetAttributeTarget(ref targetPoints, targetPoints + n);
+                SetAttributeTarget(ref targetPoints, targetPoints + n);
             }
             else if (op == "-")
             {
-                this.SetAttributeTarget(ref targetPoints, targetPoints - n);
+                SetAttributeTarget(ref targetPoints, targetPoints - n);
             }
         }
 
@@ -138,15 +138,15 @@ namespace WarriorRogueMage.CharacterCreation
             int netChange = newValue - targetPoints;
             if (newValue > 6)
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "No attribute can be greater than 6.");
+                WrmChargenCommon.SendErrorMessage(Session, "No attribute can be greater than 6.");
             }
             else if (newValue < 0)
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "No attribute can be less than 0.");
+                WrmChargenCommon.SendErrorMessage(Session, "No attribute can be less than 0.");
             }
-            else if (this.SpentPoints + netChange > MaxPoints)
+            else if (SpentPoints + netChange > MaxPoints)
             {
-                WrmChargenCommon.SendErrorMessage(this.Session, "You do not have enough points to spend.");
+                WrmChargenCommon.SendErrorMessage(Session, "You do not have enough points to spend.");
             }
             else
             {
@@ -162,11 +162,11 @@ namespace WarriorRogueMage.CharacterCreation
             sb.AppendLine("You have 10 character points to be divided between 3 attributes.");
             sb.AppendLine("No attribute can have more than 6 points. Attributes can be zero.");
             sb.AppendLine();
-            sb.AppendLine(string.Format("Warrior : {0}", this.warriorPoints));
-            sb.AppendLine(string.Format("Rogue   : {0}", this.roguePoints));
-            sb.AppendLine(string.Format("Mage    : {0}", this.magePoints));
+            sb.AppendLine(string.Format("Warrior : {0}", warriorPoints));
+            sb.AppendLine(string.Format("Rogue   : {0}", roguePoints));
+            sb.AppendLine(string.Format("Mage    : {0}", magePoints));
             sb.AppendLine();
-            sb.AppendFormat("You have {0} character points left.", MaxPoints - this.SpentPoints);
+            sb.AppendFormat("You have {0} character points left.", MaxPoints - SpentPoints);
             sb.AppendLine();
             sb.AppendLine("<%yellow%>====================================================================");
             sb.AppendLine("To add points to an attribute, use the + operator. Example: warrior +6");
@@ -174,7 +174,7 @@ namespace WarriorRogueMage.CharacterCreation
             sb.AppendLine("When you are done distributing the character points, type done.");
             sb.AppendLine("====================================================================<%n%>");
 
-            this.Session.Write(sb.ToString(), sendPrompt);
+            Session.Write(sb.ToString(), sendPrompt);
         }
 
         private SetAttributeCommand FindTargetCommand(string s)
@@ -225,13 +225,13 @@ namespace WarriorRogueMage.CharacterCreation
 
         private void SetPlayerBehaviorAttributes()
         {
-            var playerBehavior = this.Session.Thing.Behaviors.FindFirst<PlayerBehavior>();
+            var playerBehavior = Session.Thing.Behaviors.FindFirst<PlayerBehavior>();
             var attributes = playerBehavior.Parent.Attributes;
-            var character = this.Session.Thing;
+            var character = Session.Thing;
 
-            attributes["WAR"].SetValue(this.warriorPoints, character);
-            attributes["ROG"].SetValue(this.roguePoints, character);
-            attributes["MAG"].SetValue(this.magePoints, character);
+            attributes["WAR"].SetValue(warriorPoints, character);
+            attributes["ROG"].SetValue(roguePoints, character);
+            attributes["MAG"].SetValue(magePoints, character);
         }
     }
 }

--- a/src/WarriorRogueMage/CharacterCreation/WRMCharacterCreationStateMachine.cs
+++ b/src/WarriorRogueMage/CharacterCreation/WRMCharacterCreationStateMachine.cs
@@ -36,16 +36,16 @@ namespace WarriorRogueMage.CharacterCreation
             // entry point of the state machine
             if (current == null)
             {
-                return new ConfirmCreationEntryState(this.Session);
+                return new ConfirmCreationEntryState(Session);
             }
 
             if (previousStatus == StepStatus.Success)
             {
-                return this.AdvanceState(current);
+                return AdvanceState(current);
             }
             else
             {
-                return this.RegressState(current);
+                return RegressState(current);
             }
         }
 
@@ -57,39 +57,39 @@ namespace WarriorRogueMage.CharacterCreation
             // they could of course reuse some/all of the states below in addition to their own.
             if (current is ConfirmCreationEntryState)
             {
-                return new GetNameState(this.Session);
+                return new GetNameState(Session);
             }
             else if (current is GetNameState)
             {
-                return new GetPasswordState(this.Session);
+                return new GetPasswordState(Session);
             }
             else if (current is GetPasswordState)
             {
-                return new ConfirmPasswordState(this.Session);
+                return new ConfirmPasswordState(Session);
             }
             else if (current is ConfirmPasswordState)
             {
-                return new PickGenderState(this.Session);
+                return new PickGenderState(Session);
             }
             else if (current is PickGenderState)
             {
-                return new GetDescriptionState(this.Session);
+                return new GetDescriptionState(Session);
             }
             else if (current is GetDescriptionState)
             {
-                return new SetAttributesState(this.Session);
+                return new SetAttributesState(Session);
             }
             else if (current is SetAttributesState)
             {
-                return new PickSkillsState(this.Session);
+                return new PickSkillsState(Session);
             }
             else if (current is PickSkillsState)
             {
-                return new PickTalentsState(this.Session);
+                return new PickTalentsState(Session);
             }
             else if (current is PickTalentsState)
             {
-                return new PickRaceState(this.Session);
+                return new PickRaceState(Session);
             }
             else if (current is PickRaceState)
             {
@@ -105,7 +105,7 @@ namespace WarriorRogueMage.CharacterCreation
             if (current is ConfirmPasswordState)
             {
                 // If password confirmation failed, try selecting a new password.
-                return new GetPasswordState(this.Session);
+                return new GetPasswordState(Session);
             }
 
             throw new InvalidOperationException("The character state machine does not know how to calculate the next step after '" + current.GetType().Name + "' fails");

--- a/src/WarriorRogueMage/Combat/WRMCombat.cs
+++ b/src/WarriorRogueMage/Combat/WRMCombat.cs
@@ -22,7 +22,7 @@ namespace WarriorRogueMage
         /// <summary>Prevents a default instance of the <see cref="WrmCombat"/> class from being created.</summary>
         private WrmCombat()
         {
-            this.CombatSession = new GameCombatSession();
+            CombatSession = new GameCombatSession();
         }
 
         /// <summary>Gets the singleton instance.</summary>
@@ -39,16 +39,16 @@ namespace WarriorRogueMage
         /// <summary>To be used in combat systems that are turn based.</summary>
         public void ProcessCombatRound()
         {
-            this.combatQueue = new Queue(this.CombatSession.Combatants.Count);
-            this.CreateCombatOrder();
+            combatQueue = new Queue(CombatSession.Combatants.Count);
+            CreateCombatOrder();
 
-            foreach (Thing combatant in this.CombatSession.Combatants)
+            foreach (Thing combatant in CombatSession.Combatants)
             {
-                this.ProcessCombatantRoundActions(combatant);
+                ProcessCombatantRoundActions(combatant);
             }
 
             // When the round is over, clear the queue.
-            this.combatQueue.Clear();
+            combatQueue.Clear();
         }
 
         /// <summary>To be used in combat systems that are near-real time.</summary>
@@ -63,7 +63,7 @@ namespace WarriorRogueMage
             Die combatDie = DiceService.Instance.GetDie(6);
             var bin = new Dictionary<string, int>();
 
-            foreach (Thing combatant in this.CombatSession.Combatants)
+            foreach (Thing combatant in CombatSession.Combatants)
             {
                 // Find out who goes first, then add them to the queue.
                 // Rinse and repeat, until all have been placed in the
@@ -85,7 +85,7 @@ namespace WarriorRogueMage
 
             ////foreach (var ent in sortedBin)
             ////{
-            ////    Thing combatant = this.CombatSession.Combatants.Values
+            ////    Thing combatant = CombatSession.Combatants.Values
             ////}
         }
 
@@ -99,15 +99,15 @@ namespace WarriorRogueMage
         /// <summary>Starts this system.</summary>
         public void Start()
         {
-            this.SystemHost.UpdateSystemHost(this, "Starting WRM combat engine...");
-            this.SystemHost.UpdateSystemHost(this, "WRM combat engine has been started.");
+            SystemHost.UpdateSystemHost(this, "Starting WRM combat engine...");
+            SystemHost.UpdateSystemHost(this, "WRM combat engine has been started.");
         }
 
         /// <summary>Stops this system.</summary>
         public void Stop()
         {
-            this.SystemHost.UpdateSystemHost(this, "Stopping WRM combat engine...");
-            this.SystemHost.UpdateSystemHost(this, "WRM combat engine has been stopped.");
+            SystemHost.UpdateSystemHost(this, "Stopping WRM combat engine...");
+            SystemHost.UpdateSystemHost(this, "WRM combat engine has been stopped.");
         }
 
         /// <summary>Allows the sub system host to receive an update when subscribed to this system.</summary>
@@ -121,7 +121,7 @@ namespace WarriorRogueMage
         /// <param name="sender">The system host to receive our updates.</param>
         public void SubscribeToSystemHost(ISystemHost sender)
         {
-            this.SystemHost = sender;
+            SystemHost = sender;
         }
 
         private static int DoInititiveRoll(Die combatDie, Thing combatant)

--- a/src/WarriorRogueMage/Races/WRMRace.cs
+++ b/src/WarriorRogueMage/Races/WRMRace.cs
@@ -23,9 +23,9 @@ namespace WarriorRogueMage
         /// <param name="racialTalents">The talents of the race.</param>
         public WRMRace(string name, string description, params Talent[] racialTalents) : base()
         {
-            this.Name = name;
-            this.Description = description;
-            this.RacialTalents = racialTalents.ToList();
+            Name = name;
+            Description = description;
+            RacialTalents = racialTalents.ToList();
         }
 
         /// <summary>Gets the list of racial talents.</summary>

--- a/src/WarriorRogueMage/Skills/WRMSkill.cs
+++ b/src/WarriorRogueMage/Skills/WRMSkill.cs
@@ -18,9 +18,9 @@ namespace WarriorRogueMage.Skills
         /// <param name="description">The description for this skill.</param>
         public WRMSkill(string name, string controllingAttribute, string description)
         {
-            this.Name = name;
-            this.Description = description;
-            this.ControllingAttribute = controllingAttribute;
+            Name = name;
+            Description = description;
+            ControllingAttribute = controllingAttribute;
         }
 
         /// <summary>Initializes a new instance of the <see cref="WRMSkill"/> class.</summary>
@@ -30,17 +30,17 @@ namespace WarriorRogueMage.Skills
         /// <param name="playerThing">The player thing that will be the parent of this skill.</param>
         public WRMSkill(string name, string controllingAttribute, string description, Thing playerThing)
         {
-            this.Name = name;
-            this.Description = description;
-            this.ControllingAttribute = controllingAttribute;
-            this.PlayerThing = playerThing;
+            Name = name;
+            Description = description;
+            ControllingAttribute = controllingAttribute;
+            PlayerThing = playerThing;
         }
 
         /// <summary>Initializes a new instance of the <see cref="WRMSkill"/> class.</summary>
         /// <param name="playerThing">The player thing that will be the parent of this skill.</param>
         public WRMSkill(Thing playerThing)
         {
-            this.PlayerThing = playerThing;
+            PlayerThing = playerThing;
         }
     }
 }

--- a/src/WarriorRogueMage/Talents/NormalTalent.cs
+++ b/src/WarriorRogueMage/Talents/NormalTalent.cs
@@ -50,13 +50,13 @@ namespace WarriorRogueMage
         {
         }
 
-        /// <summary>Called when a parent has just been assigned to this talent. (Refer to this.PlayerThing)</summary>
+        /// <summary>Called when a parent has just been assigned to this talent. (Refer to PlayerThing)</summary>
         public override void OnAddTalent()
         {
             base.OnAddTalent();
         }
 
-        /// <summary>Called when the current parent of this talent is about to be removed. (Refer to this.PlayerThing)</summary>
+        /// <summary>Called when the current parent of this talent is about to be removed. (Refer to PlayerThing)</summary>
         public override void OnRemoveTalent()
         {
             base.OnRemoveTalent();
@@ -76,13 +76,13 @@ namespace WarriorRogueMage
         {
         }
 
-        /// <summary>Called when a parent has just been assigned to this talent. (Refer to this.PlayerThing)</summary>
+        /// <summary>Called when a parent has just been assigned to this talent. (Refer to PlayerThing)</summary>
         public override void OnAddTalent()
         {
             base.OnAddTalent();
         }
 
-        /// <summary>Called when the current parent of this talent is about to be removed. (Refer to this.PlayerThing)</summary>
+        /// <summary>Called when the current parent of this talent is about to be removed. (Refer to PlayerThing)</summary>
         public override void OnRemoveTalent()
         {
             base.OnRemoveTalent();
@@ -194,13 +194,13 @@ namespace WarriorRogueMage
         {
         }
 
-        /// <summary>Called when a parent has just been assigned to this talent. (Refer to this.PlayerThing.)</summary>
+        /// <summary>Called when a parent has just been assigned to this talent. (Refer to PlayerThing.)</summary>
         public override void OnAddTalent()
         {
             base.OnAddTalent();
         }
 
-        /// <summary>Called when the current parent of this talent is about to be removed. (Refer to this.PlayerThing.)</summary>
+        /// <summary>Called when the current parent of this talent is about to be removed. (Refer to PlayerThing.)</summary>
         public override void OnRemoveTalent()
         {
             base.OnRemoveTalent();
@@ -220,13 +220,13 @@ namespace WarriorRogueMage
         {
         }
 
-        /// <summary>Called when a parent has just been assigned to this talent. (Refer to this.PlayerThing.)</summary>
+        /// <summary>Called when a parent has just been assigned to this talent. (Refer to PlayerThing.)</summary>
         public override void OnAddTalent()
         {
             base.OnAddTalent();
         }
 
-        /// <summary>Called when the current parent of this talent is about to be removed. (Refer to this.PlayerThing.)</summary>
+        /// <summary>Called when the current parent of this talent is about to be removed. (Refer to PlayerThing.)</summary>
         public override void OnRemoveTalent()
         {
             base.OnRemoveTalent();

--- a/src/WarriorRogueMage/Talents/RacialTalents.cs
+++ b/src/WarriorRogueMage/Talents/RacialTalents.cs
@@ -31,7 +31,7 @@ namespace WarriorRogueMage
             "This talent allows the player to roll two six sided dice instead of one when making a check using the relevant attribute. The highest result counts.",
             TalentType.Racial)
         {
-            this.ExceptionalAttribute = attribute;
+            ExceptionalAttribute = attribute;
         }
 
         /// <summary>Initializes a new instance of the <see cref="ExceptionalAttributeTalent"/> class.</summary>
@@ -54,7 +54,7 @@ namespace WarriorRogueMage
             "Natural armor usually is in the form of scales or thick fur that protects the character from damage. The Defense granted by natural armor works as long as no other armor is worn.",
             TalentType.Racial)
         {
-            this.DefenseBonus = defenseBonus;
+            DefenseBonus = defenseBonus;
         }
 
         /// <summary>Initializes a new instance of the <see cref="NaturalArmorTalent"/> class.</summary>

--- a/src/WarriorRogueMage/Talents/Talent.cs
+++ b/src/WarriorRogueMage/Talents/Talent.cs
@@ -28,9 +28,9 @@ namespace WarriorRogueMage
         /// <param name="talentType">Type of the talent.</param>
         public Talent(string name, string description, TalentType talentType)
         {
-            this.Name = name;
-            this.Description = description;
-            this.TalentType = talentType;
+            Name = name;
+            Description = description;
+            TalentType = talentType;
         }
 
         /// <summary>Initializes a new instance of the <see cref="Talent"/> class.</summary>
@@ -41,18 +41,18 @@ namespace WarriorRogueMage
         /// <param name="rules">The rules.</param>
         public Talent(string name, string description, TalentType talentType, Thing parent, params string[] rules)
         {
-            this.Name = name;
-            this.Description = description;
-            this.TalentType = talentType;
-            this.Rules = rules.ToList();
-            this.PlayerThing = parent;
+            Name = name;
+            Description = description;
+            TalentType = talentType;
+            Rules = rules.ToList();
+            PlayerThing = parent;
         }
 
         /// <summary>Initializes a new instance of the <see cref="Talent"/> class.</summary>
         /// <param name="parent">The parent.</param>
         public Talent(Thing parent)
         {
-            this.PlayerThing = parent;
+            PlayerThing = parent;
         }
 
         /// <summary>Gets or sets the player thing.</summary>
@@ -71,12 +71,12 @@ namespace WarriorRogueMage
         /// <summary>Gets the rules.</summary>
         public List<string> Rules { get; private set; }
 
-        /// <summary>Called when a parent has just been assigned to this talent. (Refer to this.PlayerThing.)</summary>
+        /// <summary>Called when a parent has just been assigned to this talent. (Refer to PlayerThing.)</summary>
         public virtual void OnAddTalent()
         {
         }
 
-        /// <summary>Called when the current parent of this talent is about to be removed. (Refer to this.PlayerThing.)</summary>
+        /// <summary>Called when the current parent of this talent is about to be removed. (Refer to PlayerThing.)</summary>
         public virtual void OnRemoveTalent()
         {
         }
@@ -92,7 +92,7 @@ namespace WarriorRogueMage
         /// <param name="other">An object to compare with this object.</param>
         public bool Equals(Talent other)
         {
-            if (this.TalentType == other.TalentType && this.Name == other.Name)
+            if (TalentType == other.TalentType && Name == other.Name)
             {
                 return true;
             }

--- a/src/WarriorRogueMage/Talents/TalentFinder.cs
+++ b/src/WarriorRogueMage/Talents/TalentFinder.cs
@@ -18,7 +18,7 @@ namespace WarriorRogueMage
         /// <summary>Prevents a default instance of the TalentFinder class from being created.</summary>
         private TalentFinder()
         {
-            this.Recompose();
+            Recompose();
         }
 
         /// <summary>Gets the singleton instance of the TalentFinder class.</summary>
@@ -35,8 +35,8 @@ namespace WarriorRogueMage
         {
             AttributedModelServices.ComposeParts(DefaultComposer.Container, this);
 
-            this.NormalTalents = (from t in this.AllTalents where t.TalentType == TalentType.Normal select t).ToList();
-            this.RacialTalents = (from t in this.AllTalents where t.TalentType == TalentType.Racial select t).ToList();
+            NormalTalents = (from t in AllTalents where t.TalentType == TalentType.Normal select t).ToList();
+            RacialTalents = (from t in AllTalents where t.TalentType == TalentType.Racial select t).ToList();
         }
     }
 }


### PR DESCRIPTION
Ran VS2019 enforcement of rule to omit  from all solution source, per some default VS enforcement settings, and adjusted a bunch of additional comments and docs to follow this pattern.

This is a quick step towards https://github.com/DavidRieman/WheelMUD/issues/24 (getting up and running with automatic Visual Studio style enforcement via default-friendly settings).

Any thoughts on moving forward?

We'll probably want to think about other naming conventions (constructor params vs members to avoid "this." in some remaining cases), automatic properties adoption and naming, etc...  Still need to look at what VS2019 can do out of the box for us on these style fronts.

Cleanup for `usings` could follow (moving them out of namespace where the old StyleCop validation used to want them).