### PR TITLE
Delete unused sessionFactory to fix build warning.

### DIFF
--- a/src/Actions/OLC/Tunnel.cs
+++ b/src/Actions/OLC/Tunnel.cs
@@ -57,10 +57,17 @@ namespace WheelMUD.Actions
             exitBehavior.AddDestination(tunnelDirection, toThing);
             exitBehavior.AddDestination(mirrorDirection, fromThing);
 
-            // Prepare a new exit Thing with the default set of exit behaviors. Assign the ID pattern that will get an
-            // auto-assigned index from the DB, and save it immediately so the existing rooms can refer to it by ID.
-            var exit = new Thing(new MultipleParentsBehavior(), exitBehavior) { Id = "exits|" };
-            exit.Save();
+            // Prepare a new exit Thing with the default set of exit behaviors.
+            var exit = new Thing(new MultipleParentsBehavior(), exitBehavior);
+            if (fromThing.Persists && toThing.Persists)
+            {
+                // If the linked exists persist, so too will the exit between them. (If either one does not persist,
+                // then trying to persist the exit too could lead to unlinked exits accumulating across future server
+                // restarts.) Assign the ID pattern that will get an auto-assigned index from the DB, and save it
+                // immediately so the existing rooms can refer to it by ID.
+                exit.Id = "exits|";
+                exit.Save();
+            }
 
             fromThing.Add(exit);
             toThing.Add(exit);

--- a/src/Data/Helpers.cs
+++ b/src/Data/Helpers.cs
@@ -14,9 +14,6 @@ namespace WheelMUD.Data
     /// <summary>Helper methods for the WheelMUD.Data namespace.</summary>
     public class Helpers
     {
-        /// <summary>The session factory variable.</summary>
-        private static IDbConnection sessionFactory;
-
         private static IWheelMudDocumentStorageProvider configuredDocumentStorageProvider;
 
         static Helpers()


### PR DESCRIPTION
Trivial fix (deleted unused var).

Also adding fix for issue exposed by test: Fix tunnel command to only persist the exit if the linked rooms can also persist. (Before this, a test exposed that real persistence would occur for something even though the rooms were marked non-persistable.)

With these two issues, hopefully main will be 100% clean builds again.