### PR TITLE
Fix a bug arising from the recent Files dir change

### DIFF
--- a/src/Core/Renderer/DefaultSplashScreenRenderer.cs
+++ b/src/Core/Renderer/DefaultSplashScreenRenderer.cs
@@ -26,9 +26,7 @@ namespace WheelMUD.Core
         /// <summary>Load the splash screens.</summary>
         private static void LoadSplashScreens()
         {
-            string dir = Path.GetDirectoryName(GameConfiguration.DataStoragePath);
-            string path = Path.Combine(dir, "Files", "SplashScreens");
-
+            string path = Path.Combine(GameConfiguration.DataStoragePath, "SplashScreens");
             var dirInfo = new DirectoryInfo(path);
             var files = new List<FileInfo>(dirInfo.GetFiles());
 
@@ -54,7 +52,7 @@ namespace WheelMUD.Core
         {
             if (!splashScreens.Any())
             {
-                return $"Welcome to {GameConfiguration.Name}.<%nl%>";
+                return $"Welcome to {GameConfiguration.Name}.{AnsiSequences.NewLine}";
             }
 
             var random = new Random();

--- a/src/Main/Application.cs
+++ b/src/Main/Application.cs
@@ -87,21 +87,22 @@ namespace WheelMUD.Main
 
             string appDir = appFile.Directory.FullName;
 
+            // If there is no data directory yet, seed it with the source code's starting set of (source-controlled) initial data. After this,
+            // the copied set of data (living in the Data Storage area) will be living "game data" that evolve with the game instance.
             if (!Directory.Exists(GameConfiguration.DataStoragePath))
             {
-                // If the database file doesn't exist, try to copy the original source.
-                string sourcePath = null;
+                string sourcePath;
                 int i = appDir.IndexOf(Path.DirectorySeparatorChar + "systemdata" + Path.DirectorySeparatorChar, StringComparison.Ordinal);
                 if (i > 0)
                 {
-                    sourcePath = appDir.Substring(0, i) + Path.DirectorySeparatorChar + "systemdata" + Path.DirectorySeparatorChar + "Files" + Path.DirectorySeparatorChar;
+                    sourcePath = Path.Combine(appDir.Substring(0, i), "systemdata", "Files");
                 }
                 else
                 {
                     // The binDebug folder now houses a sub-folder like "netcoreapp3.1" so we need to go up
-                    // two levels to search for the starting system data.
-                    sourcePath = Path.GetDirectoryName(Path.GetDirectoryName(appDir));
-                    sourcePath = Path.Combine(sourcePath + Path.DirectorySeparatorChar + "systemdata" + Path.DirectorySeparatorChar + "Files" + Path.DirectorySeparatorChar);
+                    // two levels to search for the starting base system data.
+                    string baseSourcePath = Path.GetDirectoryName(Path.GetDirectoryName(appDir));
+                    sourcePath = Path.Combine(baseSourcePath, "systemdata", "Files");
                 }
 
                 DirectoryCopy(sourcePath, GameConfiguration.DataStoragePath, true);


### PR DESCRIPTION
Splash screens were trying to read from the .../wheelmud/wheelmud/files/splashscreens path which no longer gets generated and won't exist for someone who hasn't launched it yet with the old version.
Also cleaned up how the Application auto-copy of the data was building the paths and some related comments.