### PR TITLE
Upgrade 4 NuGet package versions

### DIFF
--- a/src/Data.Sqlite/WheelMUD.Data.Sqlite.csproj
+++ b/src/Data.Sqlite/WheelMUD.Data.Sqlite.csproj
@@ -19,7 +19,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ServiceStack.OrmLite.Sqlite.Core" Version="5.10.2" />
+    <PackageReference Include="ServiceStack.OrmLite.Sqlite.Core" Version="5.10.4" />
     <ProjectReference Include="..\Core\WheelMUD.Core.csproj" />
     <ProjectReference Include="..\Data\WheelMUD.Data.csproj" />
   </ItemGroup>

--- a/src/Data/WheelMUD.Data.csproj
+++ b/src/Data/WheelMUD.Data.csproj
@@ -19,7 +19,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ServiceStack.OrmLite.Core" Version="5.10.2" />
+    <PackageReference Include="ServiceStack.OrmLite.Core" Version="5.10.4" />
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <ProjectReference Include="..\Utilities\WheelMUD.Utilities.csproj" />

--- a/src/Tests/CoreTests/CoreTests.csproj
+++ b/src/Tests/CoreTests/CoreTests.csproj
@@ -4,9 +4,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <ProjectReference Include="..\..\Core\WheelMUD.Core.csproj" />
     <ProjectReference Include="..\..\Server\WheelMUD.Server.csproj" />
     <ProjectReference Include="..\..\Universe\WheelMUD.Universe.csproj" />

--- a/src/Tests/WarriorRogueMageTests/WarriorRogueMageTests.csproj
+++ b/src/Tests/WarriorRogueMageTests/WarriorRogueMageTests.csproj
@@ -4,9 +4,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <ProjectReference Include="..\..\Core\WheelMUD.Core.csproj" />
     <ProjectReference Include="..\..\WarriorRogueMage\WarriorRogueMage.csproj" />
     <ProjectReference Include="..\TestFramework\TestHelpers.csproj" />


### PR DESCRIPTION
Upgrade all NuGet packages except RavenDB to latest.

(RavenDB would require us to each perform manual updates since it seems to force dependencies upgrades which must be performed outside the NuGet ecosystem.  Not a bad idea, but putting it off for a while to minimize the number of times we have to take on this pain while we don't even have any public-facing servers to worry about the security bugs those minor updates may be fixing, etc.)