### PR TITLE
fix LoginState prompt

### DIFF
--- a/src/ConnectionStates/LoginState.cs
+++ b/src/ConnectionStates/LoginState.cs
@@ -23,7 +23,6 @@ namespace WheelMUD.ConnectionStates
             : base(session)
         {
             this.userName = userName;
-            session.Write("Please enter your password:");
         }
 
         /// <summary>Process the specified input.</summary>
@@ -76,7 +75,7 @@ namespace WheelMUD.ConnectionStates
 
         public override string BuildPrompt()
         {
-            return "> ";
+            return string.Format("Please enter your password:{0}> ", Environment.NewLine);
         }
 
         /// <summary>Authenticate the user name and password supplied.</summary>

--- a/systemdata/Files/Credits.txt
+++ b/systemdata/Files/Credits.txt
@@ -12,6 +12,7 @@ ACTIVE CHAMPION:
 ACTIVE DEVELOPERS:
 * Duane King (honestduane / Feverdream)
 * Jeremy Holland
+* Rebekka Williamsdóttir (octave-syndicate)
 
 ;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ; We sincerely give our thanks to all members of the WheelMUD Development Team


### PR DESCRIPTION
Fix the LoginState prompt by allowing  the prompt via the BuildPrompt method override as opposed to a call to the write method within the class constructor. 