### PR TITLE
Telnet Options handling improvement / cleanup

### DIFF
--- a/src/Server/Interfaces/ITelnetCodeHandler.cs
+++ b/src/Server/Interfaces/ITelnetCodeHandler.cs
@@ -9,13 +9,13 @@ using WheelMUD.Server.Interfaces;
 
 namespace WheelMUD.Interfaces
 {
-    using System.Collections.Generic;
-
     /// <summary>An interface defining a TelnetCodeHandler.</summary>
     public interface ITelnetCodeHandler
     {
-        /// <summary>Gets a list of the telnet options recognised by the server.</summary>
-        List<ITelnetOption> TelnetOptions { get; }
+        /// <summary>Find the TelnetOption class instance of the given type.</summary>
+        /// <typeparam name="T">The ITelnetOption type to search for.</typeparam>
+        /// <returns>The TelnetOption instance of the given type, or null if it can not be found.</returns>
+        T FindOption<T>() where T : ITelnetOption;
 
         /// <summary>Instruct the handler to process the data for telnet option codes</summary>
         /// <param name="data">The data to process</param>

--- a/src/Server/Telnet/ConnectionTelnetStateOptionCode.cs
+++ b/src/Server/Telnet/ConnectionTelnetStateOptionCode.cs
@@ -29,10 +29,10 @@ namespace WheelMUD.Server.Telnet
         public override void ProcessInput(byte data)
         {
             // If the data is not one of our implemented options then we reset back.
-            TelnetOption option = (TelnetOption)Parent.TelnetOptions.Find(delegate (ITelnetOption o) { return o.OptionCode == data; });
+            TelnetOption option = (TelnetOption)Parent.FindOption(data);
             if (option == null)
             {
-                // We have received an option code that we dont recognise, so we create a temporary
+                // We have received an option code that we do not recognise, so we create a temporary
                 // telnet option to deal with it.
                 option = new TelnetOption("temp", data, false, Parent.Connection);
             }

--- a/src/Server/Telnet/ConnectionTelnetStateSubRequestIAC.cs
+++ b/src/Server/Telnet/ConnectionTelnetStateSubRequestIAC.cs
@@ -39,7 +39,7 @@ namespace WheelMUD.Server.Telnet
                     Parent.SubRequestBuffer.RemoveAt(0);
 
                     // Find the related option.
-                    TelnetOption option = (TelnetOption)Parent.TelnetOptions.Find(delegate (ITelnetOption o) { return o.OptionCode == optionCode; });
+                    TelnetOption option = (TelnetOption)Parent.FindOption(optionCode);
                     if (option == null)
                     {
                         // We have received an option code that we dont recognise, so we create a temporary

--- a/src/Server/Telnet/TelnetOptionEcho.cs
+++ b/src/Server/Telnet/TelnetOptionEcho.cs
@@ -28,15 +28,7 @@ namespace WheelMUD.Server.Telnet
         /// <summary>Post-processing as called after negotiation.</summary>
         public override void AfterNegotiation()
         {
-            switch (UsState)
-            {
-                case TelnetOptionState.YES:
-                    Connection.TerminalOptions.UseEcho = true;
-                    break;
-                case TelnetOptionState.NO:
-                    Connection.TerminalOptions.UseEcho = false;
-                    break;
-            }
+            Connection.TerminalOptions.UseEcho = UsState == TelnetOptionState.YES;
         }
     }
 }

--- a/src/Server/Telnet/TelnetOptionMCCP.cs
+++ b/src/Server/Telnet/TelnetOptionMCCP.cs
@@ -27,14 +27,7 @@ namespace WheelMUD.Server.Telnet
         /// <summary>Post-processing as called after negotiation.</summary>
         public override void AfterNegotiation()
         {
-            if (UsState == TelnetOptionState.YES)
-            {
-                Connection.TerminalOptions.UseMCCP = true;
-            }
-            else
-            {
-                Connection.TerminalOptions.UseMCCP = false;
-            }
+            Connection.TerminalOptions.UseMCCP = UsState == TelnetOptionState.YES;
         }
     }
 }

--- a/src/Server/Telnet/TelnetOptionMXP.cs
+++ b/src/Server/Telnet/TelnetOptionMXP.cs
@@ -18,10 +18,6 @@ namespace WheelMUD.Server.Telnet
         public TelnetOptionMXP(bool wantOption, Connection connection)
             : base("mxp", 91, wantOption, connection)
         {
-            // Initialize the values of all automatic properties that need values 
-            // to be assumed non-zero or null.
-            AwaitingVersionResponse = false;
-            VersionResponseBuffer = string.Empty;
         }
 
         /// <summary>Represents version response state in the MXP telnet option.</summary>
@@ -53,7 +49,7 @@ namespace WheelMUD.Server.Telnet
         internal ResponseState VersionResponseState { get; set; }
 
         /// <summary>Gets or sets the version response buffer contents.</summary>
-        internal string VersionResponseBuffer { get; set; }
+        internal string VersionResponseBuffer { get; set; } = string.Empty;
 
         /// <summary>Process the sub negotiation.</summary>
         /// <param name="data">The data to process.</param>


### PR DESCRIPTION
Summary of Changes:
* Telnet options handling: Improved typing strength (via familiar pattern similar to `FindFirst` of `BehaviorManager`) instead of name string search.
* Simplified some verbose code for telnet options handling.
* Improves some threading safety as all access of the options list is behind the lock object, instead of exposing the list of options directly.
* Ensured the Echo negotiation _can_ occur as-is, we just don't support echoing mode right now (and may not want to).

Branched off of my other big branch to build off of that code; will want to finish that PR first for an automatic rebase to master.